### PR TITLE
fix: mobile share links no longer hang at 'Opening shared design...'

### DIFF
--- a/apps/ui/src/stores/__tests__/workspaceStore.test.ts
+++ b/apps/ui/src/stores/__tests__/workspaceStore.test.ts
@@ -126,6 +126,30 @@ describe('workspaceStore', () => {
     expect(openedTab.render).toEqual(createEmptyRenderState());
   });
 
+  it('replaces the initial tab even when showWelcome is already false (mobile regression)', () => {
+    // On mobile, useMobileLayout calls hideWelcomeScreen() before openSharedDocument runs.
+    // Previously this caused openSharedDocument to create a new tab instead of replacing
+    // the initial one, so the render result landed on the wrong tab and onVisualReady
+    // never fired — leaving the "Opening shared design…" overlay stuck forever.
+    const store = createWorkspaceStore();
+    const initialTabId = store.getState().activeTabId!;
+
+    // Simulate mobile: welcome screen dismissed before share loads
+    store.getState().hideWelcomeScreen();
+    expect(store.getState().showWelcome).toBe(false);
+
+    const returnedTabId = store.getState().openSharedDocument({
+      name: 'My Design',
+      content: 'cube(10);',
+    });
+
+    // Must replace (same ID), not create a new tab
+    expect(returnedTabId).toBe(initialTabId);
+    expect(store.getState().tabs).toHaveLength(1);
+    expect(store.getState().activeTabId).toBe(initialTabId);
+    expect(store.getState().tabs[0].content).toBe('cube(10);');
+  });
+
   it('ignores stale render results by request id', () => {
     const store = createWorkspaceStore();
     const tabId = store.getState().activeTabId!;

--- a/apps/ui/src/stores/workspaceStore.ts
+++ b/apps/ui/src/stores/workspaceStore.ts
@@ -133,11 +133,7 @@ export function createWorkspaceStore(
       const state = get();
       const firstTab = state.tabs[0];
       const shouldReplaceFirstTab =
-        state.showWelcome &&
-        state.tabs.length === 1 &&
-        firstTab &&
-        !firstTab.filePath &&
-        !firstTab.isDirty;
+        state.tabs.length === 1 && firstTab && !firstTab.filePath && !firstTab.isDirty;
 
       if (!shouldReplaceFirstTab) {
         return get().createTab({
@@ -173,11 +169,7 @@ export function createWorkspaceStore(
       const state = get();
       const firstTab = state.tabs[0];
       const shouldReplaceFirstTab =
-        state.showWelcome &&
-        state.tabs.length === 1 &&
-        firstTab &&
-        !firstTab.filePath &&
-        !firstTab.isDirty;
+        state.tabs.length === 1 && firstTab && !firstTab.filePath && !firstTab.isDirty;
 
       if (shouldReplaceFirstTab) {
         const nextTabId = get().replaceWelcomeTab({

--- a/e2e/tests/integration/share-links.spec.ts
+++ b/e2e/tests/integration/share-links.spec.ts
@@ -50,6 +50,31 @@ test.describe('Share links', () => {
     );
   });
 
+  test('loads shared design on mobile viewport without hanging', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+
+    await page.route(`**/api/share/${SHARE_ID}`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: SHARE_ID,
+          code: SHARE_CODE,
+          title: 'Mobile Test Share',
+          createdAt: '2026-03-24T00:00:00.000Z',
+          forkedFrom: null,
+          thumbnailUrl: null,
+        }),
+      });
+    });
+
+    await page.goto(`/s/${SHARE_ID}`, { waitUntil: 'domcontentloaded' });
+
+    // Loading overlay must clear — previously it hung forever on mobile viewports
+    await expect(page.getByTestId('share-loading-screen')).toHaveCount(0, { timeout: 30_000 });
+    await expect(page.getByTestId('share-banner')).toBeVisible({ timeout: 5_000 });
+  });
+
   test('opens shared links without onboarding and keeps saved layout preference unchanged', async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary

- On mobile viewports (≤767px), `useMobileLayout` calls `hideWelcomeScreen()` during initial mount, setting `showWelcome = false` before the share loading flow reaches the `applying` phase
- Both `replaceWelcomeTab` and `openSharedDocument` had `state.showWelcome &&` in their `shouldReplaceFirstTab` guard — with `showWelcome` already `false`, they fell through to `createTab()` instead of replacing the initial tab in-place
- The render result was stored under the old tab ID; the new active tab had `previewSrc = ''`, so `ThreeViewer` never mounted, `onVisualReady` never fired, and the loading overlay was stuck forever

**Fix:** remove `state.showWelcome &&` from `shouldReplaceFirstTab` in both locations. The remaining conditions (`tabs.length === 1 && !filePath && !isDirty`) are sufficient to identify a clean initial tab regardless of welcome-screen state.

## Test plan

- [x] Unit regression test added in `workspaceStore.test.ts`: calls `hideWelcomeScreen()` before `openSharedDocument` and asserts the returned tab ID equals the initial tab ID (same tab replaced, not a new one created)
- [x] E2E test added in `share-links.spec.ts`: opens a share link at 390×844 viewport and asserts the loading overlay clears and share banner becomes visible
- [x] All 30 share/workspace unit tests pass
- [x] `pnpm format` passes with no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)