### PR TITLE
fix: prevent SVG viewer pan crash on mobile Safari

### DIFF
--- a/apps/ui/src/components/SvgViewer.tsx
+++ b/apps/ui/src/components/SvgViewer.tsx
@@ -751,11 +751,16 @@ export function SvgViewer({ src, onVisualReady }: SvgViewerProps) {
       dragRef.current.moved = true;
     }
 
+    // Capture before setViewport — Safari can fire pointercancel between the null
+    // guard above and when the React updater callback runs, setting dragRef.current
+    // to null and causing a crash.
+    const { originTranslateX, originTranslateY } = dragRef.current;
+
     setViewport((current) =>
       sanitizeViewport({
         ...current,
-        translateX: dragRef.current!.originTranslateX + deltaX,
-        translateY: dragRef.current!.originTranslateY + deltaY,
+        translateX: originTranslateX + deltaX,
+        translateY: originTranslateY + deltaY,
         fitMode: 'custom',
         interactionSource: 'pan',
       })


### PR DESCRIPTION
# Summary

## What changed
- Capture `originTranslateX`/`originTranslateY` from `dragRef.current` synchronously before calling `setViewport` in `SvgViewer.handlePointerMove`

## Why
- Mobile Safari aggressively fires `pointercancel` events (e.g. when detecting a scroll gesture or palm input). This created a race condition: the null guard on `dragRef.current` would pass, then `setViewport` would schedule a React updater callback, then `pointercancel` would fire and set `dragRef.current = null`, and finally when React executed the updater the `dragRef.current!.originTranslateX` access would crash with `TypeError: null is not an object`.
- Sentry issue: OPENSCAD-STUDIO-8

## Implementation notes
- Destructuring the values into local variables before the `setViewport` call means the callback closes over stable values rather than the mutable ref, eliminating the race entirely.

# Testing

## Coverage checklist
- [x] No new tests were needed for this change

## Validation performed
- [x] `npx tsc -b --noEmit`

## Test details
- Verified the fix eliminates the null-ref access by inspection — `originTranslateX` and `originTranslateY` are captured synchronously before any async work.
- Reproducing on-device requires a physical iOS device with Safari; the fix is straightforward enough to validate by code review.

# Performance

## Performance impact
- [x] No meaningful performance impact is expected

## Justification
- Destructuring two numbers is negligible.

# UI changes

## Screenshots or recordings
- N/A

# Issue link

- Closes OPENSCAD-STUDIO-8