### PR TITLE
Harden customizer E2E stability

### DIFF
--- a/apps/ui/src/components/CustomizerPanel.tsx
+++ b/apps/ui/src/components/CustomizerPanel.tsx
@@ -42,6 +42,17 @@ interface GroupedParams {
   params: CustomizerParam[];
 }
 
+function toTestIdSegment(value: string | null): string {
+  if (!value) return 'default';
+  return (
+    value
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '') || 'default'
+  );
+}
+
 const PROMINENCE_ORDER: Record<ParameterProminence, number> = {
   primary: 0,
   secondary: 1,
@@ -123,7 +134,11 @@ function getCustomizerAnalyticsSummary(tabs: GroupedParams[] | { params: Customi
 
 function LoadingState() {
   return (
-    <div className="p-4 space-y-3" aria-label="Loading customizer">
+    <div
+      className="p-4 space-y-3"
+      aria-label="Loading customizer"
+      data-testid="customizer-loading-state"
+    >
       {[0, 1, 2].map((block) => (
         <div
           key={block}
@@ -381,7 +396,12 @@ export function CustomizerPanel({
 
   if (!parserReady) {
     return (
-      <div className="h-full overflow-y-auto" style={{ backgroundColor: 'var(--bg-primary)' }}>
+      <div
+        className="h-full overflow-y-auto"
+        style={{ backgroundColor: 'var(--bg-primary)' }}
+        data-testid="customizer-panel"
+        data-state="loading"
+      >
         <LoadingState />
       </div>
     );
@@ -392,7 +412,8 @@ export function CustomizerPanel({
       <div
         className="h-full flex flex-col items-center justify-center p-6 gap-5"
         style={{ backgroundColor: 'var(--bg-primary)' }}
-        data-testid="customizer-empty-state"
+        data-testid="customizer-panel"
+        data-state="empty"
       >
         <div className="flex flex-col items-center gap-3 text-center max-w-[220px]">
           <div
@@ -405,10 +426,19 @@ export function CustomizerPanel({
             <TbAdjustmentsHorizontal size={22} />
           </div>
           <div className="space-y-1.5">
-            <Text variant="section-heading" as="h2" className="leading-snug">
+            <Text
+              variant="section-heading"
+              as="h2"
+              className="leading-snug"
+              data-testid="customizer-empty-title"
+            >
               No parameters yet
             </Text>
-            <Text variant="caption" className="leading-relaxed">
+            <Text
+              variant="caption"
+              className="leading-relaxed"
+              data-testid="customizer-empty-description"
+            >
               Ask the AI to add customizer parameters with sliders and labels.
             </Text>
           </div>
@@ -442,7 +472,12 @@ export function CustomizerPanel({
   }
 
   return (
-    <div className="h-full overflow-y-auto" style={{ backgroundColor: 'var(--bg-primary)' }}>
+    <div
+      className="h-full overflow-y-auto"
+      style={{ backgroundColor: 'var(--bg-primary)' }}
+      data-testid="customizer-panel"
+      data-state="ready"
+    >
       <div
         className="sticky top-0 z-10 border-b border-l backdrop-blur"
         style={{
@@ -465,6 +500,7 @@ export function CustomizerPanel({
                     checked={showAdvanced}
                     onChange={(event) => setShowAdvanced(event.target.checked)}
                     aria-label="Show advanced controls"
+                    data-testid="customizer-advanced-toggle"
                   />
                   <span>Advanced</span>
                 </div>
@@ -592,6 +628,7 @@ export function CustomizerPanel({
                     checked={showAdvanced}
                     onChange={(event) => setShowAdvanced(event.target.checked)}
                     aria-label="Show advanced controls"
+                    data-testid="customizer-advanced-toggle"
                   />
                   <span>Advanced</span>
                 </div>
@@ -613,7 +650,11 @@ export function CustomizerPanel({
 
       <div className="p-3 space-y-3">
         {groupedTabs.map((tab) => (
-          <section key={tab.name} className="space-y-3">
+          <section
+            key={tab.name}
+            className="space-y-3"
+            data-testid={`customizer-tab-${toTestIdSegment(tab.name)}`}
+          >
             {showTabHeaders && (
               <div className="flex items-center justify-between">
                 <div>
@@ -629,7 +670,11 @@ export function CustomizerPanel({
 
                 if (shouldFlattenGroup) {
                   return (
-                    <div key={`${tab.name}-${group.id}`} className="space-y-2">
+                    <div
+                      key={`${tab.name}-${group.id}`}
+                      className="space-y-2"
+                      data-testid={`customizer-group-${toTestIdSegment(group.name ?? tab.name)}`}
+                    >
                       {group.params.map((param) => {
                         const baseline = baselineParams.get(getParamKey(param));
                         const isDirty = baseline !== undefined && param.rawValue !== baseline;
@@ -655,6 +700,7 @@ export function CustomizerPanel({
                     style={{
                       backgroundColor: 'var(--bg-secondary)',
                     }}
+                    data-testid={`customizer-group-${toTestIdSegment(group.name)}`}
                   >
                     {group.name && !isRedundantGroupName(tab.name, group.name) && (
                       <div className="mb-2">

--- a/e2e/fixtures/app.fixture.ts
+++ b/e2e/fixtures/app.fixture.ts
@@ -116,6 +116,11 @@ export class AppHelper {
     return this.page.locator('canvas[data-engine]').first();
   }
 
+  /** Customizer panel root */
+  get customizerPanel(): Locator {
+    return this.page.getByTestId('customizer-panel');
+  }
+
   /** 2D SVG preview container */
   get previewSvg2D(): Locator {
     return this.page.locator('[data-preview-svg]').first();
@@ -138,18 +143,29 @@ export class AppHelper {
     }
   }
 
-  async updateSourceAndRender(code: string, trigger: string = 'manual'): Promise<RenderSnapshot | null> {
+  async updateSourceAndRender(
+    code: string,
+    trigger: string = 'manual',
+    options?: { waitForPreviewState?: boolean; timeout?: number }
+  ): Promise<RenderSnapshot | null> {
     const snapshot = await this.page.evaluate(
       async ({ nextCode, renderTrigger }) => {
-        return (window as any).__TEST_OPENSCAD__?.updateSourceAndRender?.(nextCode, renderTrigger) ?? null;
+        return (
+          (window as any).__TEST_OPENSCAD__?.updateSourceAndRender?.(nextCode, renderTrigger) ??
+          null
+        );
       },
       { nextCode: code, renderTrigger: trigger }
     );
 
-    if (snapshot?.previewKind === 'mesh' && snapshot.previewSrc) {
+    if (
+      options?.waitForPreviewState !== false &&
+      snapshot?.previewKind === 'mesh' &&
+      snapshot.previewSrc
+    ) {
       await this.waitForPreviewState({
         modelVersion: snapshot.previewSrc,
-        timeout: 30_000,
+        timeout: options?.timeout ?? 30_000,
       });
     }
 
@@ -203,22 +219,13 @@ export class AppHelper {
         if (expected.fitCount !== undefined && preview.fitCount !== expected.fitCount) {
           return false;
         }
-        if (
-          expected.orthographic !== undefined &&
-          preview.orthographic !== expected.orthographic
-        ) {
+        if (expected.orthographic !== undefined && preview.orthographic !== expected.orthographic) {
           return false;
         }
-        if (
-          expected.currentFits !== undefined &&
-          preview.currentFits !== expected.currentFits
-        ) {
+        if (expected.currentFits !== undefined && preview.currentFits !== expected.currentFits) {
           return false;
         }
-        if (
-          expected.axesVisible !== undefined &&
-          preview.axesVisible !== expected.axesVisible
-        ) {
+        if (expected.axesVisible !== undefined && preview.axesVisible !== expected.axesVisible) {
           return false;
         }
         if (
@@ -267,6 +274,15 @@ export class AppHelper {
 
     // Extra settle time for Three.js to finish drawing
     await this.page.waitForTimeout(500);
+  }
+
+  async waitForCustomizerState(
+    state: 'loading' | 'empty' | 'ready',
+    options?: { timeout?: number }
+  ) {
+    await expect(this.customizerPanel).toHaveAttribute('data-state', state, {
+      timeout: options?.timeout ?? 15_000,
+    });
   }
 
   /** Wait for the WASM engine to initialize (web only) */

--- a/e2e/tests/panels/customizer-panel.spec.ts
+++ b/e2e/tests/panels/customizer-panel.spec.ts
@@ -1,5 +1,4 @@
 import { test, expect } from '../../fixtures/app.fixture';
-import { setMonacoValue } from '../../helpers/editor';
 
 test.describe('Customizer Panel', () => {
   async function ensureCustomizerVisible(page: import('@playwright/test').Page) {
@@ -8,7 +7,17 @@ test.describe('Customizer Panel', () => {
       test.skip(true, 'Customizer tab not available in layout');
     }
     await customizerTab.click();
-    await page.waitForTimeout(500);
+    await expect(page.getByTestId('customizer-panel')).toBeVisible({ timeout: 10_000 });
+  }
+
+  async function updateCustomizerCode(
+    app: import('../../fixtures/app.fixture').AppHelper,
+    code: string,
+    expectedState: 'empty' | 'ready'
+  ) {
+    await app.updateSourceAndRender(code, 'manual', { waitForPreviewState: false });
+    await app.waitForRender();
+    await app.waitForCustomizerState(expectedState, { timeout: 10_000 });
   }
 
   async function useCustomizerFirstLayout(app: import('../../fixtures/app.fixture').AppHelper) {
@@ -33,11 +42,8 @@ test.describe('Customizer Panel', () => {
 
   test('shows the empty-state guidance for simple code', async ({ app }) => {
     await ensureCustomizerVisible(app.page);
-    await setMonacoValue(app.page, 'cube(10);');
-    await app.triggerRender();
-    await app.waitForRender();
-    await expect(app.page.getByTestId('customizer-empty-state')).toBeVisible({ timeout: 5000 });
-    await expect(app.page.getByText('No parameters yet')).toBeVisible({ timeout: 5000 });
+    await updateCustomizerCode(app, 'cube(10);', 'empty');
+    await expect(app.page.getByTestId('customizer-empty-title')).toBeVisible({ timeout: 5_000 });
   });
 
   test('detects customizer parameters', async ({ app }) => {
@@ -49,13 +55,11 @@ test.describe('Customizer Panel', () => {
       'cube([width, height, 5]);',
     ].join('\n');
 
-    await setMonacoValue(app.page, paramCode);
-    await app.triggerRender();
-    await app.waitForRender();
-
-    // Parser initializes asynchronously — wait for parameters to appear
-    await expect(app.page.getByText('width').first()).toBeVisible({ timeout: 10_000 });
-    await expect(app.page.getByText('height').first()).toBeVisible({ timeout: 5_000 });
+    await updateCustomizerCode(app, paramCode, 'ready');
+    await expect(app.page.getByTestId('customizer-control-width')).toBeVisible({ timeout: 10_000 });
+    await expect(app.page.getByTestId('customizer-control-height')).toBeVisible({
+      timeout: 5_000,
+    });
   });
 
   test('shows parameter controls', async ({ app }) => {
@@ -67,13 +71,10 @@ test.describe('Customizer Panel', () => {
       'cube([width, height, 5]);',
     ].join('\n');
 
-    await setMonacoValue(app.page, paramCode);
-    await app.triggerRender();
-    await app.waitForRender();
-
-    // Check for input controls (range sliders or number inputs)
-    const controls = app.page.locator('input[type="range"], input[type="number"]');
-    await expect(controls.first()).toBeVisible({ timeout: 10_000 });
+    await updateCustomizerCode(app, paramCode, 'ready');
+    const widthControl = app.page.getByTestId('customizer-control-width');
+    await expect(widthControl.locator('input[type="range"]')).toBeVisible({ timeout: 10_000 });
+    await expect(widthControl.locator('input[type="number"]')).toBeVisible({ timeout: 5_000 });
   });
 
   test('renders @studio metadata labels and keeps advanced controls hidden by default', async ({
@@ -90,9 +91,7 @@ test.describe('Customizer Panel', () => {
       'cube([width, width, 5]);',
     ].join('\n');
 
-    await setMonacoValue(app.page, paramCode);
-    await app.triggerRender();
-    await app.waitForRender();
+    await updateCustomizerCode(app, paramCode, 'ready');
 
     const widthControl = app.page.getByTestId('customizer-control-width');
     await expect(widthControl).toBeVisible({ timeout: 10_000 });
@@ -100,10 +99,10 @@ test.describe('Customizer Panel', () => {
     await expect(widthControl.getByText('Overall width', { exact: true })).toBeVisible({
       timeout: 5_000,
     });
-    await expect(app.page.getByText('Body', { exact: true })).toBeVisible({ timeout: 5_000 });
+    await expect(app.page.getByTestId('customizer-group-body')).toBeVisible({ timeout: 5_000 });
     await expect(app.page.getByTestId('customizer-control-tolerance')).toHaveCount(0);
 
-    await app.page.getByLabel('Show advanced controls').click();
+    await app.page.getByTestId('customizer-advanced-toggle').click();
     await expect(app.page.getByTestId('customizer-control-tolerance')).toBeVisible({
       timeout: 5_000,
     });
@@ -111,19 +110,15 @@ test.describe('Customizer Panel', () => {
 
   test('shows the refinement CTA when no parameters are available', async ({ app }) => {
     await ensureCustomizerVisible(app.page);
-    await setMonacoValue(app.page, 'cube(10);');
-    await app.triggerRender();
-    await app.waitForRender();
-
-    await expect(app.page.getByTestId('customizer-empty-state')).toBeVisible({ timeout: 10_000 });
-    await expect(app.page.getByText('No parameters yet')).toBeVisible({ timeout: 5_000 });
+    await updateCustomizerCode(app, 'cube(10);', 'empty');
+    await expect(app.page.getByTestId('customizer-empty-title')).toBeVisible({ timeout: 5_000 });
     await expect(app.page.getByTestId('customizer-refine-button')).toBeVisible({ timeout: 5_000 });
   });
 
   test('supports the customizer-first layout actions', async ({ app }) => {
     await useCustomizerFirstLayout(app);
 
-    await expect(app.page.getByTestId('customizer-empty-state')).toBeVisible({ timeout: 10_000 });
+    await app.waitForCustomizerState('empty', { timeout: 10_000 });
     await expect(app.page.getByTestId('customizer-refine-button')).toBeVisible({ timeout: 5_000 });
     await expect(app.page.getByRole('button', { name: /Edit Code/i })).toBeVisible({
       timeout: 5_000,
@@ -138,13 +133,13 @@ test.describe('Customizer Panel', () => {
       'cube([width, height, 5]);',
     ].join('\n');
 
-    await setMonacoValue(app.page, paramCode);
-    await app.triggerRender();
-    await app.waitForRender();
+    await updateCustomizerCode(app, paramCode, 'ready');
 
     await app.page.locator('.dv-tab').filter({ hasText: 'Customizer' }).click();
-    await app.page.waitForTimeout(300);
-    await expect(app.page.getByTestId('customizer-download-button')).toBeVisible({ timeout: 10_000 });
+    await app.waitForCustomizerState('ready', { timeout: 10_000 });
+    await expect(app.page.getByTestId('customizer-download-button')).toBeVisible({
+      timeout: 10_000,
+    });
     await app.page.getByTestId('customizer-refine-button').click();
     await expect(app.page.getByText('Add an API key to get started')).toBeVisible({
       timeout: 10_000,
@@ -161,9 +156,7 @@ test.describe('Customizer Panel', () => {
       'cube([width, 20, 5]);',
     ].join('\n');
 
-    await setMonacoValue(app.page, paramCode);
-    await app.triggerRender();
-    await app.waitForRender();
+    await updateCustomizerCode(app, paramCode, 'ready');
 
     await expect(app.page.getByTestId('customizer-control-width')).toBeVisible({
       timeout: 10_000,

--- a/implementation-plans/customizer-e2e-flake-hardening.md
+++ b/implementation-plans/customizer-e2e-flake-hardening.md
@@ -1,0 +1,29 @@
+# Customizer E2E Flake Hardening
+
+## Goal
+
+Root-cause the slow, first-run flaky customizer E2E failures and harden both the panel and its tests so the suite waits on stable readiness states and uses durable selectors wherever possible.
+
+## Approach
+
+- Reproduce the customizer panel spec in isolation to identify whether the first-run delay comes from parser startup, renderer startup, or brittle panel activation/waiting.
+- Add or reuse explicit customizer readiness hooks and stable test ids instead of relying on visible text or fixed timeouts.
+- Update the customizer Playwright spec to wait for those stable signals and avoid text-only selectors where the UI already has a better identity.
+- Re-run the focused suite, including repeated first-run style executions, to verify the flake is resolved and runtime improves.
+
+## Affected Areas
+
+- `implementation-plans/customizer-e2e-flake-hardening.md`
+- `e2e/tests/panels/customizer-panel.spec.ts`
+- `e2e/fixtures/app.fixture.ts`
+- `apps/ui/src/components/CustomizerPanel.tsx`
+- `apps/ui/src/components/customizer/ParameterControl.tsx`
+
+## Checklist
+
+- [x] Inspect the customizer panel spec, helpers, and parser startup path
+- [x] Reproduce the first-run flake locally and identify the main bottleneck
+- [x] Add stable hooks or helpers needed for deterministic customizer readiness
+- [x] Update the spec to use durable selectors and readiness waits
+- [x] Re-run the focused customizer suite enough times to check first-run stability
+- [x] Summarize the root cause, fix, and any residual risks


### PR DESCRIPTION
## Summary
- remove the customizer spec's Monaco-plus-manual-render race by using the atomic test render path
- add stable customizer panel test ids and state hooks so the suite can wait on deterministic readiness instead of text and sleeps
- make preview-state synchronization optional in the fixture for tests that only need render completion

## Testing
- pnpm format:check
- pnpm lint
- pnpm exec playwright test e2e/tests/panels/customizer-panel.spec.ts --project=web-chromium --workers=1 --reporter=line
- env CI=1 pnpm exec playwright test e2e/tests/panels/customizer-panel.spec.ts --project=web-chromium --workers=1 --repeat-each=2 --grep "detects customizer parameters|shows parameter controls|renders @studio metadata labels|shows the refinement CTA" --reporter=line
- pnpm exec playwright test e2e/tests/panels/customizer-panel.spec.ts --project=web-chromium --workers=1 --grep "detects customizer parameters|shows parameter controls" --reporter=line