### PR TITLE
chore: prepare release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] - 2026-03-20
+
+### Changed
+- Made AI First the default mode option in the NUX layout picker.
+
+### Fixed
+- Fixed the Tauri desktop window close permission configuration.
+
 ## [0.12.0] - 2026-03-18
 
 ### Added

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "0.12.0",
+  "version": "0.13.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/ui/src-tauri/Cargo.lock
+++ b/apps/ui/src-tauri/Cargo.lock
@@ -2445,7 +2445,7 @@ dependencies = [
 
 [[package]]
 name = "openscad-studio"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "chrono",
  "diffy",

--- a/apps/ui/src-tauri/Cargo.toml
+++ b/apps/ui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openscad-studio"
-version = "0.12.0"
+version = "0.13.0"
 description = "Modern OpenSCAD editor with AI assistance"
 authors = ["OpenSCAD Studio Contributors"]
 edition = "2021"

--- a/apps/ui/src-tauri/tauri.conf.json
+++ b/apps/ui/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenSCAD Studio",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "identifier": "com.openscad.studio",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/apps/ui/src/constants/appInfo.ts
+++ b/apps/ui/src/constants/appInfo.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '0.12.0';
+export const APP_VERSION = '0.13.0';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openscad-studio",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "private": true,
   "description": "Modern OpenSCAD editor with live preview and AI copilot",
   "packageManager": "pnpm@10.12.4",


### PR DESCRIPTION
## Summary

- prepare release v0.13.0
- update release version files
- add changelog entry for v0.13.0

## Release flow

After this PR is merged to `main`, run:

```bash
./scripts/release.sh publish 0.13.0
```