### PR TITLE
Tighten compact customizer number inputs

### DIFF
--- a/apps/ui/src/components/__tests__/ParameterControl.test.tsx
+++ b/apps/ui/src/components/__tests__/ParameterControl.test.tsx
@@ -27,9 +27,15 @@ describe('ParameterControl', () => {
     renderWithProviders(<ParameterControl param={makeParam()} onChange={() => {}} />);
 
     const control = screen.getByTestId('customizer-control-pot_height');
+    const input = control.querySelector('[data-slot="inline-meta"] input');
+    const inputShell = input?.closest('.w-24');
 
     expect(control.getAttribute('data-layout')).toBe('inline');
-    expect(control.querySelector('[data-slot="inline-meta"] input')).toBeTruthy();
+    expect(input).toBeTruthy();
+    expect(input?.className).toContain('px-2.5');
+    expect(input?.className).toContain('py-1.5');
+    expect(input?.className).toContain('text-right');
+    expect(inputShell).toBeTruthy();
     expect(control.querySelector('[data-slot="control-body"] input')).toBeNull();
     expect(screen.getByText('mm')).toBeTruthy();
   });

--- a/apps/ui/src/components/customizer/ParameterControl.tsx
+++ b/apps/ui/src/components/customizer/ParameterControl.tsx
@@ -221,11 +221,15 @@ function ValueWithUnit({
   value,
   unit,
   className,
+  density = 'default',
 }: {
   value: React.ReactNode;
   unit?: string;
   className?: string;
+  density?: 'default' | 'compact';
 }) {
+  const isCompact = density === 'compact';
+
   return (
     <div
       className={`flex items-center overflow-hidden rounded-lg border${className ? ` ${className}` : ''}`}
@@ -237,7 +241,7 @@ function ValueWithUnit({
       <div className="flex-1">{value}</div>
       {unit && (
         <span
-          className="px-2 text-xs"
+          className={`${isCompact ? 'px-1.5 py-1' : 'px-2'} text-xs`}
           style={{
             color: 'var(--text-tertiary)',
             borderLeft: '1px solid var(--border-primary)',
@@ -528,7 +532,8 @@ function NumberControl({
   const control = (
     <ValueWithUnit
       unit={displayUnit}
-      className={layout === 'inline' ? 'w-28 shrink-0' : 'w-36'}
+      className={layout === 'inline' ? 'w-24 shrink-0' : 'w-36'}
+      density={layout === 'inline' ? 'compact' : 'default'}
       value={
         <input
           type="number"
@@ -542,7 +547,9 @@ function NumberControl({
               event.currentTarget.blur();
             }
           }}
-          className="customizer-number-input w-full bg-transparent px-3 py-2 text-sm outline-none"
+          className={`customizer-number-input w-full bg-transparent text-sm outline-none ${
+            layout === 'inline' ? 'px-2.5 py-1.5 text-right' : 'px-3 py-2'
+          }`}
           style={{ color: 'var(--text-primary)' }}
         />
       }


### PR DESCRIPTION
# Summary

## What changed

- tightened the compact inline number input used when customizer controls do not have `@studio` metadata so the value field and unit pill take up less horizontal space
- kept the annotated/stacked number control sizing unchanged
- added a component regression test that asserts the compact inline number control uses the reduced padding and width

## Why

- unannotated customizer number inputs were visually larger than the annotated controls, which made the panel feel heavier and wasted horizontal space

## Implementation notes

- added a compact density option to the shared `ValueWithUnit` wrapper so only the inline fallback number control uses the tighter unit pill spacing
- no new `implementation-plans/` file was created because this is a narrow maintenance fix and the repo guidance explicitly excludes small housekeeping changes from that requirement

# Testing

## Coverage checklist

- [ ] Backend unit tests added or updated for changed Rust behavior
- [x] Client unit/component tests added or updated for changed frontend behavior
- [ ] E2E tests added or updated for net new user-facing flows
- [ ] No new tests were needed for this change

## Validation performed

- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm test:unit`
- [ ] `pnpm test:formatter:ci`
- [ ] `pnpm test:e2e:web`
- [x] `bash scripts/validate-changes.sh --dry-run ...`
- [ ] `cd apps/ui/src-tauri && cargo fmt --check`
- [ ] `cd apps/ui/src-tauri && cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cd apps/ui/src-tauri && cargo check --all-targets --all-features`

## Test details

- Ran `bash scripts/validate-changes.sh --dry-run --changed-file apps/ui/src/components/customizer/ParameterControl.tsx --changed-file apps/ui/src/components/__tests__/ParameterControl.test.tsx` to confirm inferred validation scope.
- Ran `bash scripts/validate-changes.sh --scope baseline`, which completed successfully.
- Skipped formatter regression tests because no formatter code changed.
- Skipped web E2E because this is a small presentation-only tweak covered by an updated component test.
- Skipped Rust checks because no desktop Rust code changed.

# Performance

## Performance impact

- [x] Performance was considered for this change
- [x] No meaningful performance impact is expected

## Justification

- The change only adjusts Tailwind classes and a tiny render-time branch for control density; it does not affect rendering frequency, data flow, or bundle shape in a meaningful way.

# UI changes

## Screenshots or recordings

- N/A

# Issue link

- Closes #
