### PR TITLE
[codex] fix export validation errors (OPENSCAD-STUDIO-D)

### DIFF
--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -32,6 +32,7 @@ import { useAiAgent } from './hooks/useAiAgent';
 import { useHistory } from './hooks/useHistory';
 import { useMobileLayout } from './hooks/useMobileLayout';
 import { getPlatform, eventBus, type ExportFormat } from './platform';
+import { isExportValidationError } from './services/exportErrors';
 import { RenderService } from './services/renderService';
 import { getPreviewSceneStyle } from './services/previewSceneConfig';
 import { isShareEnabled } from './services/shareService';
@@ -1127,6 +1128,7 @@ function App() {
           notifyError({
             operation: 'export-file',
             error: err,
+            capture: !isExportValidationError(err),
             fallbackMessage: 'Export failed',
             toastId: 'export-error',
             logLabel: 'Export failed',

--- a/apps/ui/src/components/ExportDialog.tsx
+++ b/apps/ui/src/components/ExportDialog.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useAnalytics } from '../analytics/runtime';
 import { getPlatform, type ExportFormat } from '../platform';
+import { isExportValidationError } from '../services/exportErrors';
 import { RenderService, type ExportFormat as WasmExportFormat } from '../services/renderService';
 import {
   Button,
@@ -86,6 +87,7 @@ export function ExportDialog({ isOpen, onClose, source, previewKind }: ExportDia
       notifyError({
         operation: 'export-file',
         error: err,
+        capture: !isExportValidationError(err),
         fallbackMessage: 'Export failed',
         toastId: 'export-error',
         logLabel: '[ExportDialog] Export failed',

--- a/apps/ui/src/components/MenuBar.tsx
+++ b/apps/ui/src/components/MenuBar.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react';
 import { toast } from 'sonner';
 import { getPlatform, type ExportFormat } from '../platform';
 import { RenderService } from '../services/renderService';
+import { normalizeAppError } from '../utils/notifications';
 
 interface MenuBarProps {
   source: string;
@@ -95,7 +96,7 @@ export function MenuBar({
       toast.success('Exported successfully');
     } catch (err) {
       console.error('Export failed:', err);
-      toast.error(`Export failed: ${err}`);
+      toast.error(normalizeAppError(err, 'Export failed').message);
     }
   };
 

--- a/apps/ui/src/components/panels/PanelComponents.tsx
+++ b/apps/ui/src/components/panels/PanelComponents.tsx
@@ -12,6 +12,7 @@ import { PanelErrorBoundary } from '../ErrorBoundary';
 import { useWorkspace } from '../../contexts/WorkspaceContext';
 import { useWorkspaceStore } from '../../stores/workspaceStore';
 import { selectActiveTab } from '../../stores/workspaceSelectors';
+import { isExportValidationError } from '../../services/exportErrors';
 import { RenderService } from '../../services/renderService';
 import { getPlatform } from '../../platform';
 import { notifyError } from '../../utils/notifications';
@@ -142,6 +143,7 @@ const CustomizerPanelWrapper: React.FC<IDockviewPanelProps> = () => {
       notifyError({
         operation: 'export-file',
         error: err,
+        capture: !isExportValidationError(err),
         fallbackMessage: 'STL export failed',
         toastId: 'export-error',
         logLabel: 'STL export failed',
@@ -165,6 +167,7 @@ const CustomizerPanelWrapper: React.FC<IDockviewPanelProps> = () => {
       notifyError({
         operation: 'export-file',
         error: err,
+        capture: !isExportValidationError(err),
         fallbackMessage: 'SVG export failed',
         toastId: 'export-error',
         logLabel: 'SVG export failed',

--- a/apps/ui/src/services/__tests__/exportErrors.test.ts
+++ b/apps/ui/src/services/__tests__/exportErrors.test.ts
@@ -1,0 +1,19 @@
+import {
+  createExportValidationError,
+  isExportValidationError,
+  isImplicitOpenScadError,
+} from '../exportErrors';
+
+describe('exportErrors', () => {
+  it('treats dimension mismatch stderr as an implicit OpenSCAD error', () => {
+    expect(isImplicitOpenScadError('Current top level object is not a 2D object.')).toBe(true);
+    expect(isImplicitOpenScadError('Current top level object is not a 3D object.')).toBe(true);
+  });
+
+  it('creates a typed export validation error with the OpenSCAD message', () => {
+    const error = createExportValidationError(['Current top level object is not a 2D object.']);
+
+    expect(isExportValidationError(error)).toBe(true);
+    expect(error.message).toBe('Export failed:\nCurrent top level object is not a 2D object.');
+  });
+});

--- a/apps/ui/src/services/exportErrors.ts
+++ b/apps/ui/src/services/exportErrors.ts
@@ -1,0 +1,28 @@
+const IMPLICIT_OPENSCAD_ERROR_PATTERNS = [
+  /^Current top level object is not a [23]D object\.$/i,
+  /^No top level geometry to render\.$/i,
+];
+
+export class ExportValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ExportValidationError';
+  }
+}
+
+export function isImplicitOpenScadError(line: string): boolean {
+  const normalized = line.trim();
+  return IMPLICIT_OPENSCAD_ERROR_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+export function createExportValidationError(messages: string[]): ExportValidationError {
+  const normalizedMessages = Array.from(
+    new Set(messages.map((message) => message.trim()).filter(Boolean))
+  );
+
+  return new ExportValidationError(`Export failed:\n${normalizedMessages.join('\n')}`);
+}
+
+export function isExportValidationError(error: unknown): error is ExportValidationError {
+  return error instanceof ExportValidationError;
+}

--- a/apps/ui/src/services/renderService.ts
+++ b/apps/ui/src/services/renderService.ts
@@ -4,6 +4,7 @@ import type {
   WorkerRenderResult,
   WorkerErrorResult,
 } from './openscad-worker';
+import { createExportValidationError, isImplicitOpenScadError } from './exportErrors';
 import { notifyError } from '../utils/notifications';
 
 // ============================================================================
@@ -50,25 +51,29 @@ export function parseOpenScadStderr(stderr: string): Diagnostic[] {
     if (!line) continue;
 
     const match = ERROR_REGEX.exec(line);
-    if (!match) continue;
-
-    const severityStr = match[1].toLowerCase();
+    const severityStr = match?.[1].toLowerCase();
     let severity: Diagnostic['severity'];
-    switch (severityStr) {
-      case 'error':
-        severity = 'error';
-        break;
-      case 'warning':
-        severity = 'warning';
-        break;
-      case 'echo':
-        severity = 'info';
-        break;
-      default:
-        continue;
+    if (severityStr) {
+      switch (severityStr) {
+        case 'error':
+          severity = 'error';
+          break;
+        case 'warning':
+          severity = 'warning';
+          break;
+        case 'echo':
+          severity = 'info';
+          break;
+        default:
+          continue;
+      }
+    } else if (isImplicitOpenScadError(line)) {
+      severity = 'error';
+    } else {
+      continue;
     }
 
-    const message = match[2] || '';
+    const message = match?.[2] || line;
     const lineMatch = LINE_NUMBER_REGEX.exec(message);
     const lineNumber = lineMatch ? parseInt(lineMatch[1], 10) : undefined;
 
@@ -393,7 +398,7 @@ export class RenderService {
       const diagnostics = parseOpenScadStderr(result.stderr);
       const errors = diagnostics.filter((d) => d.severity === 'error');
       if (errors.length > 0) {
-        throw new Error(`Export failed:\n${errors.map((e) => e.message).join('\n')}`);
+        throw createExportValidationError(errors.map((e) => e.message));
       }
       throw new Error('Export produced no output');
     }

--- a/apps/ui/src/utils/__tests__/notifications.test.ts
+++ b/apps/ui/src/utils/__tests__/notifications.test.ts
@@ -1,3 +1,5 @@
+/** @jest-environment jsdom */
+
 import { jest } from '@jest/globals';
 
 jest.mock('sonner', () => ({
@@ -8,7 +10,12 @@ jest.mock('sonner', () => ({
   },
 }));
 
+jest.mock('../../sentry', () => ({
+  captureSentryException: jest.fn(),
+}));
+
 import { toast } from 'sonner';
+import { captureSentryException } from '../../sentry';
 import { normalizeAppError, notifyError, notifyPromise, notifySuccess } from '../notifications';
 
 describe('notifications', () => {
@@ -39,6 +46,21 @@ describe('notifications', () => {
 
     expect(toast.error).toHaveBeenCalledWith('No such file or directory', {
       id: 'open-file-error',
+      description: undefined,
+    });
+  });
+
+  it('can skip Sentry capture for handled UI validation errors', () => {
+    notifyError({
+      operation: 'export-file',
+      error: new Error('Current top level object is not a 2D object.'),
+      capture: false,
+      fallbackMessage: 'Export failed',
+    });
+
+    expect(captureSentryException).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith('Current top level object is not a 2D object.', {
+      id: undefined,
       description: undefined,
     });
   });

--- a/apps/ui/src/utils/notifications.ts
+++ b/apps/ui/src/utils/notifications.ts
@@ -14,6 +14,7 @@ export interface NormalizedAppError {
 export interface UiErrorContext {
   operation: string;
   error?: unknown;
+  capture?: boolean;
   fallbackMessage?: string;
   displayMessage?: string;
   toastId?: string;
@@ -69,6 +70,7 @@ export function normalizeAppError(
 export function notifyError({
   operation,
   error,
+  capture = true,
   fallbackMessage,
   displayMessage,
   toastId,
@@ -83,17 +85,19 @@ export function notifyError({
 
   if (error !== undefined) {
     console.error(logLabel ?? `[${operation}]`, error);
-    captureSentryException(error, {
-      tags: {
-        operation,
-        error_domain: errorDomain ?? inferErrorDomain(operation),
-      },
-      extra: {
-        source_component: sourceComponent ?? logLabel ?? operation,
-        handled: handled ?? true,
-        ...analyticsProperties,
-      },
-    });
+    if (capture) {
+      captureSentryException(error, {
+        tags: {
+          operation,
+          error_domain: errorDomain ?? inferErrorDomain(operation),
+        },
+        extra: {
+          source_component: sourceComponent ?? logLabel ?? operation,
+          handled: handled ?? true,
+          ...analyticsProperties,
+        },
+      });
+    }
   }
 
   toast.error(displayMessage ?? normalized.message, {

--- a/implementation-plans/bug-triager-2026-03-28.md
+++ b/implementation-plans/bug-triager-2026-03-28.md
@@ -1,0 +1,37 @@
+# Bug Triager 2026-03-28
+
+## Goal
+
+Triage new Sentry issues from the last 24 hours, verify whether fixes already exist, and land validated PRs with failing-then-passing regression tests for any issues that still need code changes.
+
+## Issues
+
+- `OPENSCAD-STUDIO-E`: `TypeError: crypto.randomUUID is not a function`
+- `OPENSCAD-STUDIO-D`: `Error: Export produced no output`
+
+## Approach
+
+- Inspect Sentry issue details and repository state to determine whether an existing branch or PR already covers each issue.
+- Reproduce unresolved issues locally and add the smallest regression tests that fail before the fix.
+- Implement fixes on issue-specific branches, rerun the targeted tests, and open PRs.
+- After PR creation, wait 15 minutes and verify CI with `gh`, fixing any follow-up failures if needed.
+
+## Affected Areas
+
+- `apps/ui/src/services/renderService.ts`
+- `apps/ui/src/services/exportErrors.ts`
+- `apps/ui/src/services/__tests__/exportErrors.test.ts`
+- `apps/ui/src/components/*`
+- `apps/ui/src/utils/*`
+
+## Checklist
+
+- [x] Inspect new Sentry issues from the last 24 hours
+- [x] Check for existing in-flight fixes
+- [x] Reproduce and verify `OPENSCAD-STUDIO-E`
+- [x] Reproduce and verify `OPENSCAD-STUDIO-D`
+- [x] Add failing regression test(s)
+- [x] Implement missing fix(es)
+- [x] Run targeted tests to confirm pass
+- [ ] Open PR(s)
+- [ ] Wait 15 minutes and verify CI


### PR DESCRIPTION
# Summary

## What changed
- added a small export-error helper that recognizes OpenSCAD export failures even when stderr does not prefix them with `ERROR:`
- changed `renderService.exportModel()` to throw a typed validation error with the underlying OpenSCAD message instead of the generic `Export produced no output`
- stopped forwarding those expected export-validation failures to Sentry from the export dialog, panel shortcuts, and menu export path
- added regression coverage for the new export error classification and the opt-out Sentry capture path
- documented the automation triage work in an implementation plan

## Why
Sentry issue `OPENSCAD-STUDIO-D` showed `Error: Export produced no output` coming from the export dialog. The real failure was an OpenSCAD validation message like `Current top level object is not a 2D object.` or `...not a 3D object.`, but `parseOpenScadStderr()` only treated lines beginning with `ERROR:`, `WARNING:`, or `ECHO:` as diagnostics. That caused the export path to throw a misleading generic error and report a handled user-facing validation failure to Sentry.

## User impact
Users now see the actual OpenSCAD export problem in the UI, and expected validation failures from exporting the wrong dimensional output no longer create Sentry issues.

## Validation
- added a regression test and ran it against a detached HEAD worktree to confirm it failed before the implementation existed
- `pnpm -C apps/ui test --runInBand src/services/__tests__/exportErrors.test.ts`
- `pnpm -C apps/ui test --runInBand src/utils/__tests__/notifications.test.ts`
- `pnpm -C apps/ui test --runInBand src/services/__tests__/exportErrors.test.ts src/utils/__tests__/notifications.test.ts`
- `pnpm -C apps/ui type-check`

## Issue link
- Sentry: `OPENSCAD-STUDIO-D`
