### PR TITLE
fix: explicitly upload and delete source maps in sentryVitePlugin

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -23,6 +23,9 @@ export default defineConfig({
             release: {
               name: sentryRelease,
             },
+            sourcemaps: {
+              filesToDeleteAfterUpload: ['dist/**/*.map'],
+            },
           }),
         ]
       : []),


### PR DESCRIPTION
# Summary

## What changed
- Added `sourcemaps: { filesToDeleteAfterUpload: ['dist/**/*.map'] }` to `sentryVitePlugin` in `apps/web/vite.config.ts`

## Why
- Sentry events were showing "Processing Error" with fully minified stack traces (e.g. `Wa.current.originTranslateX` instead of `dragRef.current.originTranslateX`)
- Without an explicit `sourcemaps` block, the plugin may upload source map artifacts with incorrect URL path metadata, preventing Sentry from matching them to minified JS files served from Cloudflare Pages
- Without `filesToDeleteAfterUpload`, `.map` files were also being deployed to Cloudflare Pages, exposing source code publicly

## Implementation notes
- `filesToDeleteAfterUpload: ['dist/**/*.map']` tells the plugin to upload all map files and remove them from `dist/` before deployment

# Testing

## Coverage checklist
- [x] No new tests were needed for this change

## Validation performed
- [x] `yarn lint`
- [x] `npx tsc -b --noEmit`

## Test details
- Config-only change; validated by inspecting the generated Vite plugin options
- Full verification requires a CI deployment: after merging, trigger a handled error in the browser and confirm the Sentry event shows unminified source lines with no "Processing Error" badge

# Performance

## Performance impact
- [x] No meaningful performance impact is expected

## Justification
- Build-time only change; no runtime code affected

# UI changes

## Screenshots or recordings
- N/A

# Issue link

- Closes #