### PR TITLE
chore: prepare release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2026-04-02
+
+### Added
+- Multi-file project workflows with a file tree and workspace switching for larger OpenSCAD projects.
+- Shareable design links with web loading, thumbnails, and better staging and review support.
+- Viewer annotations and color-aware 3D previews for clearer design inspection.
+
+### Changed
+- Refined desktop rendering and project management to better match native OpenSCAD workflows.
+- Reworked settings, customizer, diagnostics, and tool panels for a denser, more consistent editing experience.
+- Expanded automated validation, CI coverage, and pull request preview tooling.
+
+### Fixed
+- Improved mobile viewing with better pinch zoom, panel behavior, and share-screen loading.
+- Fixed export and save edge cases, including STL/customizer flows and 2D SVG defaults.
+- Corrected formatter/parser issues, AI error handling, and other rendering stability problems.
+
 ## [0.13.1] - 2026-03-23
 
 ### Fixed

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "0.13.1",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/ui/src-tauri/Cargo.lock
+++ b/apps/ui/src-tauri/Cargo.lock
@@ -2545,7 +2545,7 @@ dependencies = [
 
 [[package]]
 name = "openscad-studio"
-version = "0.13.1"
+version = "1.0.0"
 dependencies = [
  "chrono",
  "diffy",

--- a/apps/ui/src-tauri/Cargo.toml
+++ b/apps/ui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openscad-studio"
-version = "0.13.1"
+version = "1.0.0"
 description = "Modern OpenSCAD editor with AI assistance"
 authors = ["OpenSCAD Studio Contributors"]
 edition = "2021"

--- a/apps/ui/src-tauri/tauri.conf.json
+++ b/apps/ui/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenSCAD Studio",
-  "version": "0.13.1",
+  "version": "1.0.0",
   "identifier": "com.openscad.studio",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/apps/ui/src/constants/appInfo.ts
+++ b/apps/ui/src/constants/appInfo.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '0.13.1';
+export const APP_VERSION = '1.0.0';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openscad-studio",
-  "version": "0.13.1",
+  "version": "1.0.0",
   "private": true,
   "description": "Modern OpenSCAD editor with live preview and AI copilot",
   "packageManager": "pnpm@10.12.4",


### PR DESCRIPTION
## Summary

- prepare release v1.0.0
- update release version files
- add changelog entry for v1.0.0

## Release flow

After this PR is merged to `main`, run:

```bash
./scripts/release.sh publish 1.0.0
```