### PR TITLE
fix: filter DOM Event rejections and polyfill Object.hasOwn

### DIFF
--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -59,6 +59,12 @@ const RELEASE_ASSETS: Record<MacArch, string> = {
 type MacArch = 'aarch64' | 'x64';
 
 function isIgnorableRejection(reason: unknown): boolean {
+  // Raw DOM Events (e.g. from img.onerror = reject) carry no meaningful error
+  // message and should not be forwarded to Sentry.
+  if (typeof Event !== 'undefined' && reason instanceof Event) {
+    return true;
+  }
+
   const message =
     reason instanceof Error
       ? reason.message
@@ -531,7 +537,7 @@ function App() {
                 reject(new Error('Could not get 2d context'));
               }
             };
-            img.onerror = reject;
+            img.onerror = () => reject(new Error('Failed to load SVG image'));
             img.src = url;
           });
           URL.revokeObjectURL(url);

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -114,6 +114,15 @@
         </style>
       </div>
     </div>
+    <script>
+      // Polyfill Object.hasOwn for Safari < 15.4 and other older browsers.
+      // Some dependencies (e.g. posthog-js, ai SDK) rely on this method.
+      if (!Object.hasOwn) {
+        Object.hasOwn = function (obj, prop) {
+          return Object.prototype.hasOwnProperty.call(obj, prop);
+        };
+      }
+    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
# Summary

## What changed
- `isIgnorableRejection` now returns `true` for raw DOM `Event` objects, preventing them from being forwarded to Sentry
- `img.onerror = reject` replaced with `img.onerror = () => reject(new Error('Failed to load SVG image'))` to reject with a proper `Error` instead of a DOM Event
- Added synchronous `Object.hasOwn` polyfill script in `apps/web/index.html` before the module entry point

## Why
- Fixes two Sentry issues triaged from production:
  - **OPENSCAD-STUDIO-3** (Desktop): `img.onerror = reject` passed a raw DOM `Event` as the Promise rejection reason. `isIgnorableRejection` couldn't extract a message from it (Events have no `.message`), so it was forwarded to Sentry as an `<unknown>` error.
  - **OPENSCAD-STUDIO-2** (Web): `Object.hasOwn` is not available in Safari < 15.4, but a dependency (posthog-js or ai SDK) uses it at module init time. The polyfill must run synchronously before any module loads.

## Implementation notes
- The `Event` instanceof guard in `isIgnorableRejection` is defense-in-depth — DOM Events as rejection reasons are always noise, never actionable errors
- The polyfill is placed as a plain `<script>` (not `type="module"`) so it executes synchronously before the module graph initializes

# Testing

## Coverage checklist
- [x] No new tests were needed for this change

## Validation performed
- [x] `pnpm lint`
- [x] `npx tsc -b --noEmit` (via `pnpm type-check`)

## Test details
- Lint and type-check pass clean. Both fixes are defensive guards for edge-case browser/runtime behavior that is not easily unit-testable.

# Performance

## Performance impact
- [x] No meaningful performance impact is expected

## Justification
- The `instanceof Event` check is a single guard at the top of `isIgnorableRejection`, which is only called on unhandled rejections (rare path). The polyfill is a no-op on all modern browsers.

# UI changes

## Screenshots or recordings
- N/A

# Issue link

- Closes OPENSCAD-STUDIO-2, OPENSCAD-STUDIO-3 (Sentry)