### PR TITLE
fix: add production KV and R2 bindings to wrangler.toml

### DIFF
--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -12,6 +12,14 @@ pages_build_output_dir = "./dist"
 # which runs `wrangler pages dev` with local `SHARE_KV` and `SHARE_R2`
 # emulation plus persistent state in `.wrangler/state/share-dev`.
 
+[[kv_namespaces]]
+binding = "SHARE_KV"
+id = "7a5296abd7b44f11a331dc0cf2c42b55"
+
+[[r2_buckets]]
+binding = "SHARE_R2"
+bucket_name = "share-thumbnails-production"
+
 [[env.preview.kv_namespaces]]
 binding = "SHARE_KV"
 id = "55463463091d414fa35d361a91ba019d"


### PR DESCRIPTION
# Summary

## What changed
- Added top-level `[[kv_namespaces]]` and `[[r2_buckets]]` bindings for the production environment in `apps/web/wrangler.toml`

## Why
- `SHARE_KV` and `SHARE_R2` were only configured under `[[env.preview.*]]`, so the production Pages worker had no access to these bindings
- This caused every `POST /api/share` request on production to throw a `TypeError` (Cloudflare Error 1101 / 500), while staging worked fine

## Implementation notes
- Production KV namespace: `worker-SHARE_KV_PRODUCTION` (`7a5296abd7b44f11a331dc0cf2c42b55`)
- Production R2 bucket: `share-thumbnails-production`
- Preview/staging bindings are unchanged

# Testing

## Coverage checklist
- [ ] No new tests were needed for this change

## Validation performed
- Verified production KV namespace ID and R2 bucket name via `wrangler kv namespace list` and `wrangler r2 bucket list`

# Performance

## Performance impact
- [ ] No meaningful performance impact is expected

## Justification
- Config-only change, no runtime logic modified.

# UI changes

## Screenshots or recordings
- N/A

# Issue link
- N/A