### PR TITLE
fix: mobile UX improvements

### DIFF
--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -1557,7 +1557,7 @@ function App() {
           borderBottom: '1px solid var(--border-subtle)',
         }}
       >
-        {!capabilities.hasNativeMenu && !isMobile && (
+        {!capabilities.hasNativeMenu && (
           <WebMenuBar
             onExport={() => setShowExportDialog(true)}
             onShare={canUseShare ? handleOpenShareDialog : undefined}
@@ -1566,6 +1566,8 @@ function App() {
             onRedo={handleRedo}
           />
         )}
+
+        {isMobile && <div className="flex-1" />}
 
         {!isMobile && (
           <div className="flex-1 min-w-0 overflow-hidden">
@@ -1587,21 +1589,6 @@ function App() {
                 }}
               />
             )}
-          </div>
-        )}
-
-        {isMobile && (
-          <div className="flex items-center gap-2 px-3 flex-1">
-            <img
-              src="/favicon-32x32.png"
-              alt="OpenSCAD Studio"
-              width={20}
-              height={20}
-              className="rounded"
-            />
-            <span className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
-              OpenSCAD Studio
-            </span>
           </div>
         )}
 

--- a/apps/ui/src/components/SvgViewer.tsx
+++ b/apps/ui/src/components/SvgViewer.tsx
@@ -5,6 +5,7 @@ import { getPreviewSceneStyle } from '../services/previewSceneConfig';
 import { Button, IconButton, Text } from './ui';
 import type { MeasurementListItemData } from './viewer-measurements/types';
 import { updateSetting, useSettings } from '../stores/settingsStore';
+import { useMobileLayout } from '../hooks/useMobileLayout';
 import { buildOverlayModel } from './svg-viewer/overlayModel';
 import { useSvgViewerAnalytics } from './svg-viewer/useSvgViewerAnalytics';
 import {
@@ -369,6 +370,7 @@ function StatusCard({
 export function SvgViewer({ src, onVisualReady }: SvgViewerProps) {
   const { theme } = useTheme();
   const [settings] = useSettings();
+  const { isMobile } = useMobileLayout();
   const [documentState, setDocumentState] = useState<DocumentState>(INITIAL_DOCUMENT_STATE);
   const [loadedDocument, setLoadedDocument] = useState<ParsedSvgDocument | null>(null);
   const [viewport, setViewport] = useState<SvgViewportState>(INITIAL_VIEWPORT);
@@ -392,6 +394,8 @@ export function SvgViewer({ src, onVisualReady }: SvgViewerProps) {
     originTranslateY: number;
     moved: boolean;
   } | null>(null);
+  const activePointersRef = useRef<Map<number, { x: number; y: number }>>(new Map());
+  const lastPinchDistRef = useRef<number | null>(null);
   const sceneStyle = useMemo(() => getPreviewSceneStyle(theme), [theme]);
 
   const themeColors = useMemo(
@@ -718,7 +722,18 @@ export function SvgViewer({ src, onVisualReady }: SvgViewerProps) {
 
   const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
     containerRef.current?.focus();
+    activePointersRef.current.set(event.pointerId, { x: event.clientX, y: event.clientY });
+    event.currentTarget.setPointerCapture(event.pointerId);
+
     if (documentState.status === 'loading' || !loadedDocument) {
+      return;
+    }
+
+    if (activePointersRef.current.size >= 2) {
+      // Second finger down — cancel any pan drag and initialize pinch tracking
+      dragRef.current = null;
+      const pts = [...activePointersRef.current.values()];
+      lastPinchDistRef.current = Math.hypot(pts[1].x - pts[0].x, pts[1].y - pts[0].y);
       return;
     }
 
@@ -735,10 +750,28 @@ export function SvgViewer({ src, onVisualReady }: SvgViewerProps) {
       moved: false,
     };
     suppressClickRef.current = false;
-    event.currentTarget.setPointerCapture(event.pointerId);
   };
 
   const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    activePointersRef.current.set(event.pointerId, { x: event.clientX, y: event.clientY });
+
+    // Pinch-to-zoom: two active pointers
+    if (activePointersRef.current.size >= 2 && lastPinchDistRef.current !== null) {
+      const pts = [...activePointersRef.current.values()];
+      const newDist = Math.hypot(pts[1].x - pts[0].x, pts[1].y - pts[0].y);
+      const scaleFactor = newDist / lastPinchDistRef.current;
+      lastPinchDistRef.current = newDist;
+      const midX = (pts[0].x + pts[1].x) / 2;
+      const midY = (pts[0].y + pts[1].y) / 2;
+      const rect = containerRef.current?.getBoundingClientRect();
+      if (rect) {
+        setViewport((prev) =>
+          zoomAroundClientPoint(prev, clampScale(prev.scale * scaleFactor), midX, midY, rect)
+        );
+      }
+      return;
+    }
+
     updateCursorAndDraftFromEvent(event.clientX, event.clientY, event.shiftKey);
 
     if (!dragRef.current) {
@@ -763,6 +796,11 @@ export function SvgViewer({ src, onVisualReady }: SvgViewerProps) {
   };
 
   const handlePointerUp = (event: React.PointerEvent<HTMLDivElement>) => {
+    activePointersRef.current.delete(event.pointerId);
+    if (activePointersRef.current.size < 2) {
+      lastPinchDistRef.current = null;
+    }
+
     if (dragRef.current?.pointerId === event.pointerId) {
       suppressClickRef.current = dragRef.current.moved;
       dragRef.current = null;
@@ -986,15 +1024,17 @@ export function SvgViewer({ src, onVisualReady }: SvgViewerProps) {
   return (
     <div className="flex flex-col h-full w-full" data-testid="preview-2d-root">
       <div className="flex flex-row flex-1 min-h-0">
-        <Svg2DToolPalette
-          mode={viewMode}
-          onModeChange={(mode) => handleViewModeChange(mode, 'toolbar')}
-          canInteract={canInteract}
-        />
+        {!isMobile && (
+          <Svg2DToolPalette
+            mode={viewMode}
+            onModeChange={(mode) => handleViewModeChange(mode, 'toolbar')}
+            canInteract={canInteract}
+          />
+        )}
         <div
           ref={containerRef}
           className="relative flex-1 min-w-0 outline-none"
-          style={{ backgroundColor: themeColors.background }}
+          style={{ backgroundColor: themeColors.background, touchAction: 'none' }}
           tabIndex={0}
           onKeyDown={handleKeyDown}
           onKeyUp={handleKeyUp}
@@ -1435,21 +1475,23 @@ export function SvgViewer({ src, onVisualReady }: SvgViewerProps) {
           ) : null}
         </div>
       </div>
-      <Svg2DContextBar
-        mode={viewMode}
-        draftMeasurement={draftMeasurement}
-        measureSummary={measureSummary}
-        measurementItems={measurementItems}
-        onMeasurementSelect={selectMeasurement}
-        onMeasurementDelete={(id) => {
-          setMeasurements((existing) => existing.filter((item) => item.id !== id));
-          if (selectedMeasurementId === id) {
-            setSelectedMeasurementId(null);
-          }
-          setLiveMessage('Measurement deleted');
-        }}
-        onMeasurementsClear={clearAllMeasurements}
-      />
+      {!isMobile && (
+        <Svg2DContextBar
+          mode={viewMode}
+          draftMeasurement={draftMeasurement}
+          measureSummary={measureSummary}
+          measurementItems={measurementItems}
+          onMeasurementSelect={selectMeasurement}
+          onMeasurementDelete={(id) => {
+            setMeasurements((existing) => existing.filter((item) => item.id !== id));
+            if (selectedMeasurementId === id) {
+              setSelectedMeasurementId(null);
+            }
+            setLiveMessage('Measurement deleted');
+          }}
+          onMeasurementsClear={clearAllMeasurements}
+        />
+      )}
     </div>
   );
 }

--- a/apps/ui/src/components/ThreeViewer.tsx
+++ b/apps/ui/src/components/ThreeViewer.tsx
@@ -74,6 +74,7 @@ import { TbBox, TbBoxModel, TbFocus2, TbSun, TbX } from 'react-icons/tb';
 import type { ToolContextPanelProps } from './three-viewer/types';
 import { updateSetting, useSettings } from '../stores/settingsStore';
 import { Text } from './ui';
+import { useMobileLayout } from '../hooks/useMobileLayout';
 
 interface ThreeViewerProps {
   stlPath: string;
@@ -959,6 +960,7 @@ function EnvironmentWithFallback({ preset }: { preset: string }) {
 export function ThreeViewer({ stlPath, isLoading, viewerId, onVisualReady }: ThreeViewerProps) {
   const { theme } = useTheme();
   const [settings] = useSettings();
+  const { isMobile } = useMobileLayout();
   const sceneStyle = useMemo(() => getPreviewSceneStyle(theme), [theme]);
   const animateInitialFrameRef = useRef(viewerId ? !introAnimatedViewerIds.has(viewerId) : true);
   const materialManagerRef = useRef(new ViewerMaterialManager());
@@ -1336,11 +1338,13 @@ export function ThreeViewer({ stlPath, isLoading, viewerId, onVisualReady }: Thr
       )}
 
       <div className="flex flex-row flex-1 min-h-0">
-        <ViewerToolPalette
-          mode={interactionMode}
-          onModeChange={(mode) => handleModeChange(mode, 'toolbar')}
-          loadedModel={loadedModel}
-        />
+        {!isMobile && (
+          <ViewerToolPalette
+            mode={interactionMode}
+            onModeChange={(mode) => handleModeChange(mode, 'toolbar')}
+            loadedModel={loadedModel}
+          />
+        )}
         <div className="relative flex-1 min-w-0">
           <div
             className="absolute top-2 right-2 z-10 flex gap-2"
@@ -1642,7 +1646,7 @@ export function ThreeViewer({ stlPath, isLoading, viewerId, onVisualReady }: Thr
         </div>
       </div>
 
-      <ViewerContextBar mode={interactionMode} {...contextPanelProps} />
+      {!isMobile && <ViewerContextBar mode={interactionMode} {...contextPanelProps} />}
     </div>
   );
 }

--- a/apps/ui/src/index.css
+++ b/apps/ui/src/index.css
@@ -82,6 +82,12 @@
   --dv-drag-over-border-color: var(--accent-primary);
 }
 
+@media (max-width: 767px) {
+  .dockview-theme-openscad {
+    --dv-tabs-and-actions-container-height: 44px;
+  }
+}
+
 .dockview-theme-openscad .dv-tabs-and-actions-container {
   border-bottom: 1px solid var(--border-subtle);
 }

--- a/apps/ui/src/stores/layoutStore.ts
+++ b/apps/ui/src/stores/layoutStore.ts
@@ -38,11 +38,33 @@ function addMobilePanels(api: DockviewApi) {
     return;
   }
 
+  const groupId = previewPanel.group.id;
   api.addPanel({
     id: 'customizer',
     component: 'customizer',
     title: 'Customizer',
-    position: { referenceGroup: previewPanel.group.id },
+    position: { referenceGroup: groupId },
+    inactive: true,
+  });
+  api.addPanel({
+    id: 'editor',
+    component: 'editor',
+    title: 'Editor',
+    position: { referenceGroup: groupId },
+    inactive: true,
+  });
+  api.addPanel({
+    id: 'ai-chat',
+    component: 'ai-chat',
+    title: 'AI',
+    position: { referenceGroup: groupId },
+    inactive: true,
+  });
+  api.addPanel({
+    id: 'console',
+    component: 'console',
+    title: 'Console',
+    position: { referenceGroup: groupId },
     inactive: true,
   });
 }

--- a/apps/ui/src/stores/workspaceStore.ts
+++ b/apps/ui/src/stores/workspaceStore.ts
@@ -353,7 +353,13 @@ export function createWorkspaceStore(
   }));
 }
 
-export const workspaceStore = createWorkspaceStore();
+const isMobileAtStartup =
+  typeof window !== 'undefined' && window.matchMedia('(max-width: 767px)').matches;
+
+export const workspaceStore = createWorkspaceStore({
+  ...createInitialWorkspaceState(),
+  showWelcome: isMobileAtStartup ? false : true,
+});
 
 export function useWorkspaceStore<T>(selector: (state: WorkspaceStore) => T): T {
   return useStore(workspaceStore, selector);


### PR DESCRIPTION
# Summary

## What changed
- Pinch-to-zoom in the 2D SVG viewer now zooms the SVG content instead of the whole page on mobile Safari
- Dockview panel tab height increased from 28px to 44px on mobile for easier tap targets
- Left tool palette and bottom context bar are hidden in both the 3D and 2D viewers on mobile
- File/Edit menu bar is now shown on mobile (was previously hidden); tab bar / file name selector remains desktop-only; a flex spacer keeps right-side controls pushed to the right
- All panels (Preview, Customizer, Editor, AI, Console) are available as tabs in a single group on mobile, with Preview and Customizer first
- Welcome screen no longer flashes on mobile — `showWelcome` is initialized to `false` at store creation time when the viewport is mobile-sized

## Why
- Mobile Safari was intercepting pinch gestures and zooming the page instead of the viewer content
- 28px tabs are too small to tap reliably on touch screens
- The tool palette and context bar take up precious screen space and are not useful without a pointer
- Mobile users had no access to the menu bar for file/edit actions
- All panels should be reachable on mobile without being locked out of Editor, AI, or Console
- The welcome screen flash was caused by `hideWelcomeScreen()` running inside a `useEffect`, which fires after the first render

## Implementation notes
- Pinch zoom: added `touch-action: none` to the SVG viewer container, plus `activePointersRef` and `lastPinchDistRef` to track two-pointer distance changes in the existing pointer event handlers
- Tab height: `@media (max-width: 767px)` override of `--dv-tabs-and-actions-container-height` to `44px` in `index.css`
- Viewer panels: `useMobileLayout()` used in `ThreeViewer` and `SvgViewer` to conditionally render `ViewerToolPalette`, `ViewerContextBar`, `Svg2DToolPalette`, and `Svg2DContextBar`
- Mobile header: removed `!isMobile` guard on `WebMenuBar`; added `flex-1` spacer on mobile in place of the tab bar
- Mobile panels: `addMobilePanels` now adds all five panels to the same group in order: Preview, Customizer, Editor, AI, Console
- Welcome flash: store initialized with `showWelcome: isMobileAtStartup ? false : true` using a synchronous `matchMedia` check

# Testing

## Coverage checklist
- [x] No new tests were needed for this change

## Validation performed
- [x] `npx tsc -b --noEmit`

## Test details
- Type-checked clean
- Verified manually in Chrome DevTools mobile emulation (≤767px)
- Pinch zoom tested conceptually — requires real iOS Safari device for full validation

# Performance

## Performance impact
- [x] No meaningful performance impact is expected

## Justification
- The `matchMedia` call at store init is synchronous and runs once at startup; negligible cost

# UI changes

## Screenshots or recordings
- N/A (mobile layout changes — best verified on device or emulator)

# Issue link

- Closes #