### PR TITLE
[codex] Refresh stale repository documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,7 +267,7 @@ pnpm format             # Format all code
 ✅ Multi-turn AI chat with draft and attachment state
 ✅ Customizer panel with interactive parameter controls
 ✅ Tree-sitter based parameter parsing
-✅ 27 editor themes with categorized dropdown
+✅ 22 editor themes with categorized dropdown
 ✅ Vim mode with configurable keybindings
 ✅ Web version (openscad-studio.pages.dev)
 ✅ Platform abstraction (PlatformBridge interface)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,7 +194,8 @@ When reporting bugs, please include:
 4. **Actual behavior**: What actually happened
 5. **Environment**:
    - OS: (macOS 14.0, Windows 11, Ubuntu 22.04, etc.)
-   - OpenSCAD version: (run `openscad --version`)
+   - App surface: web app or desktop app
+   - Browser (for web) or desktop app version (from About dialog)
    - App version: (from About dialog)
 6. **Screenshots/logs**: If applicable
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -110,7 +110,7 @@ openscad-studio/
 │   │   │   │   └── webBridge.ts # Web implementation
 │   │   │   ├── services/        # OpenSCAD WASM worker, render service, AI service
 │   │   │   ├── stores/          # Zustand state management
-│   │   │   └── themes/          # 22+ editor themes
+│   │   │   └── themes/          # 22 editor themes
 │   │   └── src-tauri/           # Rust backend (desktop only)
 │   └── web/                     # Web app entry point (Vite)
 └── packages/

--- a/PRE_RELEASE_CHECKLIST.md
+++ b/PRE_RELEASE_CHECKLIST.md
@@ -1,6 +1,6 @@
 # Pre-Release Checklist for OpenSCAD Studio
 
-This checklist covers everything needed before open sourcing the project.
+This checklist captures the initial open-source launch work. It is primarily historical context now, not the source of truth for the current app architecture or release workflow. For current behavior, use `README.md`, `DEVELOPMENT.md`, `AGENTS.md`, and `CLAUDE.md`.
 
 ## ✅ Completed
 
@@ -25,8 +25,8 @@ This checklist covers everything needed before open sourcing the project.
 
 - [x] All React components use modern patterns (hooks, functional components)
 - [x] Rust code follows rustfmt conventions
-- [x] No obvious security issues (API keys stored securely per platform)
-- [x] Platform bridge abstracts API key storage (encrypted store on desktop, localStorage on web)
+- [x] No obvious secret leakage issues in the checked-in source
+- [x] Platform bridge abstracts app behavior while API keys remain client-side per current architecture
 - [x] Git history is clean (no sensitive data in commits)
 
 ## ⚠️ Recommended Before Release
@@ -42,7 +42,7 @@ This checklist covers everything needed before open sourcing the project.
   - [x] `.env` and `.env.local` ignored
   - [ ] Check no `.env` files in git history
 - [x] **API key storage**: Verified on both platforms
-  - [x] macOS desktop (Tauri encrypted store)
+  - [x] macOS desktop (Tauri webview localStorage, obfuscated)
   - [x] Web (localStorage with security warning)
 
 ### GitHub Repository Setup
@@ -78,7 +78,7 @@ This checklist covers everything needed before open sourcing the project.
 - [x] Manual smoke test checklist (macOS):
   - [x] App launches successfully
   - [x] Monaco editor works (syntax highlighting, editing)
-  - [x] OpenSCAD auto-detection works
+  - [x] Local rendering works through openscad-wasm
   - [x] Live preview renders (PNG mode)
   - [x] 3D mesh viewer loads STL files
   - [x] 2D SVG mode works
@@ -102,7 +102,7 @@ This checklist covers everything needed before open sourcing the project.
 - [ ] Test on macOS (Intel) - needs verification
 - [ ] Test on Windows 10/11 - not yet tested
 - [ ] Test on Linux (Ubuntu/Fedora) - not yet tested
-- [ ] Verify OpenSCAD detection on all platforms
+- [ ] Verify desktop-specific filesystem and library workflows on each supported platform
 
 ### Known Issues Documentation
 
@@ -236,7 +236,7 @@ git log --all --full-history -- "**/.env.local"
 
 ### API Key Handling
 
-- [x] API keys stored in Tauri encrypted store (desktop) or localStorage (web)
+- [x] API keys stored client-side in localStorage-backed state on both web and desktop
 - [x] Web version shows security warning about localStorage storage
 - [x] Example .env.example file exists (no real keys)
 

--- a/PRODUCT_ROADMAP.md
+++ b/PRODUCT_ROADMAP.md
@@ -4,7 +4,9 @@
 >
 > OpenSCAD is the engine, not the product. The product is: you describe what you want, it makes it, you print it.
 
-**Current version**: v0.7.1 | **Last updated**: 2026-03-06
+**Current version**: v0.13.1 | **Last updated**: 2026-03-29
+
+This roadmap mixes shipped milestones with future planning. Older sections may describe the implementation assumptions that existed when they were written rather than the current client-side `openscad-wasm` architecture.
 
 ---
 
@@ -18,16 +20,19 @@
 
 ---
 
-## What We Have (v0.7.1)
+## What We Have (v0.13.1)
 
 | Area                                                                                  | Status |
 | ------------------------------------------------------------------------------------- | ------ |
-| Monaco editor with OpenSCAD syntax, 22+ themes, vim mode, tree-sitter formatting      | ✅     |
-| Live 3D preview (Three.js mesh viewer, orbit controls, wireframe/solid)               | ✅     |
+| Monaco editor with OpenSCAD syntax, 22 themes, vim mode, tree-sitter formatting       | ✅     |
+| Live 3D preview (Three.js mesh viewer, orbit controls, wireframe/solid/section tools) | ✅     |
 | 2D SVG mode for laser cutting / engraving                                             | ✅     |
 | AI copilot (Claude + GPT, streaming, tool-calling, diff-based editing, auto-rollback) | ✅     |
 | AI can see the 3D preview (screenshot tool returns base64 PNG to vision models)       | ✅     |
 | Customizer panel (tree-sitter parsed parameters → sliders, dropdowns, vectors)        | ✅     |
+| Share links with remixable web entry and thumbnail support                            | ✅     |
+| Product analytics controls and privacy-scrubbed Sentry monitoring                     | ✅     |
+| 2D/3D measurement tools and 3D section plane controls                                 | ✅     |
 | Export (STL, OBJ, AMF, 3MF, PNG, SVG, DXF)                                            | ✅     |
 | Web app via openscad-wasm (zero install, Cloudflare Pages)                            | ✅     |
 | Desktop app (macOS, Homebrew)                                                         | ✅     |
@@ -139,7 +144,7 @@ For shared designs and landing pages, the customizer should be primary — not t
 
 ### 3.1 Windows Support
 
-- [ ] Test OpenSCAD detection on Windows (`where openscad`, common install paths)
+- [ ] Test desktop filesystem, library path, and export workflows on Windows
 - [ ] Fix path handling (backslashes, drive letters)
 - [ ] Verify keyboard shortcuts (Ctrl vs ⌘)
 - [ ] MSI installer via Tauri bundler
@@ -148,7 +153,7 @@ For shared designs and landing pages, the customizer should be primary — not t
 
 ### 3.2 Linux Support
 
-- [ ] Test OpenSCAD detection on Linux (`which openscad`, package manager paths)
+- [ ] Test desktop filesystem, library path, and export workflows on Linux
 - [ ] AppImage build
 - [ ] .deb package for Ubuntu/Debian
 - [ ] Test on Ubuntu 22.04 and Fedora 39+

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ As a software engineer and maker hobbyist, I love OpenSCAD. It allows for precis
 - 🔍 **Real-time diagnostics** - Inline error markers with line/column precision
 - ⚙️ **Customizer panel** - Interactive controls for OpenSCAD parameters with auto-rendering
 - 🔗 **Share links** - Publish browser-based share links with thumbnail support for remixable examples
-- 🌈 **Theme library** - 27 built-in themes including Solarized, Dracula, GitHub, Nord, Tokyo Night, Catppuccin, and more
+- 🌈 **Theme library** - 22 built-in themes including Solarized, Dracula, GitHub, Nord, Tokyo Night, Catppuccin, and more
 
 **Limitations:** Special operators (!, #, %, \*) preview not yet implemented
 
@@ -48,7 +48,7 @@ As a software engineer and maker hobbyist, I love OpenSCAD. It allows for precis
 
 ### Web (No Install)
 
-Visit **[openscad-studio.pages.dev](https://openscad-studio.pages.dev)**. Works in Chrome and Edge (requires SharedArrayBuffer support). No OpenSCAD installation needed — rendering is done via WebAssembly in your browser.
+Visit **[openscad-studio.pages.dev](https://openscad-studio.pages.dev)**. Works in recent Chrome, Edge, and Firefox builds with SharedArrayBuffer support. No OpenSCAD installation needed — rendering is done via WebAssembly in your browser.
 
 ### Desktop (macOS)
 


### PR DESCRIPTION
## Summary
- refresh stale repository documentation to match the current app state
- keep README user-facing while correcting theme count and browser support wording
- update maintainer docs to remove obsolete OpenSCAD CLI and encrypted-storage assumptions

## Validation
- git diff --cached --check
