### PR TITLE
fix: compact share banner on mobile

### DIFF
--- a/apps/ui/src/components/ShareBanner.tsx
+++ b/apps/ui/src/components/ShareBanner.tsx
@@ -42,28 +42,27 @@ export function ShareBanner({ origin, onShareRemix, onDismiss }: ShareBannerProp
   return (
     <div
       data-testid="share-banner"
-      className="flex items-center justify-between text-sm"
+      className="flex items-center justify-between text-sm py-1.5 px-3 sm:py-[var(--space-3)] sm:px-[var(--space-4)]"
       style={{
         background:
           'linear-gradient(90deg, color-mix(in srgb, var(--accent-primary) 18%, var(--bg-secondary)), var(--bg-secondary))',
         borderBottom: '1px solid var(--border-primary)',
         color: 'var(--text-primary)',
         gap: 'var(--space-3)',
-        padding: `var(--space-3) var(--space-4)`,
       }}
     >
       <div className="min-w-0">
         <div className="font-medium">Shared design: &quot;{origin.title}&quot;</div>
         {origin.forkedFrom ? (
           <div
-            className="flex items-center text-xs"
+            className="hidden sm:flex items-center text-xs"
             style={{ gap: 'var(--space-1)', color: 'var(--text-secondary)' }}
           >
             <TbGitBranch size={12} />
             <span>Remixed from {parentTitle ? `"${parentTitle}"` : 'another shared design'}</span>
           </div>
         ) : (
-          <div className="text-xs" style={{ color: 'var(--text-secondary)' }}>
+          <div className="hidden sm:block text-xs" style={{ color: 'var(--text-secondary)' }}>
             You can edit this copy and share your remix.
           </div>
         )}
@@ -71,6 +70,7 @@ export function ShareBanner({ origin, onShareRemix, onDismiss }: ShareBannerProp
 
       <div className="flex items-center" style={{ gap: 'var(--space-control-gap)' }}>
         <Button
+          className="hidden sm:inline-flex"
           type="button"
           variant="secondary"
           size="sm"


### PR DESCRIPTION
## Summary
- Hides the subtitle text ("You can edit this copy..." / "Remixed from...") on mobile
- Hides the "Share Your Remix" button on mobile
- Reduces vertical/horizontal padding on mobile so the single-line banner sits tighter

All changes are mobile-only (`sm:` breakpoint restores desktop behavior).

<img width="490" height="113" alt="Screenshot 2026-03-27 at 9 45 06 AM" src="https://github.com/user-attachments/assets/c6500430-a1c3-43e9-937d-2f418b50627a" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)