### PR TITLE
Add reusable annotation badge for share button

### DIFF
--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -17,6 +17,7 @@ import { TabBar } from './components/TabBar';
 import { WebMenuBar } from './components/WebMenuBar';
 import { EditableFileName } from './components/EditableFileName';
 import {
+  AnnotationBadge,
   Button,
   IconButton,
   Tooltip,
@@ -1672,6 +1673,7 @@ function App() {
               <span className="inline-flex items-center gap-1.5">
                 <TbShare3 size={14} />
                 <span>Share</span>
+                <AnnotationBadge>New</AnnotationBadge>
               </span>
             </Button>
           )}

--- a/apps/ui/src/components/__tests__/AnnotationBadge.test.tsx
+++ b/apps/ui/src/components/__tests__/AnnotationBadge.test.tsx
@@ -1,0 +1,31 @@
+/** @jest-environment jsdom */
+
+import { screen } from '@testing-library/react';
+import { AnnotationBadge } from '../ui';
+import { renderWithProviders } from './test-utils';
+
+describe('AnnotationBadge', () => {
+  it('renders compact badge copy with the accent treatment by default', () => {
+    renderWithProviders(<AnnotationBadge>New</AnnotationBadge>);
+
+    const badge = screen.getByText('New');
+
+    expect(badge.tagName).toBe('SPAN');
+    expect(badge.getAttribute('data-tone')).toBe('accent');
+    expect(badge.className).toContain('uppercase');
+    expect(badge.className).toContain('border');
+  });
+
+  it('supports neutral badges for future reuse', () => {
+    renderWithProviders(
+      <AnnotationBadge tone="neutral" className="tracking-tight">
+        Beta
+      </AnnotationBadge>
+    );
+
+    const badge = screen.getByText('Beta');
+
+    expect(badge.getAttribute('data-tone')).toBe('neutral');
+    expect(badge.className).toContain('tracking-tight');
+  });
+});

--- a/apps/ui/src/components/ui/AnnotationBadge.tsx
+++ b/apps/ui/src/components/ui/AnnotationBadge.tsx
@@ -1,0 +1,42 @@
+import type { CSSProperties, HTMLAttributes } from 'react';
+
+export interface AnnotationBadgeProps extends HTMLAttributes<HTMLSpanElement> {
+  tone?: 'accent' | 'neutral';
+}
+
+const TONE_STYLES: Record<NonNullable<AnnotationBadgeProps['tone']>, CSSProperties> = {
+  accent: {
+    backgroundColor: 'color-mix(in srgb, var(--accent-primary) 18%, var(--bg-secondary))',
+    borderColor: 'color-mix(in srgb, var(--accent-primary) 44%, var(--border-primary))',
+    color: 'var(--accent-primary)',
+  },
+  neutral: {
+    backgroundColor: 'var(--bg-tertiary)',
+    borderColor: 'var(--border-primary)',
+    color: 'var(--text-secondary)',
+  },
+};
+
+export function AnnotationBadge({
+  tone = 'accent',
+  className = '',
+  style,
+  children,
+  ...props
+}: AnnotationBadgeProps) {
+  return (
+    <span
+      data-tone={tone}
+      className={[
+        'inline-flex items-center rounded-md border px-1.5 py-0.5 text-[10px] font-semibold uppercase leading-none tracking-[0.18em]',
+        className,
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      style={{ ...TONE_STYLES[tone], ...style }}
+      {...props}
+    >
+      {children}
+    </span>
+  );
+}

--- a/apps/ui/src/components/ui/index.ts
+++ b/apps/ui/src/components/ui/index.ts
@@ -1,6 +1,9 @@
 export { Button } from './Button';
 export type { ButtonProps } from './Button';
 
+export { AnnotationBadge } from './AnnotationBadge';
+export type { AnnotationBadgeProps } from './AnnotationBadge';
+
 export { Text } from './Text';
 export type { TextProps } from './Text';
 

--- a/implementation-plans/new-badge-share-button.md
+++ b/implementation-plans/new-badge-share-button.md
@@ -1,0 +1,29 @@
+# New Badge Share Button
+
+## Goal
+
+Add a reusable UI component for "new" badge annotations and use it on the header share button so the treatment can be reused elsewhere.
+
+## Approach
+
+- [x] Capture the implementation plan before code changes.
+- [x] Review the current header button and UI primitive patterns.
+- [x] Add a reusable badge component that fits the existing theme variables and compact control styling.
+- [x] Attach the badge to the header share button without changing its click target or disabled behavior.
+- [x] Add focused frontend tests for the new badge rendering.
+- [x] Run formatting and validation for the changed frontend files.
+
+## Affected Areas
+
+- `apps/ui/src/App.tsx`
+- `apps/ui/src/components/ui/AnnotationBadge.tsx`
+- `apps/ui/src/components/ui/index.ts`
+- `apps/ui/src/components/__tests__/AnnotationBadge.test.tsx`
+
+## Checklist
+
+- [x] Read the required repo guidance and inspect the target UI
+- [x] Implement the reusable badge component
+- [x] Wire the badge into the header share button
+- [x] Add or update focused tests
+- [x] Run validation and capture results


### PR DESCRIPTION
# Summary

## What changed

- added a reusable `AnnotationBadge` UI component for compact inline annotations
- attached a `New` badge to the header share button
- added a focused component test and recorded the work in `implementation-plans/new-badge-share-button.md`

## Why

- the share button needs a visible "new" annotation now, and the treatment should be reusable elsewhere without duplicating button-specific markup or styling

## Implementation notes

- `AnnotationBadge` supports `accent` and `neutral` tones and accepts regular span props for reuse
- the share button keeps its existing click target and disabled behavior; only the inline label content changed
- implementation plan: `implementation-plans/new-badge-share-button.md`

# Testing

## Coverage checklist

- [ ] Backend unit tests added or updated for changed Rust behavior
- [x] Client unit/component tests added or updated for changed frontend behavior
- [ ] E2E tests added or updated for net new user-facing flows
- [ ] No new tests were needed for this change

## Validation performed

- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm test:unit`
- [ ] `pnpm test:formatter:ci`
- [ ] `pnpm test:e2e:web`
- [x] `bash scripts/validate-changes.sh --dry-run ...`
- [ ] `cd apps/ui/src-tauri && cargo fmt --check`
- [ ] `cd apps/ui/src-tauri && cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cd apps/ui/src-tauri && cargo check --all-targets --all-features`

## Test details

- Ran `bash scripts/validate-changes.sh --dry-run --changed-file ...` to confirm the inferred scope was `baseline`.
- Ran `bash scripts/validate-changes.sh --scope baseline`, which completed successfully.
- Skipped formatter regression tests because no formatter logic changed.
- Skipped Playwright because this is a presentational tweak to an existing flow, not a new or materially changed user journey.
- Skipped Rust checks because the change is confined to frontend TypeScript files.

# Performance

## Performance impact

- [x] Performance was considered for this change
- [x] No meaningful performance impact is expected

## Justification

- The change adds one small inline span to the existing share button and a tiny reusable component export; there is no meaningful runtime or bundle impact beyond negligible static markup.

# UI changes

## Screenshots or recordings

- N/A

# Issue link

- Closes #
