### PR TITLE
feat: professional image rendering in AI chat

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "Web Dev Server",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["web:dev"],
+      "port": 3000
+    },
+    {
+      "name": "Tauri Desktop Dev",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["tauri:dev"],
+      "port": 1420
+    }
+  ]
+}

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -47,7 +47,6 @@
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^3.0.6",
     "react-syntax-highlighter": "^16.1.0",
-    "react-zoom-pan-pinch": "^3.7.0",
     "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7",
     "tailwindcss": "^3.4.16",
@@ -55,6 +54,7 @@
     "three-stdlib": "^2.36.0",
     "tree-sitter-openscad": "^0.5.1",
     "web-tree-sitter": "^0.25.10",
+    "yet-another-react-lightbox": "^3.29.2",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/apps/ui/src/components/AiPromptPanel.tsx
+++ b/apps/ui/src/components/AiPromptPanel.tsx
@@ -1,4 +1,5 @@
 import { useRef, useEffect, forwardRef, useImperativeHandle } from 'react';
+import { ChatImage, ChatImageGrid } from './ChatImage';
 import { Button, Text } from './ui';
 import { MarkdownMessage } from './MarkdownMessage';
 import { ModelSelector } from './ModelSelector';
@@ -320,33 +321,24 @@ export const AiPromptPanel = forwardRef<AiPromptPanelRef, AiPromptPanelProps>(
                           <div className="text-sm whitespace-pre-wrap font-mono">{userText}</div>
                         ) : null}
                         {imageParts.length > 0 && (
-                          <div className={`grid gap-2 ${userText ? 'mt-2' : ''}`}>
-                            {imageParts.map((part) => {
-                              const attachment = attachments[part.attachmentId];
-                              return (
-                                <div
-                                  key={part.attachmentId}
-                                  className="rounded border overflow-hidden"
-                                  style={{
-                                    backgroundColor: 'rgba(255,255,255,0.08)',
-                                    borderColor: 'rgba(255,255,255,0.2)',
-                                  }}
-                                >
-                                  {attachment?.previewUrl ? (
-                                    <img
-                                      src={attachment.previewUrl}
-                                      alt={part.filename}
-                                      className="max-w-full object-cover"
-                                      style={{ maxHeight: '220px', width: '100%' }}
-                                    />
-                                  ) : null}
-                                  <div className="px-2 py-1 text-xs" style={{ opacity: 0.85 }}>
-                                    {part.filename}
-                                  </div>
-                                </div>
-                              );
-                            })}
-                          </div>
+                          <ChatImageGrid
+                            className={userText ? 'mt-2' : ''}
+                            images={imageParts
+                              .map((part) => {
+                                const att = attachments[part.attachmentId];
+                                return {
+                                  src: att?.previewUrl ?? '',
+                                  fullSrc:
+                                    att?.normalizedData && att.normalizedMimeType
+                                      ? `data:${att.normalizedMimeType};base64,${att.normalizedData}`
+                                      : undefined,
+                                  width: att?.width,
+                                  height: att?.height,
+                                  filename: part.filename,
+                                };
+                              })
+                              .filter((img) => Boolean(img.src))}
+                          />
                         )}
                       </div>
                     </div>
@@ -427,14 +419,10 @@ export const AiPromptPanel = forwardRef<AiPromptPanelRef, AiPromptPanelProps>(
                       )}
                       {imageDataUrl && (
                         <div className="mt-2">
-                          <img
+                          <ChatImage
                             src={imageDataUrl}
                             alt="Preview screenshot"
-                            className="max-w-full rounded border"
-                            style={{
-                              maxHeight: '300px',
-                              borderColor: 'var(--border-secondary)',
-                            }}
+                            filename="preview.png"
                           />
                         </div>
                       )}
@@ -481,14 +469,10 @@ export const AiPromptPanel = forwardRef<AiPromptPanelRef, AiPromptPanelProps>(
                         )}
                         {imageDataUrl && (
                           <div className="mt-2">
-                            <img
+                            <ChatImage
                               src={imageDataUrl}
                               alt="Preview screenshot"
-                              className="max-w-full rounded border"
-                              style={{
-                                maxHeight: '300px',
-                                borderColor: 'var(--border-secondary)',
-                              }}
+                              filename="preview.png"
                             />
                           </div>
                         )}

--- a/apps/ui/src/components/ChatImage.tsx
+++ b/apps/ui/src/components/ChatImage.tsx
@@ -1,0 +1,173 @@
+import { useState } from 'react';
+import { TbPhoto } from 'react-icons/tb';
+import Lightbox from 'yet-another-react-lightbox';
+import Zoom from 'yet-another-react-lightbox/plugins/zoom';
+import Captions from 'yet-another-react-lightbox/plugins/captions';
+import 'yet-another-react-lightbox/styles.css';
+import 'yet-another-react-lightbox/plugins/captions.css';
+
+export interface ChatImageItem {
+  /** Small preview URL used for the thumbnail (256px) */
+  src: string;
+  /** Full-resolution data URL used for the lightbox (up to 1600px). Falls back to src. */
+  fullSrc?: string;
+  /** Pixel dimensions of the full-resolution image, used as hints for YARL */
+  width?: number;
+  height?: number;
+  filename?: string;
+}
+
+// Thumbnail dimensions — sized to match the composer attachment thumbnails
+const THUMB_W = 96;
+const THUMB_H = 72;
+
+interface ChatImageProps {
+  src: string;
+  fullSrc?: string;
+  width?: number;
+  height?: number;
+  alt: string;
+  filename?: string;
+  /** When part of a grid, pass all slides + this image's index for carousel */
+  slides?: ChatImageItem[];
+  slideIndex?: number;
+}
+
+export function ChatImage({
+  src,
+  fullSrc,
+  width,
+  height,
+  alt,
+  filename,
+  slides,
+  slideIndex = 0,
+}: ChatImageProps) {
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState(false);
+  const [lightboxOpen, setLightboxOpen] = useState(false);
+  const [isHovered, setIsHovered] = useState(false);
+
+  // Use full-res src for lightbox if available; pass real dimensions so YARL
+  // fills the viewport correctly rather than rendering at thumbnail size.
+  const lightboxSlides = (slides ?? [{ src, fullSrc, width, height, filename }]).map((img) => ({
+    src: img.fullSrc ?? img.src,
+    title: img.filename,
+    width: img.width ?? 1600,
+    height: img.height ?? 1600,
+  }));
+
+  if (error) {
+    return (
+      <div
+        style={{
+          width: THUMB_W,
+          height: THUMB_H,
+          flexShrink: 0,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 4,
+          borderRadius: 6,
+          backgroundColor: 'var(--bg-tertiary)',
+          color: 'var(--text-tertiary)',
+          border: '1px solid var(--border-secondary)',
+          fontSize: 10,
+        }}
+      >
+        <TbPhoto size={16} />
+        <span>Unavailable</span>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {/* Thumbnail */}
+      <div
+        style={{
+          width: THUMB_W,
+          height: THUMB_H,
+          flexShrink: 0,
+          position: 'relative',
+          borderRadius: 6,
+          overflow: 'hidden',
+          cursor: 'zoom-in',
+          border: '1px solid rgba(255, 255, 255, 0.18)',
+          backgroundColor: 'var(--bg-tertiary)',
+        }}
+        onClick={() => setLightboxOpen(true)}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+      >
+        <img
+          src={src}
+          alt={alt}
+          style={{
+            width: '100%',
+            height: '100%',
+            objectFit: 'cover',
+            display: 'block',
+            opacity: loaded ? 1 : 0,
+            transition: 'opacity 150ms ease',
+          }}
+          onLoad={() => setLoaded(true)}
+          onError={() => setError(true)}
+        />
+        {/* Hover overlay */}
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            backgroundColor: 'rgba(0, 0, 0, 0.28)',
+            opacity: isHovered && loaded ? 1 : 0,
+            transition: 'opacity 120ms ease',
+            pointerEvents: 'none',
+          }}
+        />
+      </div>
+
+      {/* Always mounted — YARL controls visibility via `open` */}
+      <Lightbox
+        open={lightboxOpen}
+        close={() => setLightboxOpen(false)}
+        slides={lightboxSlides}
+        index={slideIndex}
+        plugins={[Zoom, Captions]}
+        animation={{ swipe: 150, fade: 120 }}
+        styles={{ container: { backgroundColor: 'rgba(0, 0, 0, 0.92)' } }}
+        zoom={{ maxZoomPixelRatio: 4 }}
+        captions={{ descriptionTextAlign: 'center' }}
+      />
+    </>
+  );
+}
+
+interface ChatImageGridProps {
+  images: ChatImageItem[];
+  className?: string;
+}
+
+export function ChatImageGrid({ images, className = '' }: ChatImageGridProps) {
+  const valid = images.filter((img) => Boolean(img.src));
+  if (valid.length === 0) return null;
+
+  return (
+    <div className={className} style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+      {valid.map((image, index) => (
+        <ChatImage
+          key={`${image.src}-${index}`}
+          src={image.src}
+          fullSrc={image.fullSrc}
+          width={image.width}
+          height={image.height}
+          alt={image.filename ?? `Image ${index + 1}`}
+          filename={image.filename}
+          slides={valid}
+          slideIndex={index}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/ui/src/components/__tests__/ChatImage.test.tsx
+++ b/apps/ui/src/components/__tests__/ChatImage.test.tsx
@@ -1,0 +1,92 @@
+/** @jest-environment jsdom */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import { jest } from '@jest/globals';
+import { ChatImage, ChatImageGrid } from '../ChatImage';
+
+// Mock yet-another-react-lightbox since it relies on browser APIs not in jsdom
+jest.mock('yet-another-react-lightbox', () => ({
+  __esModule: true,
+  default: ({ open, close }: { open: boolean; close: () => void }) =>
+    open ? <div data-testid="lightbox" onClick={close} /> : null,
+}));
+jest.mock('yet-another-react-lightbox/plugins/zoom', () => ({ __esModule: true, default: {} }));
+jest.mock('yet-another-react-lightbox/plugins/captions', () => ({
+  __esModule: true,
+  default: {},
+}));
+jest.mock('yet-another-react-lightbox/styles.css', () => ({}));
+jest.mock('yet-another-react-lightbox/plugins/captions.css', () => ({}));
+
+describe('ChatImage', () => {
+  it('renders image with correct src and alt', () => {
+    render(<ChatImage src="https://example.com/img.png" alt="test image" />);
+    // img starts hidden (display:none) until onLoad fires
+    const img = screen.getByRole('img', { hidden: true });
+    expect(img).toBeDefined();
+    expect(img.getAttribute('src')).toBe('https://example.com/img.png');
+    expect(img.getAttribute('alt')).toBe('test image');
+  });
+
+  it('shows broken-image placeholder when onError fires', () => {
+    render(<ChatImage src="bad-url" alt="broken" />);
+    const img = screen.getByRole('img', { hidden: true });
+    fireEvent.error(img);
+    expect(screen.getByText('Unavailable')).toBeDefined();
+    expect(screen.queryByRole('img', { hidden: true })).toBeNull();
+  });
+
+  it('opens lightbox when image container is clicked', () => {
+    render(<ChatImage src="https://example.com/img.png" alt="test" />);
+    const img = screen.getByRole('img', { hidden: true });
+    fireEvent.load(img);
+    // Click the wrapper div (parent of img)
+    fireEvent.click(img.parentElement!);
+    expect(screen.getByTestId('lightbox')).toBeDefined();
+  });
+
+  it('closes lightbox when close is triggered', () => {
+    render(<ChatImage src="https://example.com/img.png" alt="test" />);
+    const img = screen.getByRole('img', { hidden: true });
+    fireEvent.load(img);
+    fireEvent.click(img.parentElement!);
+    const lightbox = screen.getByTestId('lightbox');
+    fireEvent.click(lightbox); // triggers close()
+    expect(screen.queryByTestId('lightbox')).toBeNull();
+  });
+});
+
+describe('ChatImageGrid', () => {
+  it('renders nothing when images array is empty', () => {
+    const { container } = render(<ChatImageGrid images={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when all images have empty src', () => {
+    const { container } = render(<ChatImageGrid images={[{ src: '', filename: 'test.png' }]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders a flex container for any number of images', () => {
+    const { container } = render(
+      <ChatImageGrid images={[{ src: 'https://example.com/a.png', filename: 'a.png' }]} />
+    );
+    const grid = container.firstChild as HTMLElement;
+    expect(grid.style.display).toBe('flex');
+    expect(grid.style.flexWrap).toBe('wrap');
+  });
+
+  it('renders all valid images as thumbnails', () => {
+    const { container } = render(
+      <ChatImageGrid
+        images={[
+          { src: 'https://example.com/a.png', filename: 'a.png' },
+          { src: 'https://example.com/b.png', filename: 'b.png' },
+          { src: 'https://example.com/c.png', filename: 'c.png' },
+        ]}
+      />
+    );
+    // 3 images → 3 child wrappers
+    expect(container.firstChild?.childNodes.length).toBe(3);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,9 +114,6 @@ importers:
       react-syntax-highlighter:
         specifier: ^16.1.0
         version: 16.1.0(react@18.3.1)
-      react-zoom-pan-pinch:
-        specifier: ^3.7.0
-        version: 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -138,6 +135,9 @@ importers:
       web-tree-sitter:
         specifier: ^0.25.10
         version: 0.25.10
+      yet-another-react-lightbox:
+        specifier: ^3.29.2
+        version: 3.29.2(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -3983,6 +3983,20 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yet-another-react-lightbox@3.29.2:
+    resolution: {integrity: sha512-TMDHPn1uDOkrjEysoKCt1xsswGTcC2DPXHmjFUG1szWJ8ksu7bp+l67h/ZV27miA5hkSCLtqGzkHGTMOurce9w==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@types/react': ^16 || ^17 || ^18 || ^19
+      '@types/react-dom': ^16 || ^17 || ^18 || ^19
+      react: ^16.8.0 || ^17 || ^18 || ^19
+      react-dom: ^16.8.0 || ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -8169,6 +8183,14 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yet-another-react-lightbox@3.29.2(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.26
+      '@types/react-dom': 18.3.7(@types/react@18.3.26)
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
# Summary

## What changed
- Added `ChatImage` and `ChatImageGrid` components backed by `yet-another-react-lightbox`
- Replaced the old full-width stacked image layout in the AI chat transcript with a compact thumbnail row (96×72px, `object-cover`) matching the composer's attachment style
- Lightbox now uses the full 1600px `normalizedData` image instead of the 256px `previewUrl` — images are crisp and fill the viewport
- Carousel navigation between multiple images with keyboard (ESC/arrows), touch swipe, and mouse drag
- Replaced raw `<img>` tags in tool call screenshot blocks with `ChatImage`
- Removed unused `react-zoom-pan-pinch` dependency

## Why
- The previous rendering cropped images with `object-cover` + fixed maxHeight, had no lightbox, stacked images with an awkward grid that left empty cells, showed filenames as metadata noise in the transcript, and rendered thumbnails in the lightbox at their tiny 256px preview size
- Goal: bring image UX up to the standard of ChatGPT/Claude.ai

## Implementation notes
- `ChatImageItem` carries both `src` (256px preview for fast thumbnail) and `fullSrc` (1600px data URL for lightbox) + real `width`/`height` hints so YARL fills the viewport
- `ChatImageGrid` uses `display: flex; flex-wrap: wrap` with inline styles (not Tailwind classes) to avoid JIT purging issues
- Lightbox is always mounted and controlled via YARL's `open` prop (conditional mounting was causing click-to-open to silently fail)
- Animation tuned to `swipe: 150ms, fade: 120ms` for a snappy feel
- Added `.claude/launch.json` with web (port 3000) and Tauri (port 1420) dev server configs

# Testing

## Coverage checklist
- [x] Client unit/component tests added or updated for changed frontend behavior

## Validation performed
- [x] `npx tsc -b --noEmit`
- [x] `yarn lint` (via `pnpm lint`)
- [x] `yarn test` (ChatImage unit tests — 8 passing)

## Test details
- 8 unit tests covering: renders with correct src/alt, broken-image placeholder on error, lightbox opens/closes on click, flex container for grid, filters empty src, renders correct child count for multiple images
- Manual testing by user: thumbnails render correctly, lightbox opens with full-res image, carousel navigates between multiple images

# Performance

## Performance impact
- [x] Performance was considered for this change

## Justification
- Thumbnail display uses the existing 256px `previewUrl` (already in memory) — no extra work
- Lightbox uses the existing 1600px `normalizedData` base64 string (already in memory from upload processing) — no extra network requests or re-encoding
- `yet-another-react-lightbox` core is ~10KB gzipped; replaces a custom solution with a battle-tested library

# UI changes

## Screenshots or recordings
- Thumbnails: compact 96×72px row matching the composer attachment style, hover darkening, zoom cursor
- Lightbox: full-res image filling the viewport, carousel arrows, ESC to close, filename caption, pinch/scroll to zoom

<img width="254" height="165" alt="Screenshot 2026-03-24 at 8 03 37 AM" src="https://github.com/user-attachments/assets/6fd3e6b0-7337-4b78-822f-2cd45c4010dc" />

<img width="1726" height="961" alt="Screenshot 2026-03-24 at 8 03 44 AM" src="https://github.com/user-attachments/assets/c9ad9cbb-6f23-44d1-894b-c3472151aad4" />

# Issue link

- Closes #