### PR TITLE
fix: revert CSP headers that were causing runtime issues

### DIFF
--- a/apps/ui/src-tauri/tauri.conf.json
+++ b/apps/ui/src-tauri/tauri.conf.json
@@ -19,7 +19,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self' tauri: asset:; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' tauri: asset:; worker-src 'self' blob:; connect-src 'self' tauri: asset: https://api.anthropic.com https://api.openai.com https://*.sentry.io; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: tauri: asset:; font-src 'self' data: tauri: asset:; frame-ancestors 'none';",
+      "csp": null,
       "assetProtocol": {
         "enable": true,
         "scope": ["**"]

--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -1,4 +1,3 @@
 /*
   Cross-Origin-Embedder-Policy: require-corp
   Cross-Origin-Opener-Policy: same-origin
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; worker-src 'self' blob:; connect-src 'self' https://api.anthropic.com https://api.openai.com https://openscad-studio.pages.dev https://us.i.posthog.com https://eu.i.posthog.com https://*.sentry.io; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; frame-ancestors 'none';


### PR DESCRIPTION
# Summary

## What changed
- Reverted `Content-Security-Policy` header from `apps/web/public/_headers`
- Reverted Tauri `csp` config in `tauri.conf.json` back to `null`

## Why
- The CSP headers introduced in #71 are causing runtime issues

## Implementation notes
- API key obfuscation changes from #71 are retained — only the CSP additions are reverted

# Testing

## Coverage checklist
- [x] No new tests were needed for this change

## Validation performed
- N/A — config-only revert

## Test details
- Reverts two config files to their pre-#71 state

# Performance

## Performance impact
- [x] No meaningful performance impact is expected

## Justification
- Config-only change

# UI changes

## Screenshots or recordings
- N/A

# Issue link

- Reverts CSP portion of #71