### PR TITLE
Fix missing release assets for tagged releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,6 +217,10 @@ jobs:
             exit 1
           fi
 
+          DMG_NAME=$(basename "$DMG_PATH")
+          VERSIONED_PATH="$RUNNER_TEMP/$DMG_NAME"
+          cp "$DMG_PATH" "$VERSIONED_PATH"
+
           # Create stable latest-release filenames for the web app while
           # keeping the original versioned DMG for the GitHub release + Homebrew.
           STABLE_NAME="OpenSCAD.Studio_latest_${{ matrix.arch }}.dmg"
@@ -227,7 +231,7 @@ jobs:
           # so the hash matches the file Homebrew users download.
           SHA256=$(shasum -a 256 "$DMG_PATH" | cut -d ' ' -f 1)
 
-          echo "dmg_path=$DMG_PATH" >> "$GITHUB_OUTPUT"
+          echo "dmg_path=$VERSIONED_PATH" >> "$GITHUB_OUTPUT"
           echo "stable_path=$STABLE_PATH" >> "$GITHUB_OUTPUT"
           echo "sha256=$SHA256" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
# Summary

## What changed
- Flattened the DMG artifact upload paths in `.github/workflows/release.yml` by copying the built versioned DMGs into `$RUNNER_TEMP` before uploading them.
- Kept the stable `OpenSCAD.Studio_latest_*.dmg` copies for the web app while ensuring the versioned DMGs still attach correctly to GitHub Releases and remain available for Homebrew.
- Preserved the existing release workflow shape and comments while fixing the artifact glob mismatch that prevented release assets from being attached.

## Why
- The `v0.10.0` release workflow built and uploaded DMGs successfully, but `actions/download-artifact` restored them under nested directories.
- The GitHub Release step was globbing `artifacts/dmg-aarch64/*.dmg` and `artifacts/dmg-x64/*.dmg`, which matched nothing, so the release was created without assets.
- Flattening the uploaded artifact paths makes the existing release globs work reliably for future releases.

## Implementation notes
- This branch is based on current `main` and only changes `.github/workflows/release.yml`.
- The live `v0.10.0` release was manually repaired by uploading the four built DMGs from the successful workflow run.
- Homebrew remained pointed at the versioned DMGs; the follow-up verification confirmed the tap cask and published hashes match the `0.10.0` release artifacts.

# Testing

## Coverage checklist
- [ ] Backend unit tests added or updated for changed Rust behavior
- [ ] Client unit/component tests added or updated for changed frontend behavior
- [ ] E2E tests added or updated for net new user-facing flows
- [x] No new tests were needed for this change

## Validation performed
- [ ] `cargo check --workspace`
- [ ] `cargo test --workspace`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo bench --no-run --workspace`
- [ ] `yarn lint`
- [ ] `yarn lint:css`
- [ ] `npx tsc -b --noEmit`
- [ ] `yarn test`
- [ ] `npx playwright test`

## Test details
- Validated the workflow logs for GitHub Actions run `23151819204` to confirm the DMGs were built, notarized, and uploaded, and to isolate the release attachment failure to the artifact download path structure.
- Ran `pnpm exec prettier --check .github/workflows/release.yml` after the workflow fix.
- Verified the repaired `v0.10.0` release now includes the expected versioned and latest DMG assets.
- Verified Homebrew resolves `openscad-studio` `0.10.0`, uses the updated cask from the tap, and matches the published DMG SHA256 values.

# Performance

## Performance impact
- [x] Performance was considered for this change
- [x] No meaningful performance impact is expected

## Justification
- The change only affects artifact staging paths inside the release workflow. It does not change application runtime behavior or the DMG contents.

# UI changes

## Screenshots or recordings
- N/A

# Issue link

- Closes #
