### PR TITLE
fix: add crypto.randomUUID fallback (OPENSCAD-STUDIO-E)

### DIFF
--- a/apps/ui/src/analytics/stableId.ts
+++ b/apps/ui/src/analytics/stableId.ts
@@ -1,9 +1,11 @@
+import { createRandomId } from '../utils/randomId';
+
 export const STABLE_ANALYTICS_ID_KEY = 'openscad-studio:analytics-id';
 
 export function getOrCreateStableId(): string {
   const existing = localStorage.getItem(STABLE_ANALYTICS_ID_KEY);
   if (existing) return existing;
-  const id = crypto.randomUUID();
+  const id = createRandomId();
   localStorage.setItem(STABLE_ANALYTICS_ID_KEY, id);
   return id;
 }

--- a/apps/ui/src/hooks/useAiAgent.ts
+++ b/apps/ui/src/hooks/useAiAgent.ts
@@ -50,6 +50,7 @@ import {
   type PreviewSceneStyle,
 } from '../services/previewSceneConfig';
 import { getRelativeProjectPath, normalizeProjectRelativePath } from '../utils/projectFilePaths';
+import { createRandomId } from '../utils/randomId';
 import { updateSetting, loadSettings, type MeasurementUnit } from '../stores/settingsStore';
 
 function extractErrorText(error: unknown): string {
@@ -405,7 +406,7 @@ export function useAiAgent() {
               ...nextConversation.messages,
               {
                 type: 'assistant' as const,
-                id: crypto.randomUUID(),
+                id: createRandomId(),
                 turnId: activeTurn.turnId,
                 content: options.completionNotice,
                 state: 'complete' as const,
@@ -637,7 +638,7 @@ export function useAiAgent() {
 
       const userMessage: UserMessage = {
         type: 'user',
-        id: crypto.randomUUID(),
+        id: createRandomId(),
         parts: draftParts,
         timestamp: Date.now(),
       };
@@ -645,7 +646,7 @@ export function useAiAgent() {
       const updatedMessages = [...currentState.messages, userMessage];
       const submittedDraft = draft;
       const submittedReadyIds = getReadyAttachmentIds(draft, currentState.attachments);
-      const turnId = crypto.randomUUID();
+      const turnId = createRandomId();
       const activeTurn = createActiveTurnState(turnId, userMessage.id);
 
       committedMessagesRef.current = updatedMessages;

--- a/apps/ui/src/platform/__tests__/historyService.test.ts
+++ b/apps/ui/src/platform/__tests__/historyService.test.ts
@@ -1,0 +1,35 @@
+import { historyService } from '../historyService';
+
+describe('historyService', () => {
+  const originalCrypto = Object.getOwnPropertyDescriptor(globalThis, 'crypto');
+
+  beforeEach(() => {
+    historyService.clear();
+  });
+
+  afterEach(() => {
+    historyService.clear();
+    if (originalCrypto) {
+      Object.defineProperty(globalThis, 'crypto', originalCrypto);
+    }
+  });
+
+  it('creates checkpoints when crypto.randomUUID is unavailable', () => {
+    Object.defineProperty(globalThis, 'crypto', {
+      configurable: true,
+      value: {
+        getRandomValues(bytes: Uint8Array) {
+          for (let index = 0; index < bytes.length; index += 1) {
+            bytes[index] = index;
+          }
+          return bytes;
+        },
+      },
+    });
+
+    const checkpointId = historyService.createCheckpoint('cube(10);', [], 'Initial', 'user');
+
+    expect(checkpointId).toBe('00010203-0405-4607-8809-0a0b0c0d0e0f');
+    expect(historyService.getAll()).toHaveLength(1);
+  });
+});

--- a/apps/ui/src/platform/historyService.ts
+++ b/apps/ui/src/platform/historyService.ts
@@ -1,3 +1,5 @@
+import { createRandomId } from '../utils/randomId';
+
 export interface Diagnostic {
   severity: 'error' | 'warning' | 'info';
   line?: number;
@@ -37,7 +39,7 @@ class HistoryService {
     changeType: ChangeType
   ): string {
     const checkpoint: EditorCheckpoint = {
-      id: crypto.randomUUID(),
+      id: createRandomId(),
       timestamp: Date.now(),
       code,
       diagnostics,

--- a/apps/ui/src/utils/aiAttachments.ts
+++ b/apps/ui/src/utils/aiAttachments.ts
@@ -1,4 +1,5 @@
 import type { AiDraft, AttachmentRecord, AttachmentStore } from '../types/aiChat';
+import { createRandomId } from './randomId';
 
 export const MAX_ATTACHMENTS_PER_MESSAGE = 4;
 export const MAX_SOURCE_FILE_BYTES = 8 * 1024 * 1024;
@@ -165,7 +166,7 @@ function buildErrorAttachment(
   errorMessage: string
 ): AttachmentRecord {
   return {
-    id: crypto.randomUUID(),
+    id: createRandomId(),
     filename: file.name,
     sourceMimeType: file.type,
     sizeBytes: file.size,
@@ -201,7 +202,7 @@ async function normalizeImageFile(file: File, dedupeKey: string): Promise<Attach
     const previewBlob = await createPreviewBlob(canvas, hasAlpha);
 
     return {
-      id: crypto.randomUUID(),
+      id: createRandomId(),
       filename: file.name,
       sourceMimeType: file.type,
       normalizedMimeType,

--- a/apps/ui/src/utils/aiTurnState.ts
+++ b/apps/ui/src/utils/aiTurnState.ts
@@ -7,6 +7,7 @@ import type {
   ToolCall,
   ToolCallMessage,
 } from '../types/aiChat';
+import { createRandomId } from './randomId';
 
 type StreamChunk = TextStreamPart<ToolSet>;
 
@@ -69,7 +70,7 @@ function createAssistantMessage(
 
   return {
     type: 'assistant',
-    id: crypto.randomUUID(),
+    id: createRandomId(),
     turnId,
     content: trimmed,
     state,
@@ -80,7 +81,7 @@ function createAssistantMessage(
 function createToolMessage(toolCall: ToolCall, toolName?: string): ToolCallMessage {
   return {
     type: 'tool-call',
-    id: crypto.randomUUID(),
+    id: createRandomId(),
     toolCallId: toolCall.toolCallId,
     toolName: toolName ?? toolCall.name,
     args: toolCall.args,

--- a/apps/ui/src/utils/randomId.ts
+++ b/apps/ui/src/utils/randomId.ts
@@ -1,0 +1,33 @@
+function fillRandomBytes(bytes: Uint8Array): void {
+  const cryptoApi = globalThis.crypto;
+  if (cryptoApi?.getRandomValues) {
+    cryptoApi.getRandomValues(bytes);
+    return;
+  }
+
+  for (let index = 0; index < bytes.length; index += 1) {
+    bytes[index] = Math.floor(Math.random() * 256);
+  }
+}
+
+export function createRandomId(): string {
+  const cryptoApi = globalThis.crypto;
+  if (cryptoApi?.randomUUID) {
+    return cryptoApi.randomUUID();
+  }
+
+  const bytes = new Uint8Array(16);
+  fillRandomBytes(bytes);
+
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0'));
+  return [
+    hex.slice(0, 4).join(''),
+    hex.slice(4, 6).join(''),
+    hex.slice(6, 8).join(''),
+    hex.slice(8, 10).join(''),
+    hex.slice(10, 16).join(''),
+  ].join('-');
+}


### PR DESCRIPTION
# Summary

## What changed
- added a shared runtime ID helper with a fallback for environments that expose `crypto` without `crypto.randomUUID()`
- routed runtime ID creation through that helper in analytics, history checkpoints, AI turn state, and attachment/message IDs
- added a regression test covering checkpoint creation when `crypto.randomUUID()` is unavailable

## Why
Sentry issue `OPENSCAD-STUDIO-E` showed the app throwing `TypeError: crypto.randomUUID is not a function` in production. We were calling `crypto.randomUUID()` directly in several frontend runtime paths, which is safe in modern browsers but not in partial Web Crypto environments.

## Implementation notes
- the fallback uses `crypto.getRandomValues()` when available and only falls back further to `Math.random()` if needed
- the generated IDs remain UUID-v4-shaped so existing callers do not need to change behavior
- this keeps the fix centralized instead of scattering one-off guards around each callsite

# Testing

## Coverage checklist
- [x] Client unit/component tests added or updated for changed frontend behavior
- [ ] Backend unit tests added or updated for changed Rust behavior
- [ ] E2E tests added or updated for net new user-facing flows
- [ ] No new tests were needed for this change

## Validation performed
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --dir apps/ui test -- src/platform/__tests__/historyService.test.ts`
- [ ] Full local Playwright run

## Test details
- added coverage for the unsupported-runtime case by removing `crypto.randomUUID()` and verifying checkpoint creation still succeeds
- broader validation continues in GitHub Actions for this branch

# Performance

## Performance impact
- [x] Performance was considered for this change
- [x] No meaningful performance impact is expected

## Justification
ID generation was already happening in these paths; this only adds a small fallback branch when `randomUUID()` is unavailable.

# UI changes

## Screenshots or recordings
- N/A

# Issue link

- Sentry: `OPENSCAD-STUDIO-E`
