### PR TITLE
feat: persist stable anonymous ID for accurate unique user tracking

### DIFF
--- a/apps/ui/src/analytics/__tests__/runtime.test.ts
+++ b/apps/ui/src/analytics/__tests__/runtime.test.ts
@@ -6,6 +6,8 @@ import { createAnalyticsApi, resetAnalyticsErrorDedupeForTests } from '../runtim
 function createClient() {
   return {
     capture: jest.fn(),
+    identify: jest.fn(),
+    reset: jest.fn(),
     opt_in_capturing: jest.fn(),
     opt_out_capturing: jest.fn(),
     register: jest.fn(),

--- a/apps/ui/src/analytics/bootstrap.ts
+++ b/apps/ui/src/analytics/bootstrap.ts
@@ -1,6 +1,7 @@
 import type { PlatformCapabilities } from '../platform';
 import { APP_VERSION } from '../constants/appInfo';
 import { scrubAndFilterEvent } from './sanitize';
+import { getOrCreateStableId } from './stableId';
 
 export type RuntimeSurface = 'web' | 'desktop';
 
@@ -8,6 +9,7 @@ export interface PostHogClientLike {
   init: (token: string, config: Record<string, unknown>) => void;
   capture: (eventName: string, properties?: Record<string, unknown>) => void;
   register: (properties: Record<string, unknown>) => void;
+  identify: (distinctId: string) => void;
   opt_in_capturing: (options?: Record<string, unknown>) => void;
   opt_out_capturing: () => void;
 }
@@ -101,6 +103,7 @@ export function initializePostHog(
   client.register(getBootstrapSharedProperties(options));
   if (options.analyticsEnabled) {
     client.opt_in_capturing({ captureEventName: false });
+    client.identify(getOrCreateStableId());
   } else {
     client.opt_out_capturing();
   }

--- a/apps/ui/src/analytics/runtime.tsx
+++ b/apps/ui/src/analytics/runtime.tsx
@@ -14,6 +14,7 @@ import { useHasApiKey } from '../stores/apiKeyStore';
 import { useSettings } from '../stores/settingsStore';
 import { type RuntimeSurface } from './bootstrap';
 import { sanitizeAnalyticsProperties } from './sanitize';
+import { clearStableId, getOrCreateStableId } from './stableId';
 
 export type RenderTrigger =
   | 'initial'
@@ -58,6 +59,8 @@ export interface AnalyticsApi {
 
 interface PostHogCaptureClient {
   capture: (eventName: string, properties?: Record<string, unknown>) => void;
+  identify: (distinctId: string) => void;
+  reset: () => void;
   opt_in_capturing: (options?: Record<string, unknown>) => void;
   opt_out_capturing: () => void;
   register: (properties: Record<string, unknown>) => void;
@@ -227,6 +230,7 @@ export function createAnalyticsApi(options: {
 
       if (enabled) {
         client.opt_in_capturing({ captureEventName: false });
+        client.identify(getOrCreateStableId());
         if (runtimeOptions?.capturePreferenceChange) {
           client.capture(
             'analytics preference changed',
@@ -248,6 +252,8 @@ export function createAnalyticsApi(options: {
             })
           );
         }
+        clearStableId();
+        client.reset();
         client.opt_out_capturing();
       }
 

--- a/apps/ui/src/analytics/stableId.ts
+++ b/apps/ui/src/analytics/stableId.ts
@@ -1,0 +1,13 @@
+export const STABLE_ANALYTICS_ID_KEY = 'openscad-studio:analytics-id';
+
+export function getOrCreateStableId(): string {
+  const existing = localStorage.getItem(STABLE_ANALYTICS_ID_KEY);
+  if (existing) return existing;
+  const id = crypto.randomUUID();
+  localStorage.setItem(STABLE_ANALYTICS_ID_KEY, id);
+  return id;
+}
+
+export function clearStableId(): void {
+  localStorage.removeItem(STABLE_ANALYTICS_ID_KEY);
+}


### PR DESCRIPTION
# Summary

## What changed
- Added `apps/ui/src/analytics/stableId.ts` — generates a UUID on first visit and persists it to `localStorage` under `openscad-studio:analytics-id`
- `bootstrap.ts` — calls `posthog.identify(stableId)` at startup when analytics is enabled
- `runtime.tsx` — calls `identify` when the user enables analytics; calls `clearStableId()` + `posthog.reset()` when they disable it
- Updated `runtime.test.ts` mock client with `identify` and `reset` stubs

## Why
- PostHog was configured with `person_profiles: 'identified_only'` but `posthog.identify()` was never called, so Growth Accounting showed ~3 users while WAU showed 67 — all anonymous sessions
- A stable ID lets PostHog count unique returning users accurately without requiring auth

## Implementation notes
- Privacy-respecting: opting out removes the stored UUID and resets PostHog, severing the identity link. Re-enabling generates a fresh UUID — the user cannot be correlated back to their prior identity
- `person_profiles: 'identified_only'` is intentionally kept — no anonymous person profiles are created

| State | localStorage | PostHog |
|---|---|---|
| Analytics ON (boot) | UUID created if missing | `identify(uuid)` |
| Analytics ON (toggle) | UUID created if missing | `opt_in` → `identify(uuid)` |
| Analytics OFF (toggle) | UUID deleted | `reset()` → `opt_out` |
| Analytics OFF (boot) | UUID not touched | `opt_out` only |

# Testing

## Coverage checklist
- [x] Client unit/component tests added or updated for changed frontend behavior

## Validation performed
- `tsc --noEmit` passes clean
- Mock client in `runtime.test.ts` updated with `identify` and `reset`

# Performance

## Performance impact
- [x] No meaningful performance impact is expected

## Justification
- One `localStorage.getItem` and one `posthog.identify()` call at startup — negligible.

# UI changes

## Screenshots or recordings
- N/A

# Issue link
- N/A