### PR TITLE
feat: add desktop MCP render bridge

### DIFF
--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: pr
+description: Use when the user wants to open a pull request or finish a branch handoff. Read the PR template, inspect changes vs main, run the release skill first if the branch name looks like a version, validate the branch with the shared repo checks, open a draft PR targeting main, and return the preview deployment URL when one applies.
+---
+
+# Open Pull Request
+
+1. Read `.github/PULL_REQUEST_TEMPLATE.md` and understand its required sections.
+2. Inspect what has changed on this branch vs `main`. If there are unrelated changes, stop and ask the user what to do.
+3. If the branch name looks like a release branch or versioned release workflow, run the release skill first before continuing.
+4. Choose the right validation scopes for the changed files and run them through `scripts/validate-changes.sh`.
+5. Prefer `bash scripts/validate-changes.sh --scope baseline` for normal TS or workflow changes. Add scopes when needed:
+   - `--scope formatter` for formatter behavior changes
+   - `--scope rust` for `apps/ui/src-tauri` or other desktop-only changes
+   - `--scope e2e-web` for materially changed user-facing web flows
+6. If formatting fixes are still needed before validation, run `pnpm format` intentionally first, then rerun the validation helper in check mode. Do not rely on the helper to mutate files unless you explicitly choose `--fix`.
+7. Draft a PR title and body that follow the template exactly, filling each section from the actual branch changes, validations run, validations skipped, and tests added.
+8. Open or update a draft PR against `main`:
+   - Create with `gh pr create --draft --base main` when no PR exists for the branch.
+   - Update the existing PR body when one already exists.
+9. After the PR exists, wait for the `Deploy PR Preview` workflow when the change is web-relevant.
+10. Return:
+   - the full PR URL
+   - the preview URL when one applies
+   - any explicit follow-up if the preview deploy or sticky comment failed
+
+## Preview Expectations
+
+- Web-relevant PRs should publish to `https://pr-<number>.openscad-studio.pages.dev`
+- Docs-only and desktop-only PRs may skip preview deployment
+- If Cloudflare deploy succeeds but the sticky comment fails, report that separately instead of pretending the preview is unavailable

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -30,6 +30,7 @@
     "@radix-ui/react-context-menu": "^2.2.16",
     "@radix-ui/react-select": "^2.1.6",
     "@radix-ui/react-switch": "^1.2.6",
+    "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@react-three/drei": "^9.114.3",
     "@react-three/fiber": "^8.17.10",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -26,6 +26,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@monaco-editor/react": "^4.6.0",
     "@posthog/react": "^1.8.2",
+    "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-context-menu": "^2.2.16",
     "@radix-ui/react-select": "^2.1.6",
     "@radix-ui/react-switch": "^1.2.6",

--- a/apps/ui/src-tauri/Cargo.lock
+++ b/apps/ui/src-tauri/Cargo.lock
@@ -48,12 +48,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
-name = "ascii"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
-
-[[package]]
 name = "ashpd"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,6 +233,58 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "base64"
@@ -472,6 +518,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,12 +541,6 @@ dependencies = [
  "wasm-bindgen",
  "windows-link 0.2.1",
 ]
-
-[[package]]
-name = "chunked_transfer"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "combine"
@@ -576,6 +627,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -652,8 +712,18 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -671,12 +741,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core",
+ "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.106",
 ]
@@ -999,6 +1093,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1054,12 +1154,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1127,6 +1243,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1286,8 +1403,22 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -1446,6 +1577,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
@@ -1551,6 +1691,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -1702,6 +1843,12 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -1950,6 +2097,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libappindicator"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2068,10 +2221,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
@@ -2565,8 +2733,12 @@ dependencies = [
 name = "openscad-studio"
 version = "1.1.0"
 dependencies = [
+ "axum",
  "chrono",
  "diffy",
+ "futures",
+ "rmcp",
+ "schemars 0.8.22",
  "serde",
  "serde_json",
  "similar",
@@ -2576,7 +2748,9 @@ dependencies = [
  "tauri-plugin-fs",
  "tauri-plugin-opener",
  "tauri-plugin-process",
- "tiny_http",
+ "tokio",
+ "tokio-util",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -2649,6 +2823,12 @@ dependencies = [
  "smallvec",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
 name = "pathdiff"
@@ -2896,6 +3076,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2997,6 +3187,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3029,6 +3225,17 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -3087,6 +3294,12 @@ checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rand_hc"
@@ -3242,6 +3455,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2231b2c085b371c01bc90c0e6c1cab8834711b6394533375bdbf870b0166d419"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "futures",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pastey",
+ "pin-project-lite",
+ "rand 0.10.0",
+ "rmcp-macros",
+ "schemars 1.0.4",
+ "serde",
+ "serde_json",
+ "sse-stream",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower-service",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36ea0e100fadf81be85d7ff70f86cd805c7572601d4ab2946207f36540854b43"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3292,7 +3549,7 @@ checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "indexmap 1.9.3",
- "schemars_derive",
+ "schemars_derive 0.8.22",
  "serde",
  "serde_json",
  "url",
@@ -3317,8 +3574,10 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
+ "schemars_derive 1.0.4",
  "serde",
  "serde_json",
 ]
@@ -3328,6 +3587,18 @@ name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d020396d1d138dc19f1165df7545479dcd58d93810dc5d646a16e55abefa80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3442,6 +3713,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3507,7 +3789,7 @@ version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7e6c180db0816026a61afa1cff5344fb7ebded7e4d3062772179f2501481c27"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -3552,8 +3834,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -3663,6 +3954,19 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb4dc4d33c68ec1f27d386b5610a351922656e1fdf5c05bbaad930cd1519479a"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -4203,6 +4507,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4234,18 +4547,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiny_http"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
-dependencies = [
- "ascii",
- "chunked_transfer",
- "httpdate",
- "log",
-]
-
-[[package]]
 name = "tinystr"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4267,8 +4568,31 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -4393,6 +4717,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4431,6 +4756,7 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -4454,6 +4780,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -4561,6 +4917,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "url"
 version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4607,6 +4969,12 @@ dependencies = [
  "serde",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version-compare"
@@ -4677,7 +5045,16 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -4753,6 +5130,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.11.4",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
 name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4763,6 +5162,18 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.9.4",
+ "hashbrown 0.15.5",
+ "indexmap 2.11.4",
+ "semver",
 ]
 
 [[package]]
@@ -5373,6 +5784,94 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap 2.11.4",
+ "prettyplease",
+ "syn 2.0.106",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.9.4",
+ "indexmap 2.11.4",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.11.4",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"

--- a/apps/ui/src-tauri/Cargo.lock
+++ b/apps/ui/src-tauri/Cargo.lock
@@ -2221,15 +2221,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matchers"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
-dependencies = [
- "regex-automata",
-]
-
-[[package]]
 name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2750,7 +2741,6 @@ dependencies = [
  "tauri-plugin-process",
  "tokio",
  "tokio-util",
- "tracing-subscriber",
  "uuid",
 ]
 
@@ -3839,15 +3829,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sharded-slab"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4507,15 +4488,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread_local"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "time"
 version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4780,36 +4752,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
-dependencies = [
- "matchers",
- "nu-ansi-term",
- "once_cell",
- "regex-automata",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing",
- "tracing-core",
- "tracing-log",
 ]
 
 [[package]]
@@ -4969,12 +4911,6 @@ dependencies = [
  "serde",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "valuable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version-compare"

--- a/apps/ui/src-tauri/Cargo.lock
+++ b/apps/ui/src-tauri/Cargo.lock
@@ -48,6 +48,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
 name = "ashpd"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,6 +484,12 @@ dependencies = [
  "wasm-bindgen",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "chunked_transfer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "combine"
@@ -1521,6 +1533,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2558,6 +2576,7 @@ dependencies = [
  "tauri-plugin-fs",
  "tauri-plugin-opener",
  "tauri-plugin-process",
+ "tiny_http",
  "uuid",
 ]
 
@@ -4212,6 +4231,18 @@ checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny_http"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "httpdate",
+ "log",
 ]
 
 [[package]]

--- a/apps/ui/src-tauri/Cargo.toml
+++ b/apps/ui/src-tauri/Cargo.toml
@@ -31,4 +31,3 @@ tokio-util = { version = "0.7" }
 axum = "0.8"
 schemars = "0.8"
 futures = "0.3"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/apps/ui/src-tauri/Cargo.toml
+++ b/apps/ui/src-tauri/Cargo.toml
@@ -25,4 +25,4 @@ diffy = "0.4"
 uuid = { version = "1", features = ["v4"] }
 chrono = "0.4"
 similar = "2"
-
+tiny_http = "0.12"

--- a/apps/ui/src-tauri/Cargo.toml
+++ b/apps/ui/src-tauri/Cargo.toml
@@ -25,4 +25,10 @@ diffy = "0.4"
 uuid = { version = "1", features = ["v4"] }
 chrono = "0.4"
 similar = "2"
-tiny_http = "0.12"
+rmcp = { version = "1", features = ["server", "transport-streamable-http-server"] }
+tokio = { version = "1", features = ["net", "sync", "rt", "rt-multi-thread", "macros"] }
+tokio-util = { version = "0.7" }
+axum = "0.8"
+schemars = "0.8"
+futures = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/apps/ui/src-tauri/capabilities/default.json
+++ b/apps/ui/src-tauri/capabilities/default.json
@@ -2,7 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Capability for all local OpenSCAD Studio windows",
-  "windows": ["main", "window-*"],
+  "windows": ["*"],
   "permissions": [
     "core:default",
     "core:window:allow-close",

--- a/apps/ui/src-tauri/capabilities/default.json
+++ b/apps/ui/src-tauri/capabilities/default.json
@@ -1,8 +1,8 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Capability for the main window",
-  "windows": ["main"],
+  "description": "Capability for all local OpenSCAD Studio windows",
+  "windows": ["main", "window-*"],
   "permissions": [
     "core:default",
     "core:window:allow-close",

--- a/apps/ui/src-tauri/src/cmd/render.rs
+++ b/apps/ui/src-tauri/src/cmd/render.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::hash::{Hash, Hasher};
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 use std::sync::Mutex;
 use std::time::UNIX_EPOCH;
@@ -249,6 +249,108 @@ struct RenderWorkspace {
     project_temp_files: Vec<PathBuf>,
 }
 
+fn normalize_relative_project_path(path: &str) -> Result<PathBuf, String> {
+    let sanitized = path.trim().replace('\\', "/");
+    if sanitized.is_empty() {
+        return Ok(PathBuf::from("input.scad"));
+    }
+
+    let candidate = Path::new(&sanitized);
+    let mut normalized = PathBuf::new();
+
+    for component in candidate.components() {
+        match component {
+            Component::CurDir => {}
+            Component::Normal(part) => normalized.push(part),
+            Component::ParentDir => {
+                if !normalized.pop() {
+                    return Err(format!(
+                        "Render target path `{}` escapes the workspace root.",
+                        path
+                    ));
+                }
+            }
+            Component::RootDir | Component::Prefix(_) => {
+                return Err(format!(
+                    "Render target path `{}` must be project-relative.",
+                    path
+                ));
+            }
+        }
+    }
+
+    if normalized.as_os_str().is_empty() {
+        Ok(PathBuf::from("input.scad"))
+    } else {
+        Ok(normalized)
+    }
+}
+
+fn collapse_duplicate_leading_segment(path: &Path) -> Option<PathBuf> {
+    let parts: Vec<_> = path
+        .components()
+        .filter_map(|component| match component {
+            Component::Normal(part) => Some(part.to_owned()),
+            _ => None,
+        })
+        .collect();
+
+    if parts.len() < 2 || parts[0] != parts[1] {
+        return None;
+    }
+
+    let mut collapsed = PathBuf::new();
+    collapsed.push(&parts[0]);
+    for part in parts.iter().skip(2) {
+        collapsed.push(part);
+    }
+    Some(collapsed)
+}
+
+fn resolve_project_relative_path(project_root: &Path, raw_path: &str) -> Result<PathBuf, String> {
+    let sanitized = raw_path.trim().replace('\\', "/");
+    let raw_candidate = Path::new(&sanitized);
+
+    let normalized = if raw_candidate.is_absolute() {
+        let stripped = raw_candidate.strip_prefix(project_root).map_err(|_| {
+            format!(
+                "Render target path `{}` is outside the workspace root `{}`.",
+                raw_path,
+                project_root.display()
+            )
+        })?;
+        normalize_relative_project_path(&stripped.to_string_lossy())?
+    } else {
+        normalize_relative_project_path(&sanitized)?
+    };
+
+    let joined = project_root.join(&normalized);
+    let joined_parent_exists = joined
+        .parent()
+        .map(|parent| parent.exists())
+        .unwrap_or(false);
+    if joined.exists() || joined_parent_exists {
+        return Ok(normalized);
+    }
+
+    if let Some(collapsed) = collapse_duplicate_leading_segment(&normalized) {
+        let collapsed_joined = project_root.join(&collapsed);
+        let collapsed_parent_exists = collapsed_joined
+            .parent()
+            .map(|parent| parent.exists())
+            .unwrap_or(false);
+        if collapsed_joined.exists() || collapsed_parent_exists {
+            eprintln!(
+                "[render] Collapsing duplicated leading segment in project-relative path {:?} -> {:?}",
+                normalized, collapsed
+            );
+            return Ok(collapsed);
+        }
+    }
+
+    Ok(normalized)
+}
+
 /// Create workspace for a native render.
 ///
 /// When a `working_dir` (project root) is provided, the input file is written
@@ -279,11 +381,14 @@ fn create_render_workspace(
         // Write the input file into the project directory so all relative
         // paths (import, include, use) resolve against the real filesystem.
         let project_root = PathBuf::from(wd);
-        let relative_input = input_path.as_deref().unwrap_or("input.scad");
+        let relative_input = resolve_project_relative_path(
+            &project_root,
+            input_path.as_deref().unwrap_or("input.scad"),
+        )?;
 
         // Use a temp filename next to the real file to avoid overwriting it
         // (the editor content may have unsaved changes).
-        let real_path = project_root.join(relative_input);
+        let real_path = project_root.join(&relative_input);
         let parent = real_path.parent().unwrap_or(&project_root);
         let stem = real_path
             .file_stem()
@@ -325,7 +430,8 @@ fn create_render_workspace(
                 if is_library_file {
                     continue;
                 }
-                let real_aux = project_root.join(rel_path);
+                let normalized_rel_path = resolve_project_relative_path(&project_root, rel_path)?;
+                let real_aux = project_root.join(&normalized_rel_path);
                 // Check if the content differs from what's on disk
                 let disk_content = fs::read_to_string(&real_aux).unwrap_or_default();
                 if disk_content != *content {
@@ -594,5 +700,89 @@ fn tokio_timeout_wait(
             ))
         }
         Err(e) => Err(format!("Channel error waiting for OpenSCAD: {}", e)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        create_render_workspace, normalize_relative_project_path, resolve_project_relative_path,
+    };
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn create_temp_project_dir(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir()
+            .join("openscad-studio-render-tests")
+            .join(format!("{name}-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn normalize_relative_project_path_rejects_workspace_escape() {
+        let error = normalize_relative_project_path("../config.scad").unwrap_err();
+        assert!(error.contains("escapes the workspace root"));
+    }
+
+    #[test]
+    fn resolve_project_relative_path_keeps_valid_nested_target() {
+        let project_root = create_temp_project_dir("nested-target");
+        let nested_dir = project_root.join("openscad");
+        fs::create_dir_all(&nested_dir).unwrap();
+
+        let resolved =
+            resolve_project_relative_path(&project_root, "openscad/poly555.scad").unwrap();
+
+        assert_eq!(resolved, PathBuf::from("openscad/poly555.scad"));
+
+        let _ = fs::remove_dir_all(project_root);
+    }
+
+    #[test]
+    fn resolve_project_relative_path_collapses_duplicate_leading_segment_when_needed() {
+        let project_root = create_temp_project_dir("duplicate-segment");
+        let nested_dir = project_root.join("openscad");
+        fs::create_dir_all(&nested_dir).unwrap();
+
+        let resolved =
+            resolve_project_relative_path(&project_root, "openscad/openscad/poly555.scad").unwrap();
+
+        assert_eq!(resolved, PathBuf::from("openscad/poly555.scad"));
+
+        let _ = fs::remove_dir_all(project_root);
+    }
+
+    #[test]
+    fn create_render_workspace_places_nested_temp_input_beside_real_target() {
+        let project_root = create_temp_project_dir("workspace-input");
+        let nested_dir = project_root.join("openscad");
+        fs::create_dir_all(&nested_dir).unwrap();
+
+        let workspace = create_render_workspace(
+            "cube(10);",
+            "output.off",
+            &None,
+            &Some("openscad/poly555.scad".into()),
+            &Some(project_root.to_string_lossy().to_string()),
+            &None,
+        )
+        .unwrap();
+
+        assert_eq!(workspace.input_path.parent(), Some(nested_dir.as_path()));
+        assert_eq!(
+            workspace
+                .input_path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .map(|name| name.starts_with(".openscad-studio-poly555-")),
+            Some(true)
+        );
+
+        for temp_file in workspace.project_temp_files {
+            let _ = fs::remove_file(temp_file);
+        }
+        let _ = fs::remove_dir_all(workspace.temp_dir);
+        let _ = fs::remove_dir_all(project_root);
     }
 }

--- a/apps/ui/src-tauri/src/lib.rs
+++ b/apps/ui/src-tauri/src/lib.rs
@@ -1,9 +1,11 @@
 mod cmd;
 mod history;
+mod mcp;
 mod types;
 
 use cmd::{update_editor_state, update_working_dir, EditorState, OpenScadBinaryState};
 use history::HistoryState;
+use mcp::{shutdown_mcp_server, McpServerState};
 use tauri::menu::{MenuBuilder, MenuItemBuilder, SubmenuBuilder};
 use tauri::{Emitter, Manager};
 
@@ -12,6 +14,7 @@ pub fn run() {
     let editor_state = EditorState::default();
     let history_state = HistoryState::new();
     let openscad_state = OpenScadBinaryState::default();
+    let mcp_state = McpServerState::default();
 
     tauri::Builder::default()
         .plugin(tauri_plugin_fs::init())
@@ -20,6 +23,7 @@ pub fn run() {
         .manage(editor_state)
         .manage(history_state)
         .manage(openscad_state)
+        .manage(mcp_state.clone())
         .plugin(tauri_plugin_opener::init())
         .invoke_handler(tauri::generate_handler![
             update_editor_state,
@@ -36,6 +40,9 @@ pub fn run() {
             cmd::render::render_init,
             cmd::render::render_native,
             cmd::render::render_cancel,
+            mcp::configure_mcp_server,
+            mcp::get_mcp_server_status,
+            mcp::mcp_submit_tool_response,
         ])
         .setup(|app| {
             // Create app menu (About, Hide, Quit, etc.)
@@ -154,6 +161,11 @@ pub fn run() {
                     window.emit("menu:file:export", "dxf").unwrap();
                 }
                 _ => {}
+            }
+        })
+        .on_window_event(move |_window, event| {
+            if matches!(event, tauri::WindowEvent::Destroyed) {
+                shutdown_mcp_server(&mcp_state);
             }
         })
         .run(tauri::generate_context!())

--- a/apps/ui/src-tauri/src/lib.rs
+++ b/apps/ui/src-tauri/src/lib.rs
@@ -9,7 +9,6 @@ use mcp::{
     record_window_startup_phase, remove_window, update_window_focus, McpServerState,
     WindowLaunchIntent,
 };
-use tauri::webview::PageLoadEvent;
 use tauri::menu::{MenuBuilder, MenuItemBuilder, SubmenuBuilder};
 use tauri::{Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
 use uuid::Uuid;
@@ -45,27 +44,13 @@ fn build_window_with_label(
     let launch_intent = serde_json::to_string(intent).expect("serializable window launch intent");
     let initialization_script =
         format!("window.__OPENSCAD_STUDIO_BOOTSTRAP__ = {{ launchIntent: {launch_intent} }};");
-    let mcp_state = app.state::<McpServerState>().inner().clone();
+    let mcp_state = app.state::<McpServerState>();
     record_window_startup_phase(&mcp_state, label, "window_created", None);
 
     WebviewWindowBuilder::new(app, label, WebviewUrl::App("index.html".into()))
         .title("OpenSCAD Studio")
         .inner_size(1400.0, 900.0)
         .initialization_script(&initialization_script)
-        .on_page_load(move |window, payload| {
-            let phase = match payload.event() {
-                PageLoadEvent::Started => "page_load_started",
-                PageLoadEvent::Finished => "page_load_finished",
-            };
-            let detail = Some(payload.url().to_string());
-            eprintln!(
-                "[startup:{}] page_load phase={} url={}",
-                window.label(),
-                phase,
-                payload.url()
-            );
-            record_window_startup_phase(&mcp_state, window.label(), phase, detail);
-        })
         .build()?;
     Ok(())
 }
@@ -91,6 +76,15 @@ fn emit_to_focused_window<T: serde::Serialize + Clone>(
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // Enable rmcp tracing to diagnose session lifecycle issues.
+    // Set RUST_LOG=rmcp=debug,info to see session create/close events.
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("rmcp=debug")),
+        )
+        .try_init();
+
     let editor_state = EditorState::default();
     let history_state = HistoryState::new();
     let openscad_state = OpenScadBinaryState::default();

--- a/apps/ui/src-tauri/src/lib.rs
+++ b/apps/ui/src-tauri/src/lib.rs
@@ -76,15 +76,6 @@ fn emit_to_focused_window<T: serde::Serialize + Clone>(
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    // Enable rmcp tracing to diagnose session lifecycle issues.
-    // Set RUST_LOG=rmcp=debug,info to see session create/close events.
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("rmcp=debug")),
-        )
-        .try_init();
-
     let editor_state = EditorState::default();
     let history_state = HistoryState::new();
     let openscad_state = OpenScadBinaryState::default();

--- a/apps/ui/src-tauri/src/lib.rs
+++ b/apps/ui/src-tauri/src/lib.rs
@@ -31,8 +31,7 @@ pub(crate) fn create_new_window_with_launch_intent(
         let _ = tx.send(result);
     })?;
 
-    rx.recv()
-        .map_err(|e| tauri::Error::Anyhow(e.into()))??;
+    rx.recv().map_err(|e| tauri::Error::Anyhow(e.into()))??;
     Ok(label)
 }
 

--- a/apps/ui/src-tauri/src/lib.rs
+++ b/apps/ui/src-tauri/src/lib.rs
@@ -5,9 +5,38 @@ mod types;
 
 use cmd::{update_editor_state, update_working_dir, EditorState, OpenScadBinaryState};
 use history::HistoryState;
-use mcp::{shutdown_mcp_server, McpServerState};
+use mcp::{remove_window, update_window_focus, McpServerState};
 use tauri::menu::{MenuBuilder, MenuItemBuilder, SubmenuBuilder};
-use tauri::{Emitter, Manager};
+use tauri::{Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
+use uuid::Uuid;
+
+fn create_new_window(app: &tauri::AppHandle) -> tauri::Result<()> {
+    let label = format!("window-{}", Uuid::new_v4());
+    WebviewWindowBuilder::new(app, label, WebviewUrl::App("index.html".into()))
+        .title("OpenSCAD Studio")
+        .inner_size(1400.0, 900.0)
+        .build()?;
+    Ok(())
+}
+
+fn emit_to_focused_window<T: serde::Serialize + Clone>(
+    app: &tauri::AppHandle,
+    event: &str,
+    payload: T,
+) {
+    if let Some((_, window)) = app
+        .webview_windows()
+        .into_iter()
+        .find(|(_, window)| window.is_focused().unwrap_or(false))
+    {
+        let _ = window.emit(event, payload.clone());
+        return;
+    }
+
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.emit(event, payload);
+    }
+}
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -43,6 +72,7 @@ pub fn run() {
             mcp::configure_mcp_server,
             mcp::get_mcp_server_status,
             mcp::mcp_submit_tool_response,
+            mcp::mcp_update_window_context,
         ])
         .setup(|app| {
             // Create app menu (About, Hide, Quit, etc.)
@@ -61,6 +91,11 @@ pub fn run() {
                 .item(
                     &MenuItemBuilder::with_id("new", "New")
                         .accelerator("CmdOrCtrl+N")
+                        .build(app)?,
+                )
+                .item(
+                    &MenuItemBuilder::with_id("new_window", "New Window")
+                        .accelerator("CmdOrCtrl+Shift+N")
                         .build(app)?,
                 )
                 .item(
@@ -117,56 +152,60 @@ pub fn run() {
 
             Ok(())
         })
-        .on_menu_event(|app, event| {
-            // Emit events to frontend to handle the menu actions
-            let window = app.get_webview_window("main").unwrap();
-            match event.id().as_ref() {
-                "new" => {
-                    window.emit("menu:file:new", ()).unwrap();
-                }
-                "open" => {
-                    window.emit("menu:file:open", ()).unwrap();
-                }
-                "open_folder" => {
-                    window.emit("menu:file:open_folder", ()).unwrap();
-                }
-                "save" => {
-                    window.emit("menu:file:save", ()).unwrap();
-                }
-                "save_as" => {
-                    window.emit("menu:file:save_as", ()).unwrap();
-                }
-                "save_all" => {
-                    window.emit("menu:file:save_all", ()).unwrap();
-                }
-                "export_stl" => {
-                    window.emit("menu:file:export", "stl").unwrap();
-                }
-                "export_obj" => {
-                    window.emit("menu:file:export", "obj").unwrap();
-                }
-                "export_amf" => {
-                    window.emit("menu:file:export", "amf").unwrap();
-                }
-                "export_3mf" => {
-                    window.emit("menu:file:export", "3mf").unwrap();
-                }
-                "export_png" => {
-                    window.emit("menu:file:export", "png").unwrap();
-                }
-                "export_svg" => {
-                    window.emit("menu:file:export", "svg").unwrap();
-                }
-                "export_dxf" => {
-                    window.emit("menu:file:export", "dxf").unwrap();
-                }
-                _ => {}
+        .on_menu_event(|app, event| match event.id().as_ref() {
+            "new" => {
+                emit_to_focused_window(app, "menu:file:new", ());
             }
+            "new_window" => {
+                let _ = create_new_window(app);
+            }
+            "open" => {
+                emit_to_focused_window(app, "menu:file:open", ());
+            }
+            "open_folder" => {
+                emit_to_focused_window(app, "menu:file:open_folder", ());
+            }
+            "save" => {
+                emit_to_focused_window(app, "menu:file:save", ());
+            }
+            "save_as" => {
+                emit_to_focused_window(app, "menu:file:save_as", ());
+            }
+            "save_all" => {
+                emit_to_focused_window(app, "menu:file:save_all", ());
+            }
+            "export_stl" => {
+                emit_to_focused_window(app, "menu:file:export", "stl");
+            }
+            "export_obj" => {
+                emit_to_focused_window(app, "menu:file:export", "obj");
+            }
+            "export_amf" => {
+                emit_to_focused_window(app, "menu:file:export", "amf");
+            }
+            "export_3mf" => {
+                emit_to_focused_window(app, "menu:file:export", "3mf");
+            }
+            "export_png" => {
+                emit_to_focused_window(app, "menu:file:export", "png");
+            }
+            "export_svg" => {
+                emit_to_focused_window(app, "menu:file:export", "svg");
+            }
+            "export_dxf" => {
+                emit_to_focused_window(app, "menu:file:export", "dxf");
+            }
+            _ => {}
         })
-        .on_window_event(move |_window, event| {
-            if matches!(event, tauri::WindowEvent::Destroyed) {
-                shutdown_mcp_server(&mcp_state);
+        .on_window_event(move |window, event| match event {
+            tauri::WindowEvent::Focused(focused) => {
+                update_window_focus(&mcp_state, window.label(), *focused);
             }
+            tauri::WindowEvent::Destroyed => {
+                remove_window(&mcp_state, window.label());
+            }
+            tauri::WindowEvent::CloseRequested { .. } => {}
+            _ => {}
         })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/ui/src-tauri/src/lib.rs
+++ b/apps/ui/src-tauri/src/lib.rs
@@ -5,16 +5,37 @@ mod types;
 
 use cmd::{update_editor_state, update_working_dir, EditorState, OpenScadBinaryState};
 use history::HistoryState;
-use mcp::{remove_window, update_window_focus, McpServerState};
+use mcp::{remove_window, update_window_focus, McpServerState, WindowLaunchIntent};
 use tauri::menu::{MenuBuilder, MenuItemBuilder, SubmenuBuilder};
 use tauri::{Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
 use uuid::Uuid;
 
-fn create_new_window(app: &tauri::AppHandle) -> tauri::Result<()> {
+pub(crate) fn create_new_window_with_launch_intent(
+    app: &tauri::AppHandle,
+    intent: WindowLaunchIntent,
+) -> tauri::Result<String> {
     let label = format!("window-{}", Uuid::new_v4());
+    eprintln!(
+        "[startup:{}] create_new_window_with_launch_intent {:?}",
+        label, intent
+    );
+    build_window_with_label(app, &label, &intent)?;
+    Ok(label)
+}
+
+fn build_window_with_label(
+    app: &tauri::AppHandle,
+    label: &str,
+    intent: &WindowLaunchIntent,
+) -> tauri::Result<()> {
+    let launch_intent = serde_json::to_string(intent).expect("serializable window launch intent");
+    let initialization_script =
+        format!("window.__OPENSCAD_STUDIO_BOOTSTRAP__ = {{ launchIntent: {launch_intent} }};");
+
     WebviewWindowBuilder::new(app, label, WebviewUrl::App("index.html".into()))
         .title("OpenSCAD Studio")
         .inner_size(1400.0, 900.0)
+        .initialization_script(&initialization_script)
         .build()?;
     Ok(())
 }
@@ -44,6 +65,7 @@ pub fn run() {
     let history_state = HistoryState::new();
     let openscad_state = OpenScadBinaryState::default();
     let mcp_state = McpServerState::default();
+    let window_mcp_state = mcp_state.clone();
 
     tauri::Builder::default()
         .plugin(tauri_plugin_fs::init())
@@ -72,6 +94,8 @@ pub fn run() {
             mcp::configure_mcp_server,
             mcp::get_mcp_server_status,
             mcp::mcp_submit_tool_response,
+            mcp::mcp_mark_window_bridge_ready,
+            mcp::report_window_open_result,
             mcp::mcp_update_window_context,
         ])
         .setup(|app| {
@@ -152,12 +176,12 @@ pub fn run() {
 
             Ok(())
         })
-        .on_menu_event(|app, event| match event.id().as_ref() {
+        .on_menu_event(move |app, event| match event.id().as_ref() {
             "new" => {
                 emit_to_focused_window(app, "menu:file:new", ());
             }
             "new_window" => {
-                let _ = create_new_window(app);
+                let _ = create_new_window_with_launch_intent(app, WindowLaunchIntent::Welcome);
             }
             "open" => {
                 emit_to_focused_window(app, "menu:file:open", ());
@@ -199,10 +223,10 @@ pub fn run() {
         })
         .on_window_event(move |window, event| match event {
             tauri::WindowEvent::Focused(focused) => {
-                update_window_focus(&mcp_state, window.label(), *focused);
+                update_window_focus(&window_mcp_state, window.label(), *focused);
             }
             tauri::WindowEvent::Destroyed => {
-                remove_window(&mcp_state, window.label());
+                remove_window(&window_mcp_state, window.label());
             }
             tauri::WindowEvent::CloseRequested { .. } => {}
             _ => {}

--- a/apps/ui/src-tauri/src/lib.rs
+++ b/apps/ui/src-tauri/src/lib.rs
@@ -5,7 +5,11 @@ mod types;
 
 use cmd::{update_editor_state, update_working_dir, EditorState, OpenScadBinaryState};
 use history::HistoryState;
-use mcp::{remove_window, update_window_focus, McpServerState, WindowLaunchIntent};
+use mcp::{
+    record_window_startup_phase, remove_window, update_window_focus, McpServerState,
+    WindowLaunchIntent,
+};
+use tauri::webview::PageLoadEvent;
 use tauri::menu::{MenuBuilder, MenuItemBuilder, SubmenuBuilder};
 use tauri::{Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
 use uuid::Uuid;
@@ -15,11 +19,21 @@ pub(crate) fn create_new_window_with_launch_intent(
     intent: WindowLaunchIntent,
 ) -> tauri::Result<String> {
     let label = format!("window-{}", Uuid::new_v4());
-    eprintln!(
-        "[startup:{}] create_new_window_with_launch_intent {:?}",
-        label, intent
-    );
-    build_window_with_label(app, &label, &intent)?;
+
+    // Window creation MUST happen on the main thread so that the IPC response
+    // handler is properly registered for the new webview. When called from a
+    // background thread (e.g. the MCP HTTP server), dispatching via
+    // run_on_main_thread ensures the window is created correctly.
+    let app_clone = app.clone();
+    let label_clone = label.clone();
+    let (tx, rx) = std::sync::mpsc::channel();
+    app.run_on_main_thread(move || {
+        let result = build_window_with_label(&app_clone, &label_clone, &intent);
+        let _ = tx.send(result);
+    })?;
+
+    rx.recv()
+        .map_err(|e| tauri::Error::Anyhow(e.into()))??;
     Ok(label)
 }
 
@@ -31,11 +45,27 @@ fn build_window_with_label(
     let launch_intent = serde_json::to_string(intent).expect("serializable window launch intent");
     let initialization_script =
         format!("window.__OPENSCAD_STUDIO_BOOTSTRAP__ = {{ launchIntent: {launch_intent} }};");
+    let mcp_state = app.state::<McpServerState>().inner().clone();
+    record_window_startup_phase(&mcp_state, label, "window_created", None);
 
     WebviewWindowBuilder::new(app, label, WebviewUrl::App("index.html".into()))
         .title("OpenSCAD Studio")
         .inner_size(1400.0, 900.0)
         .initialization_script(&initialization_script)
+        .on_page_load(move |window, payload| {
+            let phase = match payload.event() {
+                PageLoadEvent::Started => "page_load_started",
+                PageLoadEvent::Finished => "page_load_finished",
+            };
+            let detail = Some(payload.url().to_string());
+            eprintln!(
+                "[startup:{}] page_load phase={} url={}",
+                window.label(),
+                phase,
+                payload.url()
+            );
+            record_window_startup_phase(&mcp_state, window.label(), phase, detail);
+        })
         .build()?;
     Ok(())
 }
@@ -95,6 +125,7 @@ pub fn run() {
             mcp::get_mcp_server_status,
             mcp::mcp_submit_tool_response,
             mcp::mcp_mark_window_bridge_ready,
+            mcp::mcp_report_window_startup_phase,
             mcp::report_window_open_result,
             mcp::mcp_update_window_context,
         ])

--- a/apps/ui/src-tauri/src/mcp.rs
+++ b/apps/ui/src-tauri/src/mcp.rs
@@ -4,10 +4,12 @@ use std::collections::HashMap;
 use std::fs;
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread::{self, JoinHandle};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter, Manager, State, Window};
 use tiny_http::{Header, Method, Request, Response, Server, StatusCode};
 use uuid::Uuid;
+
+use crate::create_new_window_with_launch_intent;
 
 const MCP_PROTOCOL_VERSION: &str = "2025-03-26";
 const MCP_SERVER_NAME: &str = "openscad-studio";
@@ -73,12 +75,59 @@ pub struct WorkspaceDescriptor {
     pub is_focused: bool,
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RegisteredWindowMode {
+    Welcome,
+    Opening,
+    Ready,
+    OpenFailed,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum WindowLaunchIntent {
+    Welcome,
+    OpenFolder {
+        request_id: String,
+        folder_path: String,
+        create_if_empty: bool,
+    },
+    OpenFile {
+        request_id: String,
+        file_path: String,
+    },
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum WindowOpenRequest {
+    OpenFolder {
+        folder_path: String,
+        create_if_empty: bool,
+    },
+    OpenFile {
+        file_path: String,
+    },
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WindowOpenRequestPayload {
+    request_id: String,
+    request: WindowOpenRequest,
+}
+
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WindowContextPayload {
     pub title: Option<String>,
     pub workspace_root: Option<String>,
     pub render_target_path: Option<String>,
+    pub mode: Option<RegisteredWindowMode>,
+    pub pending_request_id: Option<String>,
+    #[serde(default)]
+    pub show_welcome: bool,
     #[serde(default = "default_true")]
     pub ready: bool,
 }
@@ -86,8 +135,23 @@ pub struct WindowContextPayload {
 #[derive(Clone, Debug)]
 struct RegisteredWorkspace {
     descriptor: WorkspaceDescriptor,
-    ready: bool,
+    show_welcome: bool,
+    mode: RegisteredWindowMode,
+    pending_request_id: Option<String>,
+    context_ready: bool,
+    bridge_ready: bool,
     last_focused_order: u64,
+}
+
+#[derive(Clone, Debug)]
+struct WindowOpenResult {
+    message: String,
+    opened_workspace_root: Option<String>,
+}
+
+struct PendingWindowOpenRequest {
+    window_id: String,
+    sender: mpsc::Sender<Result<WindowOpenResult, String>>,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -111,6 +175,7 @@ struct RunningServer {
 struct McpStateInner {
     running_server: Option<RunningServer>,
     pending: HashMap<String, mpsc::Sender<McpToolResponse>>,
+    window_open_requests: HashMap<String, PendingWindowOpenRequest>,
     status: McpServerStatus,
     workspaces: HashMap<String, RegisteredWorkspace>,
     sessions: HashMap<String, McpSessionBinding>,
@@ -128,6 +193,7 @@ impl Default for McpServerState {
             inner: Arc::new(Mutex::new(McpStateInner {
                 running_server: None,
                 pending: HashMap::new(),
+                window_open_requests: HashMap::new(),
                 status: McpServerStatus {
                     enabled: true,
                     port: MCP_DEFAULT_PORT,
@@ -247,48 +313,82 @@ fn remove_pending(
     inner.lock().unwrap().pending.remove(request_id)
 }
 
-fn list_open_workspaces_locked(inner: &McpStateInner) -> Vec<WorkspaceDescriptor> {
-    let mut workspaces: Vec<_> = inner.workspaces.values().cloned().collect();
+fn ordered_registered_workspaces(inner: &McpStateInner) -> Vec<(&String, &RegisteredWorkspace)> {
+    let mut workspaces: Vec<_> = inner.workspaces.iter().collect();
     workspaces.sort_by(|a, b| {
-        b.descriptor
+        b.1.descriptor
             .is_focused
-            .cmp(&a.descriptor.is_focused)
-            .then_with(|| b.last_focused_order.cmp(&a.last_focused_order))
-            .then_with(|| a.descriptor.title.cmp(&b.descriptor.title))
-            .then_with(|| a.descriptor.window_id.cmp(&b.descriptor.window_id))
+            .cmp(&a.1.descriptor.is_focused)
+            .then_with(|| b.1.last_focused_order.cmp(&a.1.last_focused_order))
+            .then_with(|| a.1.descriptor.title.cmp(&b.1.descriptor.title))
+            .then_with(|| a.0.cmp(b.0))
     });
     workspaces
-        .into_iter()
-        .map(|entry| entry.descriptor)
-        .collect()
 }
 
-fn format_workspace_list(workspaces: &[WorkspaceDescriptor]) -> String {
-    if workspaces.is_empty() {
-        return "No OpenSCAD Studio windows are currently available for MCP binding.".into();
-    }
-
-    let lines = workspaces
-        .iter()
-        .map(|workspace| {
-            let root = workspace
-                .workspace_root
-                .clone()
-                .unwrap_or_else(|| "(no workspace root)".into());
-            let render_target = workspace
-                .render_target_path
-                .clone()
-                .unwrap_or_else(|| "(no render target)".into());
-            let focused = if workspace.is_focused { "yes" } else { "no" };
-            format!(
-                "- window_id: {}\n  title: {}\n  workspace_root: {}\n  render_target_path: {}\n  focused: {}",
-                workspace.window_id, workspace.title, root, render_target, focused
-            )
+fn choose_existing_workspace_for_root(
+    inner: &McpStateInner,
+    normalized_root: &str,
+) -> Option<String> {
+    ordered_registered_workspaces(inner)
+        .into_iter()
+        .find(|(_, workspace)| {
+            workspace.context_ready
+                && workspace.mode == RegisteredWindowMode::Ready
+                && workspace.descriptor.workspace_root.as_deref() == Some(normalized_root)
         })
-        .collect::<Vec<_>>()
-        .join("\n");
+        .map(|(window_id, _)| window_id.clone())
+}
 
-    format!("Open OpenSCAD Studio workspaces:\n{lines}")
+fn choose_blank_welcome_window(inner: &McpStateInner) -> Option<String> {
+    ordered_registered_workspaces(inner)
+        .into_iter()
+        .find(|(_, workspace)| {
+            workspace.context_ready
+                && workspace.bridge_ready
+                && workspace.show_welcome
+                && workspace.mode == RegisteredWindowMode::Welcome
+                && workspace.pending_request_id.is_none()
+                && workspace.descriptor.workspace_root.is_none()
+        })
+        .map(|(window_id, _)| window_id.clone())
+}
+
+fn bind_session_to_window(inner: &mut McpStateInner, session_id: &str, window_id: String) {
+    inner
+        .sessions
+        .entry(session_id.to_string())
+        .or_default()
+        .bound_window_id = Some(window_id);
+}
+
+fn wait_for_window_tool_ready(
+    inner: &Arc<Mutex<McpStateInner>>,
+    window_id: &str,
+    timeout: Duration,
+) -> Result<(), String> {
+    let deadline = Instant::now() + timeout;
+
+    loop {
+        if inner
+            .lock()
+            .unwrap()
+            .workspaces
+            .get(window_id)
+            .map(|workspace| workspace.context_ready && workspace.bridge_ready)
+            .unwrap_or(false)
+        {
+            return Ok(());
+        }
+
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "Timed out waiting for OpenSCAD Studio window `{window_id}` to finish starting its MCP bridge."
+            ));
+        }
+
+        thread::sleep(Duration::from_millis(50));
+    }
 }
 
 fn ensure_session_id(inner: &mut McpStateInner, existing_session_id: Option<String>) -> String {
@@ -299,6 +399,20 @@ fn ensure_session_id(inner: &mut McpStateInner, existing_session_id: Option<Stri
 
 fn remove_window_and_invalidate_sessions_locked(inner: &mut McpStateInner, window_id: &str) {
     inner.workspaces.remove(window_id);
+    let pending_request_ids = inner
+        .window_open_requests
+        .iter()
+        .filter_map(|(request_id, pending)| {
+            (pending.window_id == window_id).then_some(request_id.clone())
+        })
+        .collect::<Vec<_>>();
+    for request_id in pending_request_ids {
+        if let Some(pending) = inner.window_open_requests.remove(&request_id) {
+            let _ = pending.sender.send(Err(format!(
+                "OpenSCAD Studio window `{window_id}` closed before it finished opening the requested target."
+            )));
+        }
+    }
     for session in inner.sessions.values_mut() {
         if session.bound_window_id.as_deref() == Some(window_id) {
             session.bound_window_id = None;
@@ -312,24 +426,20 @@ fn require_bound_window_id(
 ) -> Result<String, McpToolResponse> {
     let Some(session) = inner.sessions.get_mut(session_id) else {
         return Err(text_tool_response(
-            "This MCP session is not initialized. Reconnect your client and call `select_workspace` before using Studio render tools.",
+            "This MCP session is not initialized. Reconnect your client and call `get_or_create_workspace(folder_path)` before using Studio tools.",
             true,
         ));
     };
 
     let Some(window_id) = session.bound_window_id.clone() else {
-        let workspaces = list_open_workspaces_locked(inner);
         return Err(text_tool_response(
-            format!(
-                "No OpenSCAD Studio workspace is selected for this MCP session.\n\nCall `select_workspace` with a `workspace_root` or `window_id` first.\n\n{}",
-                format_workspace_list(&workspaces)
-            ),
+            "No OpenSCAD Studio workspace is selected for this MCP session. Call `get_or_create_workspace(folder_path)` first.",
             true,
         ));
     };
 
     match inner.workspaces.get(&window_id) {
-        Some(workspace) if workspace.ready => Ok(window_id),
+        Some(workspace) if workspace.context_ready => Ok(window_id),
         Some(_) => Err(text_tool_response(
             format!(
                 "The selected Studio window `{window_id}` is not ready for MCP requests yet. Wait a moment and try again."
@@ -338,11 +448,9 @@ fn require_bound_window_id(
         )),
         None => {
             session.bound_window_id = None;
-            let workspaces = list_open_workspaces_locked(inner);
             Err(text_tool_response(
                 format!(
-                    "The previously selected Studio window `{window_id}` is no longer available. Call `select_workspace` again.\n\n{}",
-                    format_workspace_list(&workspaces)
+                    "The previously selected Studio window `{window_id}` is no longer available. Call `get_or_create_workspace(folder_path)` again."
                 ),
                 true,
             ))
@@ -357,6 +465,8 @@ fn call_frontend_tool(
     tool_name: &str,
     arguments: Value,
 ) -> Result<McpToolResponse, String> {
+    wait_for_window_tool_ready(inner, window_id, Duration::from_secs(5))?;
+
     let request_id = Uuid::new_v4().to_string();
     let (tx, rx) = mpsc::channel();
 
@@ -395,32 +505,135 @@ fn call_frontend_tool(
     }
 }
 
+fn create_window_open_request(
+    inner: &Arc<Mutex<McpStateInner>>,
+    window_id: &str,
+) -> (String, mpsc::Receiver<Result<WindowOpenResult, String>>) {
+    let request_id = Uuid::new_v4().to_string();
+    let (tx, rx) = mpsc::channel();
+    inner.lock().unwrap().window_open_requests.insert(
+        request_id.clone(),
+        PendingWindowOpenRequest {
+            window_id: window_id.to_string(),
+            sender: tx,
+        },
+    );
+    (request_id, rx)
+}
+
+fn wait_for_window_open_result(
+    inner: &Arc<Mutex<McpStateInner>>,
+    request_id: &str,
+    rx: mpsc::Receiver<Result<WindowOpenResult, String>>,
+    window_id: &str,
+    target_description: &str,
+    timeout: Duration,
+) -> Result<WindowOpenResult, String> {
+    match rx.recv_timeout(timeout) {
+        Ok(result) => result,
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            inner
+                .lock()
+                .unwrap()
+                .window_open_requests
+                .remove(request_id);
+            Err(format!(
+                "Timed out waiting for OpenSCAD Studio to open `{target_description}` in window `{window_id}`."
+            ))
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            inner
+                .lock()
+                .unwrap()
+                .window_open_requests
+                .remove(request_id);
+            Err(format!(
+                "OpenSCAD Studio lost the result channel while opening `{target_description}` in window `{window_id}`."
+            ))
+        }
+    }
+}
+
+fn dispatch_window_open_request(
+    app: &AppHandle,
+    inner: &Arc<Mutex<McpStateInner>>,
+    window_id: &str,
+    request: WindowOpenRequest,
+) -> Result<WindowOpenResult, String> {
+    wait_for_window_tool_ready(inner, window_id, Duration::from_secs(5))?;
+
+    let target_description = match &request {
+        WindowOpenRequest::OpenFolder { folder_path, .. } => folder_path.clone(),
+        WindowOpenRequest::OpenFile { file_path } => file_path.clone(),
+    };
+    let (request_id, rx) = create_window_open_request(inner, window_id);
+    eprintln!(
+        "[mcp] dispatch_window_open_request window={} request_id={} target={}",
+        window_id, request_id, target_description
+    );
+
+    let payload = WindowOpenRequestPayload {
+        request_id: request_id.clone(),
+        request,
+    };
+
+    {
+        let mut locked = inner.lock().unwrap();
+        if let Some(workspace) = locked.workspaces.get_mut(window_id) {
+            workspace.mode = RegisteredWindowMode::Opening;
+            workspace.pending_request_id = Some(request_id.clone());
+            workspace.show_welcome = false;
+        }
+    }
+
+    let Some(window) = app.get_webview_window(window_id) else {
+        inner
+            .lock()
+            .unwrap()
+            .window_open_requests
+            .remove(&request_id);
+        return Err(format!(
+            "OpenSCAD Studio window `{window_id}` is no longer available."
+        ));
+    };
+
+    if let Err(error) = window.emit("desktop:open-request", payload) {
+        let mut locked = inner.lock().unwrap();
+        locked.window_open_requests.remove(&request_id);
+        if let Some(workspace) = locked.workspaces.get_mut(window_id) {
+            workspace.mode = RegisteredWindowMode::Welcome;
+            workspace.pending_request_id = None;
+            workspace.show_welcome = true;
+        }
+        return Err(format!(
+            "Failed to dispatch desktop open request to OpenSCAD Studio window `{window_id}`: {error}"
+        ));
+    }
+
+    wait_for_window_open_result(
+        inner,
+        &request_id,
+        rx,
+        window_id,
+        &target_description,
+        Duration::from_secs(120),
+    )
+}
+
 fn tool_definitions() -> Value {
     json!([
         {
-            "name": "list_open_workspaces",
-            "description": "List the currently open OpenSCAD Studio windows that can be selected for this MCP session.",
-            "inputSchema": {
-                "type": "object",
-                "properties": {},
-                "additionalProperties": false
-            }
-        },
-        {
-            "name": "select_workspace",
-            "description": "Bind this MCP session to an open OpenSCAD Studio workspace by exact workspace root or explicit window id.",
+            "name": "get_or_create_workspace",
+            "description": "Ensure this MCP session is bound to the exact requested workspace folder by attaching to an already-open match or opening/initializing it in OpenSCAD Studio.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
-                    "workspace_root": {
+                    "folder_path": {
                         "type": "string",
-                        "description": "Exact absolute workspace root path already open in OpenSCAD Studio."
-                    },
-                    "window_id": {
-                        "type": "string",
-                        "description": "Explicit OpenSCAD Studio window id from list_open_workspaces()."
+                        "description": "Absolute folder path to open as the Studio workspace."
                     }
                 },
+                "required": ["folder_path"],
                 "additionalProperties": false
             }
         },
@@ -504,120 +717,203 @@ fn tool_definitions() -> Value {
     ])
 }
 
-fn list_open_workspaces_response(inner: &McpStateInner) -> McpToolResponse {
-    let workspaces = list_open_workspaces_locked(inner);
-    text_tool_response(format_workspace_list(&workspaces), false)
-}
-
-fn select_workspace_response(
-    inner: &mut McpStateInner,
+fn get_or_create_workspace_response(
+    app: &AppHandle,
+    inner: &Arc<Mutex<McpStateInner>>,
     session_id: &str,
     arguments: &Value,
 ) -> McpToolResponse {
-    let workspace_root = arguments
-        .get("workspace_root")
+    let folder_path = arguments
+        .get("folder_path")
+        .or_else(|| arguments.get("workspace_root"))
+        .or_else(|| arguments.get("path"))
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty());
-    let window_id = arguments
-        .get("window_id")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty());
 
-    let selected_window_id = if let Some(window_id) = window_id {
-        match inner.workspaces.get(window_id) {
-            Some(_) => window_id.to_string(),
-            None => {
-                return text_tool_response(
-                    format!(
-                        "No open OpenSCAD Studio window matches `window_id` `{window_id}`.\n\n{}",
-                        format_workspace_list(&list_open_workspaces_locked(inner))
-                    ),
-                    true,
-                )
-            }
-        }
-    } else if let Some(workspace_root) = workspace_root {
-        let Some(normalized_root) = normalize_workspace_root(workspace_root) else {
-            return text_tool_response(
-                format!("Could not resolve workspace root `{workspace_root}`."),
-                true,
-            );
-        };
-
-        let matches: Vec<_> = inner
-            .workspaces
-            .values()
-            .filter(|workspace| {
-                workspace.descriptor.workspace_root.as_deref() == Some(normalized_root.as_str())
-            })
-            .map(|workspace| workspace.descriptor.clone())
-            .collect();
-
-        match matches.len() {
-            0 => {
-                return text_tool_response(
-                    format!(
-                        "No open OpenSCAD Studio workspace matches `{normalized_root}`.\n\n{}",
-                        format_workspace_list(&list_open_workspaces_locked(inner))
-                    ),
-                    true,
-                )
-            }
-            1 => matches[0].window_id.clone(),
-            _ => {
-                let options = matches
-                    .iter()
-                    .map(|workspace| format!("- {} ({})", workspace.window_id, workspace.title))
-                    .collect::<Vec<_>>()
-                    .join("\n");
-                return text_tool_response(
-                    format!(
-                        "Multiple OpenSCAD Studio windows are open for `{normalized_root}`. Re-run `select_workspace` with a `window_id`.\n\n{options}"
-                    ),
-                    true,
-                );
-            }
-        }
-    } else {
+    let Some(folder_path) = folder_path else {
         return text_tool_response(
-            "select_workspace requires either `workspace_root` or `window_id`.",
+            "get_or_create_workspace requires a `folder_path` argument.",
             true,
         );
     };
 
-    inner
-        .sessions
-        .entry(session_id.to_string())
-        .or_default()
-        .bound_window_id = Some(selected_window_id.clone());
-
-    let workspace = inner
-        .workspaces
-        .get(&selected_window_id)
-        .map(|workspace| workspace.descriptor.clone());
-
-    if let Some(workspace) = workspace {
-        let root = workspace
-            .workspace_root
-            .unwrap_or_else(|| "(no workspace root)".into());
-        let render_target = workspace
-            .render_target_path
-            .unwrap_or_else(|| "(no render target)".into());
-        text_tool_response(
-            format!(
-                "✅ Bound this MCP session to OpenSCAD Studio window `{}`.\n\nWorkspace root: {}\nRender target: {}",
-                workspace.window_id, root, render_target
-            ),
-            false,
-        )
-    } else {
-        text_tool_response(
-            format!("The selected Studio window `{selected_window_id}` is no longer available."),
+    let Some(normalized_root) = normalize_workspace_root(folder_path) else {
+        return text_tool_response(
+            format!("Could not resolve workspace folder `{folder_path}`."),
             true,
-        )
+        );
+    };
+
+    let existing_window_id = {
+        let mut locked = inner.lock().unwrap();
+        locked.sessions.entry(session_id.to_string()).or_default();
+        choose_existing_workspace_for_root(&locked, &normalized_root)
+    };
+
+    if let Some(window_id) = existing_window_id {
+        eprintln!(
+            "[mcp] get_or_create_workspace matched existing window={} root={}",
+            window_id, normalized_root
+        );
+        let response = {
+            let mut locked = inner.lock().unwrap();
+            bind_session_to_window(&mut locked, session_id, window_id.clone());
+            let workspace = locked
+                .workspaces
+                .get(&window_id)
+                .map(|entry| entry.descriptor.clone());
+            if let Some(workspace) = workspace {
+                let render_target = workspace
+                    .render_target_path
+                    .unwrap_or_else(|| "(no render target)".into());
+                text_tool_response(
+                    format!(
+                        "✅ Attached this MCP session to the already-open OpenSCAD Studio workspace at {}.\n\nWindow: {}\nRender target: {}",
+                        normalized_root, workspace.window_id, render_target
+                    ),
+                    false,
+                )
+            } else {
+                text_tool_response(
+                    format!(
+                        "OpenSCAD Studio window `{window_id}` was no longer available while attaching the workspace."
+                    ),
+                    true,
+                )
+            }
+        };
+
+        return response;
     }
+
+    let target_window_id = {
+        let locked = inner.lock().unwrap();
+        choose_blank_welcome_window(&locked)
+    };
+
+    let (target_window_id, detail) = if let Some(window_id) = target_window_id {
+        eprintln!(
+            "[mcp] get_or_create_workspace reusing blank welcome window={} root={}",
+            window_id, normalized_root
+        );
+        match dispatch_window_open_request(
+            app,
+            inner,
+            &window_id,
+            WindowOpenRequest::OpenFolder {
+                folder_path: normalized_root.clone(),
+                create_if_empty: true,
+            },
+        ) {
+            Ok(result) => {
+                let opened_root = result
+                    .opened_workspace_root
+                    .as_deref()
+                    .and_then(normalize_workspace_root);
+                if opened_root.as_deref() != Some(normalized_root.as_str()) {
+                    return text_tool_response(
+                        format!(
+                            "OpenSCAD Studio opened the wrong workspace in window `{window_id}`. Expected `{normalized_root}`, got `{}`.",
+                            opened_root.unwrap_or_else(|| "(unknown workspace)".into())
+                        ),
+                        true,
+                    );
+                }
+                (window_id, result.message)
+            }
+            Err(message) => return text_tool_response(message, true),
+        }
+    } else {
+        let (request_id, rx) = create_window_open_request(inner, "pending-new-window");
+        eprintln!(
+            "[mcp] get_or_create_workspace creating new window for root={} request_id={}",
+            normalized_root, request_id
+        );
+        match create_new_window_with_launch_intent(
+            app,
+            WindowLaunchIntent::OpenFolder {
+                request_id: request_id.clone(),
+                folder_path: normalized_root.clone(),
+                create_if_empty: true,
+            },
+        ) {
+            Ok(window_id) => {
+                eprintln!(
+                    "[mcp] get_or_create_workspace created new window={} request_id={}",
+                    window_id, request_id
+                );
+                {
+                    let mut locked = inner.lock().unwrap();
+                    if let Some(pending) = locked.window_open_requests.get_mut(&request_id) {
+                        pending.window_id = window_id.clone();
+                    }
+                }
+                let result = match wait_for_window_open_result(
+                    inner,
+                    &request_id,
+                    rx,
+                    &window_id,
+                    &normalized_root,
+                    Duration::from_secs(120),
+                ) {
+                    Ok(result) => result,
+                    Err(message) => return text_tool_response(message, true),
+                };
+                let opened_root = result
+                    .opened_workspace_root
+                    .as_deref()
+                    .and_then(normalize_workspace_root);
+                if opened_root.as_deref() != Some(normalized_root.as_str()) {
+                    return text_tool_response(
+                        format!(
+                            "OpenSCAD Studio opened the wrong workspace in window `{window_id}`. Expected `{normalized_root}`, got `{}`.",
+                            opened_root.unwrap_or_else(|| "(unknown workspace)".into())
+                        ),
+                        true,
+                    );
+                }
+                let detail = {
+                    let locked = inner.lock().unwrap();
+                    if let Some(workspace) = locked.workspaces.get(&window_id) {
+                        let render_target = workspace
+                            .descriptor
+                            .render_target_path
+                            .clone()
+                            .unwrap_or_else(|| "(no render target)".into());
+                        format!(
+                            "✅ Opened workspace at {}.\n\nRender target: {}",
+                            normalized_root, render_target
+                        )
+                    } else {
+                        result.message
+                    }
+                };
+                (window_id, detail)
+            }
+            Err(error) => {
+                inner
+                    .lock()
+                    .unwrap()
+                    .window_open_requests
+                    .remove(&request_id);
+                return text_tool_response(
+                    format!("Failed to create a new OpenSCAD Studio window: {error}"),
+                    true,
+                );
+            }
+        }
+    };
+
+    let mut locked = inner.lock().unwrap();
+    bind_session_to_window(&mut locked, session_id, target_window_id.clone());
+
+    text_tool_response(
+        format!(
+            "{detail}\n\n✅ Bound this MCP session to OpenSCAD Studio window `{target_window_id}`."
+        ),
+        false,
+    )
 }
 
 fn handle_tool_call(
@@ -642,46 +938,33 @@ fn handle_tool_call(
         .unwrap_or_else(|| Value::Object(Default::default()));
 
     let result = match name {
-        "list_open_workspaces" => {
-            let inner = inner.lock().unwrap();
-            list_open_workspaces_response(&inner)
-        }
-        "select_workspace" => {
-            match session_id.as_deref() {
-                Some(session_id) => {
-                    let mut inner = inner.lock().unwrap();
-                    select_workspace_response(&mut inner, session_id, &arguments)
-                }
-                None => text_tool_response(
-                    "This MCP request does not have a session id yet. Reconnect your MCP client and retry workspace selection.",
-                    true,
-                ),
-            }
-        }
+        "get_or_create_workspace" => match session_id.as_deref() {
+            Some(session_id) => get_or_create_workspace_response(app, inner, session_id, &arguments),
+            None => text_tool_response(
+                "This MCP request does not have a session id yet. Reconnect your MCP client and retry workspace creation.",
+                true,
+            ),
+        },
         "get_project_context" => {
-            let maybe_window_id = {
+            let window_id = {
+                let Some(session_id) = session_id.as_deref() else {
+                    return Ok(RpcOutcome {
+                        response: Some(jsonrpc_result(
+                            id,
+                            serde_json::to_value(text_tool_response(
+                                "No OpenSCAD Studio workspace is selected for this MCP session. Call `get_or_create_workspace(folder_path)` first.",
+                                true,
+                            ))
+                            .expect("serializable MCP tool response"),
+                        )),
+                        session_id: session_id_for_response.clone(),
+                    });
+                };
+
                 let mut inner = inner.lock().unwrap();
-                match session_id.as_deref() {
-                    Some(session_id) => match require_bound_window_id(&mut inner, session_id) {
-                        Ok(window_id) => Some(window_id),
-                        Err(response) => return Ok(RpcOutcome {
-                            response: Some(jsonrpc_result(
-                                id,
-                                serde_json::to_value(response)
-                                    .expect("serializable MCP tool response"),
-                            )),
-                            session_id: session_id_for_response.clone(),
-                        }),
-                    },
-                    None => {
-                        let workspaces = list_open_workspaces_locked(&inner);
-                        let response = text_tool_response(
-                            format!(
-                                "No OpenSCAD Studio workspace is selected for this MCP session.\n\nCall `select_workspace` with a `workspace_root` or `window_id` first.\n\n{}",
-                                format_workspace_list(&workspaces)
-                            ),
-                            true,
-                        );
+                match require_bound_window_id(&mut inner, session_id) {
+                    Ok(window_id) => window_id,
+                    Err(response) => {
                         return Ok(RpcOutcome {
                             response: Some(jsonrpc_result(
                                 id,
@@ -689,7 +972,7 @@ fn handle_tool_call(
                                     .expect("serializable MCP tool response"),
                             )),
                             session_id: session_id_for_response.clone(),
-                        });
+                        })
                     }
                 }
             };
@@ -697,7 +980,7 @@ fn handle_tool_call(
             call_frontend_tool(
                 app,
                 inner,
-                maybe_window_id.as_deref().expect("window id present"),
+                &window_id,
                 name,
                 arguments,
             )
@@ -710,7 +993,7 @@ fn handle_tool_call(
                         response: Some(jsonrpc_result(
                             id,
                             serde_json::to_value(text_tool_response(
-                                "No OpenSCAD Studio workspace is selected for this MCP session. Call `select_workspace` first.",
+                                "No OpenSCAD Studio workspace is selected for this MCP session. Call `get_or_create_workspace(folder_path)` first.",
                                 true,
                             ))
                             .expect("serializable MCP tool response"),
@@ -954,6 +1237,7 @@ pub fn configure_mcp_server(
         let mut inner = state.inner.lock().unwrap();
         inner.status = build_status(false, port, McpServerStateKind::Disabled, None);
         inner.sessions.clear();
+        inner.window_open_requests.clear();
         return Ok(inner.status.clone());
     }
 
@@ -1025,6 +1309,7 @@ pub fn mcp_update_window_context(
         .as_deref()
         .and_then(normalize_workspace_root);
     let title = payload.title.unwrap_or_else(|| "OpenSCAD Studio".into());
+    let render_target_path = payload.render_target_path.clone();
     let is_focused = window.is_focused().unwrap_or(false);
 
     let mut inner = state.inner.lock().unwrap();
@@ -1038,21 +1323,147 @@ pub fn mcp_update_window_context(
             .map(|workspace| workspace.last_focused_order)
             .unwrap_or(0)
     };
+    let previous_bridge_ready = inner
+        .workspaces
+        .get(&label)
+        .map(|workspace| workspace.bridge_ready)
+        .unwrap_or(false);
 
     inner.workspaces.insert(
         label.clone(),
         RegisteredWorkspace {
             descriptor: WorkspaceDescriptor {
-                window_id: label,
+                window_id: label.clone(),
                 title,
                 workspace_root: normalized_root,
-                render_target_path: payload.render_target_path,
+                render_target_path,
                 is_focused,
             },
-            ready: payload.ready,
+            show_welcome: payload.show_welcome,
+            mode: payload.mode.unwrap_or(if payload.show_welcome {
+                RegisteredWindowMode::Welcome
+            } else {
+                RegisteredWindowMode::Ready
+            }),
+            pending_request_id: payload.pending_request_id,
+            context_ready: payload.ready,
+            bridge_ready: previous_bridge_ready,
             last_focused_order: next_focus_order,
         },
     );
+
+    Ok(())
+}
+
+#[tauri::command]
+pub fn mcp_mark_window_bridge_ready(
+    window: Window,
+    state: State<'_, McpServerState>,
+) -> Result<(), String> {
+    let label = window.label().to_string();
+    let is_focused = window.is_focused().unwrap_or(false);
+
+    let mut inner = state.inner.lock().unwrap();
+    let workspace = inner
+        .workspaces
+        .entry(label.clone())
+        .or_insert_with(|| RegisteredWorkspace {
+            descriptor: WorkspaceDescriptor {
+                window_id: label.clone(),
+                title: "OpenSCAD Studio".into(),
+                workspace_root: None,
+                render_target_path: None,
+                is_focused,
+            },
+            show_welcome: true,
+            mode: RegisteredWindowMode::Welcome,
+            pending_request_id: None,
+            context_ready: false,
+            bridge_ready: false,
+            last_focused_order: 0,
+        });
+    workspace.bridge_ready = true;
+
+    Ok(())
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WindowOpenResultPayload {
+    pub request_id: String,
+    pub success: bool,
+    pub message: Option<String>,
+    pub opened_workspace_root: Option<String>,
+}
+
+#[tauri::command]
+pub fn report_window_open_result(
+    window: Window,
+    payload: WindowOpenResultPayload,
+    state: State<'_, McpServerState>,
+) -> Result<(), String> {
+    let label = window.label().to_string();
+    let mut inner = state.inner.lock().unwrap();
+
+    inner
+        .workspaces
+        .entry(label.clone())
+        .or_insert_with(|| RegisteredWorkspace {
+            descriptor: WorkspaceDescriptor {
+                window_id: label.clone(),
+                title: "OpenSCAD Studio".into(),
+                workspace_root: None,
+                render_target_path: None,
+                is_focused: window.is_focused().unwrap_or(false),
+            },
+            show_welcome: true,
+            mode: RegisteredWindowMode::Welcome,
+            pending_request_id: None,
+            context_ready: false,
+            bridge_ready: false,
+            last_focused_order: 0,
+        });
+
+    if let Some(pending) = inner.window_open_requests.remove(&payload.request_id) {
+        if let Some(workspace) = inner.workspaces.get_mut(&label) {
+            workspace.pending_request_id = None;
+            workspace.mode = if payload.success {
+                if payload.opened_workspace_root.is_some() {
+                    workspace.show_welcome = false;
+                    RegisteredWindowMode::Ready
+                } else if workspace.show_welcome {
+                    RegisteredWindowMode::Welcome
+                } else {
+                    RegisteredWindowMode::Ready
+                }
+            } else {
+                RegisteredWindowMode::OpenFailed
+            };
+        }
+        eprintln!(
+            "[mcp] report_window_open_result window={} request_id={} success={} workspace_root={}",
+            label,
+            payload.request_id,
+            payload.success,
+            payload.opened_workspace_root.as_deref().unwrap_or("(none)")
+        );
+        let result = if payload.success {
+            Ok(WindowOpenResult {
+                message: payload
+                    .message
+                    .unwrap_or_else(|| "Opened target successfully.".into()),
+                opened_workspace_root: payload
+                    .opened_workspace_root
+                    .as_deref()
+                    .and_then(normalize_workspace_root),
+            })
+        } else {
+            Err(payload
+                .message
+                .unwrap_or_else(|| "Failed to open the requested target.".into()))
+        };
+        let _ = pending.sender.send(result);
+    }
 
     Ok(())
 }
@@ -1080,7 +1491,12 @@ pub fn remove_window(state: &McpServerState, window_id: &str) {
 mod tests {
     use super::*;
 
-    fn workspace(window_id: &str, root: Option<&str>, title: &str) -> RegisteredWorkspace {
+    fn workspace(
+        window_id: &str,
+        root: Option<&str>,
+        title: &str,
+        show_welcome: bool,
+    ) -> RegisteredWorkspace {
         RegisteredWorkspace {
             descriptor: WorkspaceDescriptor {
                 window_id: window_id.into(),
@@ -1089,7 +1505,15 @@ mod tests {
                 render_target_path: Some("main.scad".into()),
                 is_focused: false,
             },
-            ready: true,
+            show_welcome,
+            mode: if show_welcome {
+                RegisteredWindowMode::Welcome
+            } else {
+                RegisteredWindowMode::Ready
+            },
+            pending_request_id: None,
+            context_ready: true,
+            bridge_ready: true,
             last_focused_order: 0,
         }
     }
@@ -1099,6 +1523,7 @@ mod tests {
         let mut inner = McpStateInner {
             running_server: None,
             pending: HashMap::new(),
+            window_open_requests: HashMap::new(),
             status: build_status(false, MCP_DEFAULT_PORT, McpServerStateKind::Disabled, None),
             workspaces: HashMap::new(),
             sessions: HashMap::new(),
@@ -1112,37 +1537,11 @@ mod tests {
     }
 
     #[test]
-    fn select_workspace_binds_by_window_id() {
-        let mut inner = McpStateInner {
-            running_server: None,
-            pending: HashMap::new(),
-            status: build_status(false, MCP_DEFAULT_PORT, McpServerStateKind::Disabled, None),
-            workspaces: HashMap::from([(
-                "window-a".into(),
-                workspace("window-a", Some("/tmp/project-a"), "Project A"),
-            )]),
-            sessions: HashMap::from([("session-1".into(), McpSessionBinding::default())]),
-            next_focus_order: 0,
-        };
-
-        let response =
-            select_workspace_response(&mut inner, "session-1", &json!({ "window_id": "window-a" }));
-
-        assert!(!response.is_error);
-        assert_eq!(
-            inner
-                .sessions
-                .get("session-1")
-                .and_then(|session| session.bound_window_id.clone()),
-            Some("window-a".into())
-        );
-    }
-
-    #[test]
     fn require_bound_window_id_errors_when_unbound() {
         let mut inner = McpStateInner {
             running_server: None,
             pending: HashMap::new(),
+            window_open_requests: HashMap::new(),
             status: build_status(false, MCP_DEFAULT_PORT, McpServerStateKind::Disabled, None),
             workspaces: HashMap::new(),
             sessions: HashMap::from([("session-1".into(), McpSessionBinding::default())]),
@@ -1153,7 +1552,7 @@ mod tests {
         assert!(response.is_error);
         assert!(matches!(
             response.content.first(),
-            Some(McpContentItem::Text { text }) if text.contains("No OpenSCAD Studio workspace is selected")
+            Some(McpContentItem::Text { text }) if text.contains("get_or_create_workspace")
         ));
     }
 
@@ -1162,10 +1561,11 @@ mod tests {
         let mut inner = McpStateInner {
             running_server: None,
             pending: HashMap::new(),
+            window_open_requests: HashMap::new(),
             status: build_status(false, MCP_DEFAULT_PORT, McpServerStateKind::Disabled, None),
             workspaces: HashMap::from([(
                 "window-a".into(),
-                workspace("window-a", Some("/tmp/project-a"), "Project A"),
+                workspace("window-a", Some("/tmp/project-a"), "Project A", false),
             )]),
             sessions: HashMap::from([(
                 "session-1".into(),
@@ -1186,5 +1586,127 @@ mod tests {
                 .and_then(|session| session.bound_window_id.clone()),
             None
         );
+    }
+
+    #[test]
+    fn choose_existing_workspace_for_root_prefers_matching_workspace() {
+        let inner = McpStateInner {
+            running_server: None,
+            pending: HashMap::new(),
+            window_open_requests: HashMap::new(),
+            status: build_status(false, MCP_DEFAULT_PORT, McpServerStateKind::Disabled, None),
+            workspaces: HashMap::from([
+                (
+                    "window-a".into(),
+                    workspace("window-a", Some("/tmp/project-a"), "Project A", false),
+                ),
+                (
+                    "window-b".into(),
+                    workspace("window-b", None, "Welcome", true),
+                ),
+            ]),
+            sessions: HashMap::new(),
+            next_focus_order: 0,
+        };
+
+        assert_eq!(
+            choose_existing_workspace_for_root(&inner, "/tmp/project-a"),
+            Some("window-a".into())
+        );
+    }
+
+    #[test]
+    fn choose_blank_welcome_window_ignores_non_welcome_windows_without_roots() {
+        let inner = McpStateInner {
+            running_server: None,
+            pending: HashMap::new(),
+            window_open_requests: HashMap::new(),
+            status: build_status(false, MCP_DEFAULT_PORT, McpServerStateKind::Disabled, None),
+            workspaces: HashMap::from([
+                (
+                    "window-a".into(),
+                    workspace("window-a", None, "Unsaved Scratch", false),
+                ),
+                (
+                    "window-b".into(),
+                    workspace("window-b", None, "Welcome", true),
+                ),
+            ]),
+            sessions: HashMap::new(),
+            next_focus_order: 0,
+        };
+
+        assert_eq!(choose_blank_welcome_window(&inner), Some("window-b".into()));
+    }
+
+    #[test]
+    fn wait_for_window_tool_ready_requires_bridge_listener() {
+        let inner = Arc::new(Mutex::new(McpStateInner {
+            running_server: None,
+            pending: HashMap::new(),
+            window_open_requests: HashMap::new(),
+            status: build_status(false, MCP_DEFAULT_PORT, McpServerStateKind::Disabled, None),
+            workspaces: HashMap::from([(
+                "main".into(),
+                RegisteredWorkspace {
+                    descriptor: WorkspaceDescriptor {
+                        window_id: "main".into(),
+                        title: "Project".into(),
+                        workspace_root: Some("/tmp/project".into()),
+                        render_target_path: Some("main.scad".into()),
+                        is_focused: true,
+                    },
+                    show_welcome: false,
+                    mode: RegisteredWindowMode::Ready,
+                    pending_request_id: None,
+                    context_ready: true,
+                    bridge_ready: false,
+                    last_focused_order: 1,
+                },
+            )]),
+            sessions: HashMap::new(),
+            next_focus_order: 0,
+        }));
+
+        let result = wait_for_window_tool_ready(&inner, "main", Duration::from_millis(0));
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("finish starting its MCP bridge"));
+    }
+
+    #[test]
+    fn wait_for_window_tool_ready_succeeds_when_context_and_bridge_are_ready() {
+        let inner = Arc::new(Mutex::new(McpStateInner {
+            running_server: None,
+            pending: HashMap::new(),
+            window_open_requests: HashMap::new(),
+            status: build_status(false, MCP_DEFAULT_PORT, McpServerStateKind::Disabled, None),
+            workspaces: HashMap::from([(
+                "main".into(),
+                RegisteredWorkspace {
+                    descriptor: WorkspaceDescriptor {
+                        window_id: "main".into(),
+                        title: "Project".into(),
+                        workspace_root: Some("/tmp/project".into()),
+                        render_target_path: Some("main.scad".into()),
+                        is_focused: true,
+                    },
+                    show_welcome: false,
+                    mode: RegisteredWindowMode::Ready,
+                    pending_request_id: None,
+                    context_ready: true,
+                    bridge_ready: true,
+                    last_focused_order: 1,
+                },
+            )]),
+            sessions: HashMap::new(),
+            next_focus_order: 0,
+        }));
+
+        let result = wait_for_window_tool_ready(&inner, "main", Duration::from_millis(0));
+
+        assert!(result.is_ok());
     }
 }

--- a/apps/ui/src-tauri/src/mcp.rs
+++ b/apps/ui/src-tauri/src/mcp.rs
@@ -92,6 +92,10 @@ pub enum WindowLaunchIntent {
         request_id: String,
         folder_path: String,
         create_if_empty: bool,
+        /// Pre-read .scad file contents (relative path → content).
+        /// Avoids FS plugin IPC calls from secondary windows.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        files: Option<std::collections::HashMap<String, String>>,
     },
     OpenFile {
         request_id: String,
@@ -132,12 +136,21 @@ pub struct WindowContextPayload {
     pub ready: bool,
 }
 
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WindowStartupPhasePayload {
+    pub phase: String,
+    pub detail: Option<String>,
+}
+
 #[derive(Clone, Debug)]
 struct RegisteredWorkspace {
     descriptor: WorkspaceDescriptor,
     show_welcome: bool,
     mode: RegisteredWindowMode,
     pending_request_id: Option<String>,
+    startup_phase: String,
+    startup_detail: Option<String>,
     context_ready: bool,
     bridge_ready: bool,
     last_focused_order: u64,
@@ -207,6 +220,74 @@ impl Default for McpServerState {
             })),
         }
     }
+}
+
+/// Read all `.scad` files from a directory tree, returning relative path → content.
+fn read_scad_files(dir: &std::path::Path) -> std::collections::HashMap<String, String> {
+    use std::collections::HashMap;
+    let mut files = HashMap::new();
+
+    fn walk(
+        base: &std::path::Path,
+        current: &std::path::Path,
+        files: &mut HashMap<String, String>,
+    ) {
+        let Ok(entries) = std::fs::read_dir(current) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+            if name_str.starts_with('.') {
+                continue;
+            }
+            if path.is_dir() {
+                walk(base, &path, files);
+            } else if name_str.ends_with(".scad") {
+                if let Ok(content) = std::fs::read_to_string(&path) {
+                    if let Ok(rel) = path.strip_prefix(base) {
+                        files.insert(rel.to_string_lossy().into_owned(), content);
+                    }
+                }
+            }
+        }
+    }
+
+    walk(dir, dir, &mut files);
+    files
+}
+
+pub(crate) fn record_window_startup_phase(
+    state: &McpServerState,
+    window_label: &str,
+    phase: impl Into<String>,
+    detail: Option<String>,
+) {
+    let phase = phase.into();
+    let mut inner = state.inner.lock().unwrap();
+    let workspace = inner
+        .workspaces
+        .entry(window_label.to_string())
+        .or_insert_with(|| RegisteredWorkspace {
+            descriptor: WorkspaceDescriptor {
+                window_id: window_label.to_string(),
+                title: "OpenSCAD Studio".into(),
+                workspace_root: None,
+                render_target_path: None,
+                is_focused: false,
+            },
+            show_welcome: true,
+            mode: RegisteredWindowMode::Welcome,
+            pending_request_id: None,
+            startup_phase: "created".into(),
+            startup_detail: None,
+            context_ready: false,
+            bridge_ready: false,
+            last_focused_order: 0,
+        });
+    workspace.startup_phase = phase;
+    workspace.startup_detail = detail;
 }
 
 struct RpcOutcome {
@@ -354,6 +435,15 @@ fn choose_blank_welcome_window(inner: &McpStateInner) -> Option<String> {
         .map(|(window_id, _)| window_id.clone())
 }
 
+fn describe_workspace_startup_phase(workspace: &RegisteredWorkspace) -> String {
+    match &workspace.startup_detail {
+        Some(detail) if !detail.trim().is_empty() => {
+            format!("last startup phase: {} ({detail})", workspace.startup_phase)
+        }
+        _ => format!("last startup phase: {}", workspace.startup_phase),
+    }
+}
+
 fn bind_session_to_window(inner: &mut McpStateInner, session_id: &str, window_id: String) {
     inner
         .sessions
@@ -382,8 +472,15 @@ fn wait_for_window_tool_ready(
         }
 
         if Instant::now() >= deadline {
+            let phase = inner
+                .lock()
+                .unwrap()
+                .workspaces
+                .get(window_id)
+                .map(describe_workspace_startup_phase)
+                .unwrap_or_else(|| "last startup phase: unknown".into());
             return Err(format!(
-                "Timed out waiting for OpenSCAD Studio window `{window_id}` to finish starting its MCP bridge."
+                "Timed out waiting for OpenSCAD Studio window `{window_id}` to finish starting its MCP bridge ({phase})."
             ));
         }
 
@@ -532,13 +629,17 @@ fn wait_for_window_open_result(
     match rx.recv_timeout(timeout) {
         Ok(result) => result,
         Err(mpsc::RecvTimeoutError::Timeout) => {
-            inner
-                .lock()
-                .unwrap()
-                .window_open_requests
-                .remove(request_id);
+            let phase = {
+                let mut locked = inner.lock().unwrap();
+                locked.window_open_requests.remove(request_id);
+                locked
+                    .workspaces
+                    .get(window_id)
+                    .map(describe_workspace_startup_phase)
+                    .unwrap_or_else(|| "last startup phase: unknown".into())
+            };
             Err(format!(
-                "Timed out waiting for OpenSCAD Studio to open `{target_description}` in window `{window_id}`."
+                "Timed out waiting for OpenSCAD Studio to open `{target_description}` in window `{window_id}` ({phase})."
             ))
         }
         Err(mpsc::RecvTimeoutError::Disconnected) => {
@@ -825,71 +926,28 @@ fn get_or_create_workspace_response(
             Err(message) => return text_tool_response(message, true),
         }
     } else {
+        // Create a new window with the open-folder intent baked into the
+        // initialization script. The window consumes the intent during its
+        // own bootstrap and reports back via report_window_open_result.
         let (request_id, rx) = create_window_open_request(inner, "pending-new-window");
-        eprintln!(
-            "[mcp] get_or_create_workspace creating new window for root={} request_id={}",
-            normalized_root, request_id
-        );
-        match create_new_window_with_launch_intent(
+        // Pre-read .scad files so the secondary window doesn't need FS plugin IPC.
+        let pre_read = read_scad_files(std::path::Path::new(&normalized_root));
+        let files = if pre_read.is_empty() { None } else { Some(pre_read) };
+        let window_id = match create_new_window_with_launch_intent(
             app,
             WindowLaunchIntent::OpenFolder {
                 request_id: request_id.clone(),
                 folder_path: normalized_root.clone(),
                 create_if_empty: true,
+                files,
             },
         ) {
-            Ok(window_id) => {
-                eprintln!(
-                    "[mcp] get_or_create_workspace created new window={} request_id={}",
-                    window_id, request_id
-                );
-                {
-                    let mut locked = inner.lock().unwrap();
-                    if let Some(pending) = locked.window_open_requests.get_mut(&request_id) {
-                        pending.window_id = window_id.clone();
-                    }
+            Ok(id) => {
+                let mut locked = inner.lock().unwrap();
+                if let Some(pending) = locked.window_open_requests.get_mut(&request_id) {
+                    pending.window_id = id.clone();
                 }
-                let result = match wait_for_window_open_result(
-                    inner,
-                    &request_id,
-                    rx,
-                    &window_id,
-                    &normalized_root,
-                    Duration::from_secs(120),
-                ) {
-                    Ok(result) => result,
-                    Err(message) => return text_tool_response(message, true),
-                };
-                let opened_root = result
-                    .opened_workspace_root
-                    .as_deref()
-                    .and_then(normalize_workspace_root);
-                if opened_root.as_deref() != Some(normalized_root.as_str()) {
-                    return text_tool_response(
-                        format!(
-                            "OpenSCAD Studio opened the wrong workspace in window `{window_id}`. Expected `{normalized_root}`, got `{}`.",
-                            opened_root.unwrap_or_else(|| "(unknown workspace)".into())
-                        ),
-                        true,
-                    );
-                }
-                let detail = {
-                    let locked = inner.lock().unwrap();
-                    if let Some(workspace) = locked.workspaces.get(&window_id) {
-                        let render_target = workspace
-                            .descriptor
-                            .render_target_path
-                            .clone()
-                            .unwrap_or_else(|| "(no render target)".into());
-                        format!(
-                            "✅ Opened workspace at {}.\n\nRender target: {}",
-                            normalized_root, render_target
-                        )
-                    } else {
-                        result.message
-                    }
-                };
-                (window_id, detail)
+                id
             }
             Err(error) => {
                 inner
@@ -902,7 +960,33 @@ fn get_or_create_workspace_response(
                     true,
                 );
             }
+        };
+
+        let result = match wait_for_window_open_result(
+            inner,
+            &request_id,
+            rx,
+            &window_id,
+            &normalized_root,
+            Duration::from_secs(120),
+        ) {
+            Ok(result) => result,
+            Err(message) => return text_tool_response(message, true),
+        };
+        let opened_root = result
+            .opened_workspace_root
+            .as_deref()
+            .and_then(normalize_workspace_root);
+        if opened_root.as_deref() != Some(normalized_root.as_str()) {
+            return text_tool_response(
+                format!(
+                    "OpenSCAD Studio opened the wrong workspace in window `{window_id}`. Expected `{normalized_root}`, got `{}`.",
+                    opened_root.unwrap_or_else(|| "(unknown workspace)".into())
+                ),
+                true,
+            );
         }
+        (window_id, result.message)
     };
 
     let mut locked = inner.lock().unwrap();
@@ -914,6 +998,58 @@ fn get_or_create_workspace_response(
         ),
         false,
     )
+}
+
+fn get_project_context_response(
+    inner: &Arc<Mutex<McpStateInner>>,
+    session_id: Option<&str>,
+) -> McpToolResponse {
+    let Some(session_id) = session_id else {
+        return text_tool_response(
+            "No OpenSCAD Studio workspace is selected for this MCP session. Call `get_or_create_workspace(folder_path)` first.",
+            true,
+        );
+    };
+
+    let mut locked = inner.lock().unwrap();
+    let window_id = match require_bound_window_id(&mut locked, session_id) {
+        Ok(window_id) => window_id,
+        Err(response) => return response,
+    };
+
+    let Some(workspace) = locked.workspaces.get(&window_id) else {
+        return text_tool_response(
+            format!(
+                "The previously selected Studio window `{window_id}` is no longer available. Call `get_or_create_workspace(folder_path)` again."
+            ),
+            true,
+        );
+    };
+
+    let mut parts = vec![format!("Studio window: {}", workspace.descriptor.title)];
+
+    if let Some(workspace_root) = &workspace.descriptor.workspace_root {
+        parts.push(format!("Workspace root: {workspace_root}"));
+    } else {
+        parts.push("Workspace root: (none)".into());
+    }
+
+    if let Some(render_target_path) = &workspace.descriptor.render_target_path {
+        parts.push(format!("Render target: {render_target_path}"));
+    } else {
+        parts.push("Render target: (none)".into());
+    }
+
+    let mode = match workspace.mode {
+        RegisteredWindowMode::Welcome => "welcome",
+        RegisteredWindowMode::Opening => "opening",
+        RegisteredWindowMode::Ready => "ready",
+        RegisteredWindowMode::OpenFailed => "open_failed",
+    };
+    parts.push(format!("Window mode: {mode}"));
+    parts.push(describe_workspace_startup_phase(workspace));
+
+    text_tool_response(parts.join("\n"), false)
 }
 
 fn handle_tool_call(
@@ -945,47 +1081,7 @@ fn handle_tool_call(
                 true,
             ),
         },
-        "get_project_context" => {
-            let window_id = {
-                let Some(session_id) = session_id.as_deref() else {
-                    return Ok(RpcOutcome {
-                        response: Some(jsonrpc_result(
-                            id,
-                            serde_json::to_value(text_tool_response(
-                                "No OpenSCAD Studio workspace is selected for this MCP session. Call `get_or_create_workspace(folder_path)` first.",
-                                true,
-                            ))
-                            .expect("serializable MCP tool response"),
-                        )),
-                        session_id: session_id_for_response.clone(),
-                    });
-                };
-
-                let mut inner = inner.lock().unwrap();
-                match require_bound_window_id(&mut inner, session_id) {
-                    Ok(window_id) => window_id,
-                    Err(response) => {
-                        return Ok(RpcOutcome {
-                            response: Some(jsonrpc_result(
-                                id,
-                                serde_json::to_value(response)
-                                    .expect("serializable MCP tool response"),
-                            )),
-                            session_id: session_id_for_response.clone(),
-                        })
-                    }
-                }
-            };
-
-            call_frontend_tool(
-                app,
-                inner,
-                &window_id,
-                name,
-                arguments,
-            )
-            .unwrap_or_else(|message| text_tool_response(message, true))
-        }
+        "get_project_context" => get_project_context_response(inner, session_id.as_deref()),
         _ => {
             let window_id = {
                 let Some(session_id) = session_id.as_deref() else {
@@ -1279,90 +1375,30 @@ pub fn get_mcp_server_status(state: State<'_, McpServerState>) -> Result<McpServ
     Ok(state.inner.lock().unwrap().status.clone())
 }
 
-#[tauri::command]
-pub fn mcp_submit_tool_response(
-    request_id: String,
-    response: McpToolResponse,
-    state: State<'_, McpServerState>,
-) -> Result<(), String> {
-    let sender = state.inner.lock().unwrap().pending.remove(&request_id);
-    let Some(sender) = sender else {
-        return Err(format!(
-            "No pending MCP tool request found for {request_id}."
-        ));
-    };
+// ── Event-based handlers (used instead of invoke for secondary-window compat) ──
 
-    sender
-        .send(response)
-        .map_err(|error| format!("Failed to send MCP tool response: {error}"))
+fn parse_event<T: serde::de::DeserializeOwned>(raw: &str) -> Option<T> {
+    serde_json::from_str(raw)
+        .map_err(|e| eprintln!("[mcp] Failed to parse event payload: {e}"))
+        .ok()
 }
 
-#[tauri::command]
-pub fn mcp_update_window_context(
-    window: Window,
-    payload: WindowContextPayload,
-    state: State<'_, McpServerState>,
-) -> Result<(), String> {
-    let label = window.label().to_string();
-    let normalized_root = payload
-        .workspace_root
-        .as_deref()
-        .and_then(normalize_workspace_root);
-    let title = payload.title.unwrap_or_else(|| "OpenSCAD Studio".into());
-    let render_target_path = payload.render_target_path.clone();
-    let is_focused = window.is_focused().unwrap_or(false);
-
-    let mut inner = state.inner.lock().unwrap();
-    let next_focus_order = if is_focused {
-        inner.next_focus_order += 1;
-        inner.next_focus_order
-    } else {
-        inner
-            .workspaces
-            .get(&label)
-            .map(|workspace| workspace.last_focused_order)
-            .unwrap_or(0)
-    };
-    let previous_bridge_ready = inner
-        .workspaces
-        .get(&label)
-        .map(|workspace| workspace.bridge_ready)
-        .unwrap_or(false);
-
-    inner.workspaces.insert(
-        label.clone(),
-        RegisteredWorkspace {
-            descriptor: WorkspaceDescriptor {
-                window_id: label.clone(),
-                title,
-                workspace_root: normalized_root,
-                render_target_path,
-                is_focused,
-            },
-            show_welcome: payload.show_welcome,
-            mode: payload.mode.unwrap_or(if payload.show_welcome {
-                RegisteredWindowMode::Welcome
-            } else {
-                RegisteredWindowMode::Ready
-            }),
-            pending_request_id: payload.pending_request_id,
-            context_ready: payload.ready,
-            bridge_ready: previous_bridge_ready,
-            last_focused_order: next_focus_order,
-        },
-    );
-
-    Ok(())
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct EventEnvelope<T> {
+    window_label: String,
+    #[serde(flatten)]
+    inner: T,
 }
 
-#[tauri::command]
-pub fn mcp_mark_window_bridge_ready(
-    window: Window,
-    state: State<'_, McpServerState>,
-) -> Result<(), String> {
-    let label = window.label().to_string();
-    let is_focused = window.is_focused().unwrap_or(false);
+#[derive(Deserialize)]
+struct EmptyPayload {}
 
+pub fn handle_bridge_ready_event(state: &McpServerState, raw: &str) {
+    let Some(env) = parse_event::<EventEnvelope<EmptyPayload>>(raw) else {
+        return;
+    };
+    let label = env.window_label;
     let mut inner = state.inner.lock().unwrap();
     let workspace = inner
         .workspaces
@@ -1373,36 +1409,105 @@ pub fn mcp_mark_window_bridge_ready(
                 title: "OpenSCAD Studio".into(),
                 workspace_root: None,
                 render_target_path: None,
-                is_focused,
+                is_focused: false,
             },
             show_welcome: true,
             mode: RegisteredWindowMode::Welcome,
             pending_request_id: None,
+            startup_phase: "created".into(),
+            startup_detail: None,
             context_ready: false,
             bridge_ready: false,
             last_focused_order: 0,
         });
     workspace.bridge_ready = true;
-
-    Ok(())
+    workspace.startup_phase = "bridge_ready".into();
+    workspace.startup_detail = None;
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct WindowOpenResultPayload {
-    pub request_id: String,
-    pub success: bool,
-    pub message: Option<String>,
-    pub opened_workspace_root: Option<String>,
+struct ToolResponsePayload {
+    request_id: String,
+    response: McpToolResponse,
 }
 
-#[tauri::command]
-pub fn report_window_open_result(
-    window: Window,
-    payload: WindowOpenResultPayload,
-    state: State<'_, McpServerState>,
-) -> Result<(), String> {
-    let label = window.label().to_string();
+pub fn handle_tool_response_event(state: &McpServerState, raw: &str) {
+    let Some(env) = parse_event::<EventEnvelope<ToolResponsePayload>>(raw) else {
+        return;
+    };
+    let sender = state.inner.lock().unwrap().pending.remove(&env.inner.request_id);
+    if let Some(sender) = sender {
+        let _ = sender.send(env.inner.response);
+    }
+}
+
+pub fn handle_window_context_event(state: &McpServerState, raw: &str) {
+    let Some(env) = parse_event::<EventEnvelope<WindowContextPayload>>(raw) else {
+        return;
+    };
+    let label = env.window_label;
+    let payload = env.inner;
+    let normalized_root = payload
+        .workspace_root
+        .as_deref()
+        .and_then(normalize_workspace_root);
+    let title = payload.title.unwrap_or_else(|| "OpenSCAD Studio".into());
+    let render_target_path = payload.render_target_path.clone();
+
+    let mut inner = state.inner.lock().unwrap();
+    let next_focus_order = inner
+        .workspaces
+        .get(&label)
+        .map(|w| w.last_focused_order)
+        .unwrap_or(0);
+    let previous_bridge_ready = inner
+        .workspaces
+        .get(&label)
+        .map(|w| w.bridge_ready)
+        .unwrap_or(false);
+    let previous_startup_phase = inner
+        .workspaces
+        .get(&label)
+        .map(|w| w.startup_phase.clone())
+        .unwrap_or_else(|| "context_updated".into());
+    let previous_startup_detail = inner
+        .workspaces
+        .get(&label)
+        .and_then(|w| w.startup_detail.clone());
+
+    inner.workspaces.insert(
+        label.clone(),
+        RegisteredWorkspace {
+            descriptor: WorkspaceDescriptor {
+                window_id: label,
+                title,
+                workspace_root: normalized_root,
+                render_target_path,
+                is_focused: false,
+            },
+            show_welcome: payload.show_welcome,
+            mode: payload.mode.unwrap_or(if payload.show_welcome {
+                RegisteredWindowMode::Welcome
+            } else {
+                RegisteredWindowMode::Ready
+            }),
+            pending_request_id: payload.pending_request_id,
+            startup_phase: previous_startup_phase,
+            startup_detail: previous_startup_detail,
+            context_ready: payload.ready,
+            bridge_ready: previous_bridge_ready,
+            last_focused_order: next_focus_order,
+        },
+    );
+}
+
+pub fn handle_window_open_result_event(state: &McpServerState, raw: &str) {
+    let Some(env) = parse_event::<EventEnvelope<WindowOpenResultPayload>>(raw) else {
+        return;
+    };
+    let label = env.window_label;
+    let payload = env.inner;
     let mut inner = state.inner.lock().unwrap();
 
     inner
@@ -1414,11 +1519,13 @@ pub fn report_window_open_result(
                 title: "OpenSCAD Studio".into(),
                 workspace_root: None,
                 render_target_path: None,
-                is_focused: window.is_focused().unwrap_or(false),
+                is_focused: false,
             },
             show_welcome: true,
             mode: RegisteredWindowMode::Welcome,
             pending_request_id: None,
+            startup_phase: "created".into(),
+            startup_detail: None,
             context_ready: false,
             bridge_ready: false,
             last_focused_order: 0,
@@ -1439,14 +1546,14 @@ pub fn report_window_open_result(
             } else {
                 RegisteredWindowMode::OpenFailed
             };
+            workspace.startup_phase = if payload.success {
+                "open_request_succeeded".into()
+            } else {
+                "open_request_failed".into()
+            };
+            workspace.startup_detail = payload.message.clone();
         }
-        eprintln!(
-            "[mcp] report_window_open_result window={} request_id={} success={} workspace_root={}",
-            label,
-            payload.request_id,
-            payload.success,
-            payload.opened_workspace_root.as_deref().unwrap_or("(none)")
-        );
+
         let result = if payload.success {
             Ok(WindowOpenResult {
                 message: payload
@@ -1460,11 +1567,155 @@ pub fn report_window_open_result(
         } else {
             Err(payload
                 .message
-                .unwrap_or_else(|| "Failed to open the requested target.".into()))
+                .unwrap_or_else(|| "Failed to open target.".into()))
         };
         let _ = pending.sender.send(result);
     }
+}
 
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct StartupPhaseEventPayload {
+    phase: String,
+    detail: Option<String>,
+}
+
+pub fn handle_window_startup_phase_event(state: &McpServerState, raw: &str) {
+    let Some(env) = parse_event::<EventEnvelope<StartupPhaseEventPayload>>(raw) else {
+        return;
+    };
+    record_window_startup_phase(state, &env.window_label, env.inner.phase, env.inner.detail);
+}
+
+// ── Tauri command handlers (invoke-based) ──
+
+#[tauri::command]
+pub async fn mcp_submit_tool_response(
+    request_id: String,
+    response: McpToolResponse,
+    state: State<'_, McpServerState>,
+) -> Result<(), String> {
+    let sender = state.inner.lock().unwrap().pending.remove(&request_id);
+    let Some(sender) = sender else {
+        return Err(format!("No pending MCP tool request found for {request_id}."));
+    };
+    sender
+        .send(response)
+        .map_err(|error| format!("Failed to send MCP tool response: {error}"))
+}
+
+#[tauri::command]
+pub async fn mcp_update_window_context(
+    window: Window,
+    payload: WindowContextPayload,
+    state: State<'_, McpServerState>,
+) -> Result<(), String> {
+    let label = window.label().to_string();
+    let normalized_root = payload.workspace_root.as_deref().and_then(normalize_workspace_root);
+    let title = payload.title.unwrap_or_else(|| "OpenSCAD Studio".into());
+    let render_target_path = payload.render_target_path.clone();
+    let is_focused = window.is_focused().unwrap_or(false);
+
+    let mut inner = state.inner.lock().unwrap();
+    let next_focus_order = if is_focused {
+        inner.next_focus_order += 1;
+        inner.next_focus_order
+    } else {
+        inner.workspaces.get(&label).map(|w| w.last_focused_order).unwrap_or(0)
+    };
+    let previous_bridge_ready = inner.workspaces.get(&label).map(|w| w.bridge_ready).unwrap_or(false);
+    let previous_startup_phase = inner.workspaces.get(&label).map(|w| w.startup_phase.clone()).unwrap_or_else(|| "context_updated".into());
+    let previous_startup_detail = inner.workspaces.get(&label).and_then(|w| w.startup_detail.clone());
+
+    inner.workspaces.insert(label.clone(), RegisteredWorkspace {
+        descriptor: WorkspaceDescriptor { window_id: label, title, workspace_root: normalized_root, render_target_path, is_focused },
+        show_welcome: payload.show_welcome,
+        mode: payload.mode.unwrap_or(if payload.show_welcome { RegisteredWindowMode::Welcome } else { RegisteredWindowMode::Ready }),
+        pending_request_id: payload.pending_request_id,
+        startup_phase: previous_startup_phase,
+        startup_detail: previous_startup_detail,
+        context_ready: payload.ready,
+        bridge_ready: previous_bridge_ready,
+        last_focused_order: next_focus_order,
+    });
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn mcp_mark_window_bridge_ready(
+    window: Window,
+    state: State<'_, McpServerState>,
+) -> Result<(), String> {
+    let label = window.label().to_string();
+    let is_focused = window.is_focused().unwrap_or(false);
+    let mut inner = state.inner.lock().unwrap();
+    let workspace = inner.workspaces.entry(label.clone()).or_insert_with(|| RegisteredWorkspace {
+        descriptor: WorkspaceDescriptor { window_id: label, title: "OpenSCAD Studio".into(), workspace_root: None, render_target_path: None, is_focused },
+        show_welcome: true, mode: RegisteredWindowMode::Welcome, pending_request_id: None,
+        startup_phase: "created".into(), startup_detail: None,
+        context_ready: false, bridge_ready: false, last_focused_order: 0,
+    });
+    workspace.bridge_ready = true;
+    workspace.startup_phase = "bridge_ready".into();
+    workspace.startup_detail = None;
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn mcp_report_window_startup_phase(
+    window: Window,
+    payload: WindowStartupPhasePayload,
+    state: State<'_, McpServerState>,
+) -> Result<(), String> {
+    record_window_startup_phase(&state, window.label(), payload.phase, payload.detail);
+    Ok(())
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WindowOpenResultPayload {
+    pub request_id: String,
+    pub success: bool,
+    pub message: Option<String>,
+    pub opened_workspace_root: Option<String>,
+}
+
+#[tauri::command]
+pub async fn report_window_open_result(
+    window: Window,
+    payload: WindowOpenResultPayload,
+    state: State<'_, McpServerState>,
+) -> Result<(), String> {
+    let label = window.label().to_string();
+    let mut inner = state.inner.lock().unwrap();
+    inner.workspaces.entry(label.clone()).or_insert_with(|| RegisteredWorkspace {
+        descriptor: WorkspaceDescriptor { window_id: label.clone(), title: "OpenSCAD Studio".into(), workspace_root: None, render_target_path: None, is_focused: false },
+        show_welcome: true, mode: RegisteredWindowMode::Welcome, pending_request_id: None,
+        startup_phase: "created".into(), startup_detail: None,
+        context_ready: false, bridge_ready: false, last_focused_order: 0,
+    });
+
+    if let Some(pending) = inner.window_open_requests.remove(&payload.request_id) {
+        if let Some(workspace) = inner.workspaces.get_mut(&label) {
+            workspace.pending_request_id = None;
+            workspace.mode = if payload.success {
+                if payload.opened_workspace_root.is_some() { workspace.show_welcome = false; RegisteredWindowMode::Ready }
+                else if workspace.show_welcome { RegisteredWindowMode::Welcome }
+                else { RegisteredWindowMode::Ready }
+            } else { RegisteredWindowMode::OpenFailed };
+            workspace.startup_phase = if payload.success { "open_request_succeeded".into() } else { "open_request_failed".into() };
+            workspace.startup_detail = payload.message.clone();
+        }
+        let result = if payload.success {
+            Ok(WindowOpenResult {
+                message: payload.message.unwrap_or_else(|| "Opened target successfully.".into()),
+                opened_workspace_root: payload.opened_workspace_root.as_deref().and_then(normalize_workspace_root),
+            })
+        } else {
+            Err(payload.message.unwrap_or_else(|| "Failed to open target.".into()))
+        };
+        let _ = pending.sender.send(result);
+    }
     Ok(())
 }
 
@@ -1512,6 +1763,12 @@ mod tests {
                 RegisteredWindowMode::Ready
             },
             pending_request_id: None,
+            startup_phase: if show_welcome {
+                "welcome_ready".into()
+            } else {
+                "ready".into()
+            },
+            startup_detail: None,
             context_ready: true,
             bridge_ready: true,
             last_focused_order: 0,
@@ -1659,6 +1916,8 @@ mod tests {
                     show_welcome: false,
                     mode: RegisteredWindowMode::Ready,
                     pending_request_id: None,
+                    startup_phase: "ready".into(),
+                    startup_detail: None,
                     context_ready: true,
                     bridge_ready: false,
                     last_focused_order: 1,
@@ -1696,6 +1955,8 @@ mod tests {
                     show_welcome: false,
                     mode: RegisteredWindowMode::Ready,
                     pending_request_id: None,
+                    startup_phase: "ready".into(),
+                    startup_detail: None,
                     context_ready: true,
                     bridge_ready: true,
                     last_focused_order: 1,

--- a/apps/ui/src-tauri/src/mcp.rs
+++ b/apps/ui/src-tauri/src/mcp.rs
@@ -1,12 +1,11 @@
 use rmcp::{
-    ErrorData as McpError, ServerHandler,
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
     model::{CallToolResult, Content, ServerCapabilities, ServerInfo},
     schemars, tool, tool_handler, tool_router,
     transport::streamable_http_server::{
-        StreamableHttpServerConfig, StreamableHttpService,
-        session::local::LocalSessionManager,
+        session::local::LocalSessionManager, StreamableHttpServerConfig, StreamableHttpService,
     },
+    ErrorData as McpError, ServerHandler,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -931,7 +930,9 @@ impl OpenScadMcpHandler {
 
 #[tool_router]
 impl OpenScadMcpHandler {
-    #[tool(description = "Ensure this MCP session is bound to the exact requested workspace folder by attaching to an already-open match or opening/initializing it in OpenSCAD Studio.")]
+    #[tool(
+        description = "Ensure this MCP session is bound to the exact requested workspace folder by attaching to an already-open match or opening/initializing it in OpenSCAD Studio."
+    )]
     async fn get_or_create_workspace(
         &self,
         Parameters(params): Parameters<GetOrCreateWorkspaceParams>,
@@ -950,16 +951,17 @@ impl OpenScadMcpHandler {
         Ok(mcp_response_to_call_tool_result(result))
     }
 
-    #[tool(description = "Get the current OpenSCAD Studio render target and workspace summary for the selected workspace.")]
+    #[tool(
+        description = "Get the current OpenSCAD Studio render target and workspace summary for the selected workspace."
+    )]
     async fn get_project_context(&self) -> Result<CallToolResult, McpError> {
         let state = self.shared_state.clone();
         let session_id = self.session_id.clone();
 
-        let result = tokio::task::spawn_blocking(move || {
-            get_project_context_response(&state, &session_id)
-        })
-        .await
-        .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+        let result =
+            tokio::task::spawn_blocking(move || get_project_context_response(&state, &session_id))
+                .await
+                .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
 
         Ok(mcp_response_to_call_tool_result(result))
     }
@@ -973,7 +975,9 @@ impl OpenScadMcpHandler {
         self.call_frontend("set_render_target", args).await
     }
 
-    #[tool(description = "Render the current Studio render target and return the latest diagnostics.")]
+    #[tool(
+        description = "Render the current Studio render target and return the latest diagnostics."
+    )]
     async fn get_diagnostics(&self) -> Result<CallToolResult, McpError> {
         self.call_frontend("get_diagnostics", serde_json::json!({}))
             .await
@@ -1020,7 +1024,10 @@ impl ServerHandler for OpenScadMcpHandler {
                 "openscad-studio",
                 env!("CARGO_PKG_VERSION"),
             ))
-            .with_instructions("OpenSCAD Studio MCP server — controls the OpenSCAD Studio desktop editor.".to_string())
+            .with_instructions(
+                "OpenSCAD Studio MCP server — controls the OpenSCAD Studio desktop editor."
+                    .to_string(),
+            )
     }
 }
 
@@ -1173,12 +1180,26 @@ pub async fn mcp_mark_window_bridge_ready(
     let label = window.label().to_string();
     let is_focused = window.is_focused().unwrap_or(false);
     let mut inner = state.inner.lock().unwrap();
-    let workspace = inner.workspaces.entry(label.clone()).or_insert_with(|| RegisteredWorkspace {
-        descriptor: WorkspaceDescriptor { window_id: label, title: "OpenSCAD Studio".into(), workspace_root: None, render_target_path: None, is_focused },
-        show_welcome: true, mode: RegisteredWindowMode::Welcome, pending_request_id: None,
-        startup_phase: "created".into(), startup_detail: None,
-        context_ready: false, bridge_ready: false, last_focused_order: 0,
-    });
+    let workspace = inner
+        .workspaces
+        .entry(label.clone())
+        .or_insert_with(|| RegisteredWorkspace {
+            descriptor: WorkspaceDescriptor {
+                window_id: label,
+                title: "OpenSCAD Studio".into(),
+                workspace_root: None,
+                render_target_path: None,
+                is_focused,
+            },
+            show_welcome: true,
+            mode: RegisteredWindowMode::Welcome,
+            pending_request_id: None,
+            startup_phase: "created".into(),
+            startup_detail: None,
+            context_ready: false,
+            bridge_ready: false,
+            last_focused_order: 0,
+        });
     workspace.bridge_ready = true;
     workspace.startup_phase = "bridge_ready".into();
     workspace.startup_detail = None;
@@ -1192,7 +1213,10 @@ pub async fn mcp_update_window_context(
     state: State<'_, McpServerState>,
 ) -> Result<(), String> {
     let label = window.label().to_string();
-    let normalized_root = payload.workspace_root.as_deref().and_then(normalize_workspace_root);
+    let normalized_root = payload
+        .workspace_root
+        .as_deref()
+        .and_then(normalize_workspace_root);
     let title = payload.title.unwrap_or_else(|| "OpenSCAD Studio".into());
     let render_target_path = payload.render_target_path.clone();
     let is_focused = window.is_focused().unwrap_or(false);
@@ -1202,23 +1226,51 @@ pub async fn mcp_update_window_context(
         inner.next_focus_order += 1;
         inner.next_focus_order
     } else {
-        inner.workspaces.get(&label).map(|w| w.last_focused_order).unwrap_or(0)
+        inner
+            .workspaces
+            .get(&label)
+            .map(|w| w.last_focused_order)
+            .unwrap_or(0)
     };
-    let previous_bridge_ready = inner.workspaces.get(&label).map(|w| w.bridge_ready).unwrap_or(false);
-    let previous_startup_phase = inner.workspaces.get(&label).map(|w| w.startup_phase.clone()).unwrap_or_else(|| "context_updated".into());
-    let previous_startup_detail = inner.workspaces.get(&label).and_then(|w| w.startup_detail.clone());
+    let previous_bridge_ready = inner
+        .workspaces
+        .get(&label)
+        .map(|w| w.bridge_ready)
+        .unwrap_or(false);
+    let previous_startup_phase = inner
+        .workspaces
+        .get(&label)
+        .map(|w| w.startup_phase.clone())
+        .unwrap_or_else(|| "context_updated".into());
+    let previous_startup_detail = inner
+        .workspaces
+        .get(&label)
+        .and_then(|w| w.startup_detail.clone());
 
-    inner.workspaces.insert(label.clone(), RegisteredWorkspace {
-        descriptor: WorkspaceDescriptor { window_id: label, title, workspace_root: normalized_root, render_target_path, is_focused },
-        show_welcome: payload.show_welcome,
-        mode: payload.mode.unwrap_or(if payload.show_welcome { RegisteredWindowMode::Welcome } else { RegisteredWindowMode::Ready }),
-        pending_request_id: payload.pending_request_id,
-        startup_phase: previous_startup_phase,
-        startup_detail: previous_startup_detail,
-        context_ready: payload.ready,
-        bridge_ready: previous_bridge_ready,
-        last_focused_order: next_focus_order,
-    });
+    inner.workspaces.insert(
+        label.clone(),
+        RegisteredWorkspace {
+            descriptor: WorkspaceDescriptor {
+                window_id: label,
+                title,
+                workspace_root: normalized_root,
+                render_target_path,
+                is_focused,
+            },
+            show_welcome: payload.show_welcome,
+            mode: payload.mode.unwrap_or(if payload.show_welcome {
+                RegisteredWindowMode::Welcome
+            } else {
+                RegisteredWindowMode::Ready
+            }),
+            pending_request_id: payload.pending_request_id,
+            startup_phase: previous_startup_phase,
+            startup_detail: previous_startup_detail,
+            context_ready: payload.ready,
+            bridge_ready: previous_bridge_ready,
+            last_focused_order: next_focus_order,
+        },
+    );
     Ok(())
 }
 
@@ -1239,29 +1291,57 @@ pub async fn report_window_open_result(
 ) -> Result<(), String> {
     let label = window.label().to_string();
     let mut inner = state.inner.lock().unwrap();
-    inner.workspaces.entry(label.clone()).or_insert_with(|| RegisteredWorkspace {
-        descriptor: WorkspaceDescriptor { window_id: label.clone(), title: "OpenSCAD Studio".into(), workspace_root: None, render_target_path: None, is_focused: false },
-        show_welcome: true, mode: RegisteredWindowMode::Welcome, pending_request_id: None,
-        startup_phase: "created".into(), startup_detail: None,
-        context_ready: false, bridge_ready: false, last_focused_order: 0,
-    });
+    inner
+        .workspaces
+        .entry(label.clone())
+        .or_insert_with(|| RegisteredWorkspace {
+            descriptor: WorkspaceDescriptor {
+                window_id: label.clone(),
+                title: "OpenSCAD Studio".into(),
+                workspace_root: None,
+                render_target_path: None,
+                is_focused: false,
+            },
+            show_welcome: true,
+            mode: RegisteredWindowMode::Welcome,
+            pending_request_id: None,
+            startup_phase: "created".into(),
+            startup_detail: None,
+            context_ready: false,
+            bridge_ready: false,
+            last_focused_order: 0,
+        });
 
     if let Some(pending) = inner.window_open_requests.remove(&payload.request_id) {
         if let Some(workspace) = inner.workspaces.get_mut(&label) {
             workspace.pending_request_id = None;
             workspace.mode = if payload.success {
-                if payload.opened_workspace_root.is_some() { workspace.show_welcome = false; RegisteredWindowMode::Ready }
-                else if workspace.show_welcome { RegisteredWindowMode::Welcome }
-                else { RegisteredWindowMode::Ready }
-            } else { RegisteredWindowMode::OpenFailed };
+                if payload.opened_workspace_root.is_some() {
+                    workspace.show_welcome = false;
+                    RegisteredWindowMode::Ready
+                } else if workspace.show_welcome {
+                    RegisteredWindowMode::Welcome
+                } else {
+                    RegisteredWindowMode::Ready
+                }
+            } else {
+                RegisteredWindowMode::OpenFailed
+            };
         }
         let result = if payload.success {
             Ok(WindowOpenResult {
-                message: payload.message.unwrap_or_else(|| "Opened target successfully.".into()),
-                opened_workspace_root: payload.opened_workspace_root.as_deref().and_then(normalize_workspace_root),
+                message: payload
+                    .message
+                    .unwrap_or_else(|| "Opened target successfully.".into()),
+                opened_workspace_root: payload
+                    .opened_workspace_root
+                    .as_deref()
+                    .and_then(normalize_workspace_root),
             })
         } else {
-            Err(payload.message.unwrap_or_else(|| "Failed to open target.".into()))
+            Err(payload
+                .message
+                .unwrap_or_else(|| "Failed to open target.".into()))
         };
         let _ = pending.sender.send(result);
     }
@@ -1286,7 +1366,9 @@ pub async fn mcp_submit_tool_response(
 ) -> Result<(), String> {
     let sender = state.inner.lock().unwrap().pending.remove(&request_id);
     let Some(sender) = sender else {
-        return Err(format!("No pending MCP tool request found for {request_id}."));
+        return Err(format!(
+            "No pending MCP tool request found for {request_id}."
+        ));
     };
     sender
         .send(response)
@@ -1366,7 +1448,9 @@ mod tests {
     #[test]
     fn require_bound_window_id_errors_when_unbound() {
         let mut inner = make_inner();
-        inner.sessions.insert("session-1".into(), McpSessionBinding::default());
+        inner
+            .sessions
+            .insert("session-1".into(), McpSessionBinding::default());
 
         let response = require_bound_window_id(&mut inner, "session-1").unwrap_err();
         assert!(response.is_error);

--- a/apps/ui/src-tauri/src/mcp.rs
+++ b/apps/ui/src-tauri/src/mcp.rs
@@ -1,17 +1,13 @@
 use rmcp::{
     ErrorData as McpError, ServerHandler,
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
-    model::{CallToolResult, Content, ServerCapabilities, ServerInfo, ClientJsonRpcMessage, ServerJsonRpcMessage},
+    model::{CallToolResult, Content, ServerCapabilities, ServerInfo},
     schemars, tool, tool_handler, tool_router,
     transport::streamable_http_server::{
         StreamableHttpServerConfig, StreamableHttpService,
-        session::{
-            SessionManager, ServerSseMessage, SessionId,
-            local::{LocalSessionManager, LocalSessionManagerError, SessionTransport},
-        },
+        session::local::LocalSessionManager,
     },
 };
-use futures::Stream;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -872,91 +868,6 @@ pub struct ExportFileParams {
     pub file_path: String,
 }
 
-// ── Logging session manager wrapper ───────────────────────────────────────────
-
-/// Wraps `LocalSessionManager` and logs every `close_session` call so we can
-/// see exactly when and why sessions are being dropped.
-struct LoggingSessionManager {
-    inner: LocalSessionManager,
-}
-
-impl LoggingSessionManager {
-    fn new() -> Self {
-        Self { inner: LocalSessionManager::default() }
-    }
-}
-
-impl SessionManager for LoggingSessionManager {
-    type Error = LocalSessionManagerError;
-    type Transport = SessionTransport;
-
-    fn create_session(&self) -> impl std::future::Future<Output = Result<(SessionId, Self::Transport), Self::Error>> + Send {
-        self.inner.create_session()
-    }
-
-    fn initialize_session(
-        &self,
-        id: &SessionId,
-        message: ClientJsonRpcMessage,
-    ) -> impl std::future::Future<Output = Result<ServerJsonRpcMessage, Self::Error>> + Send {
-        self.inner.initialize_session(id, message)
-    }
-
-    fn has_session(
-        &self,
-        id: &SessionId,
-    ) -> impl std::future::Future<Output = Result<bool, Self::Error>> + Send {
-        self.inner.has_session(id)
-    }
-
-    fn close_session(
-        &self,
-        id: &SessionId,
-    ) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send {
-        let id_str = id.to_string();
-        eprintln!(
-            "[session-log] close_session called for {id_str} at {:?}",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-        );
-        // Capture a backtrace to know who's calling close_session.
-        eprintln!("[session-log] Backtrace:\n{}", std::backtrace::Backtrace::force_capture());
-        self.inner.close_session(id)
-    }
-
-    fn create_stream(
-        &self,
-        id: &SessionId,
-        message: ClientJsonRpcMessage,
-    ) -> impl std::future::Future<Output = Result<impl Stream<Item = ServerSseMessage> + Send + Sync + 'static, Self::Error>> + Send {
-        self.inner.create_stream(id, message)
-    }
-
-    fn accept_message(
-        &self,
-        id: &SessionId,
-        message: ClientJsonRpcMessage,
-    ) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send {
-        self.inner.accept_message(id, message)
-    }
-
-    fn create_standalone_stream(
-        &self,
-        id: &SessionId,
-    ) -> impl std::future::Future<Output = Result<impl Stream<Item = ServerSseMessage> + Send + Sync + 'static, Self::Error>> + Send {
-        self.inner.create_standalone_stream(id)
-    }
-
-    fn resume(
-        &self,
-        id: &SessionId,
-        last_event_id: String,
-    ) -> impl std::future::Future<Output = Result<impl Stream<Item = ServerSseMessage> + Send + Sync + 'static, Self::Error>> + Send {
-        self.inner.resume(id, last_event_id)
-    }
-}
-
 // ── rmcp handler ──────────────────────────────────────────────────────────────
 
 #[derive(Clone)]
@@ -969,10 +880,6 @@ struct OpenScadMcpHandler {
 
 impl Drop for OpenScadMcpHandler {
     fn drop(&mut self) {
-        eprintln!(
-            "[session-log] OpenScadMcpHandler DROPPED for session {} — serve_inner exited",
-            self.session_id
-        );
         let mut inner = self.shared_state.lock().unwrap();
         inner.sessions.remove(&self.session_id);
     }
@@ -1158,6 +1065,19 @@ pub async fn configure_mcp_server(
     port: u16,
     state: State<'_, McpServerState>,
 ) -> Result<McpServerStatus, String> {
+    // Idempotency check: every window calls this on mount, but we must not
+    // restart the server just because a secondary window opened. If the server
+    // is already running with the same config, return early.
+    {
+        let inner = state.inner.lock().unwrap();
+        if enabled && inner.running_server.is_some() && inner.status.port == port {
+            return Ok(inner.status.clone());
+        }
+        if !enabled && inner.running_server.is_none() {
+            return Ok(inner.status.clone());
+        }
+    }
+
     // Take ownership of any existing server handle so we can stop it.
     let previous = {
         let mut inner = state.inner.lock().unwrap();
@@ -1219,7 +1139,7 @@ pub async fn configure_mcp_server(
                 let handler = OpenScadMcpHandler::new(app_handle.clone(), shared_state.clone());
                 Ok(handler)
             },
-            std::sync::Arc::new(LoggingSessionManager::new()),
+            std::sync::Arc::new(LocalSessionManager::default()),
             StreamableHttpServerConfig::default().with_cancellation_token(ct_child.clone()),
         );
 

--- a/apps/ui/src-tauri/src/mcp.rs
+++ b/apps/ui/src-tauri/src/mcp.rs
@@ -848,9 +848,8 @@ pub struct SetRenderTargetParams {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct GetPreviewScreenshotParams {
-    /// View perspective: "current", "front", "back", "left", "right", "top", "bottom", or "isometric"
-    #[serde(default)]
-    pub view: Option<String>,
+    /// View perspective: "front", "back", "left", "right", "top", "bottom", or "isometric"
+    pub view: String,
     /// Camera azimuth angle in degrees
     #[serde(default)]
     pub azimuth: Option<f64>,
@@ -976,20 +975,24 @@ impl OpenScadMcpHandler {
     }
 
     #[tool(
-        description = "Render the current Studio render target and return the latest diagnostics."
+        description = "Render the current Studio render target and report the latest diagnostics without failing on compile errors."
     )]
     async fn get_diagnostics(&self) -> Result<CallToolResult, McpError> {
         self.call_frontend("get_diagnostics", serde_json::json!({}))
             .await
     }
 
-    #[tool(description = "Render the current Studio render target and refresh the preview.")]
+    #[tool(
+        description = "Render the current Studio render target, refresh the preview, and fail if the render reports errors."
+    )]
     async fn trigger_render(&self) -> Result<CallToolResult, McpError> {
         self.call_frontend("trigger_render", serde_json::json!({}))
             .await
     }
 
-    #[tool(description = "Capture a PNG screenshot of Studio's current preview.")]
+    #[tool(
+        description = "Capture a PNG screenshot of the latest settled render artifact for the current render target. Requires an explicit 3D view such as front, top, or isometric."
+    )]
     async fn get_preview_screenshot(
         &self,
         Parameters(params): Parameters<GetPreviewScreenshotParams>,
@@ -1002,7 +1005,9 @@ impl OpenScadMcpHandler {
         self.call_frontend("get_preview_screenshot", args).await
     }
 
-    #[tool(description = "Export the current render target to a file path on desktop.")]
+    #[tool(
+        description = "Export the current render target to a file path on desktop. If export cannot proceed, the response explains how to verify the render target and diagnostics."
+    )]
     async fn export_file(
         &self,
         Parameters(params): Parameters<ExportFileParams>,

--- a/apps/ui/src-tauri/src/mcp.rs
+++ b/apps/ui/src-tauri/src/mcp.rs
@@ -1,0 +1,525 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::sync::{mpsc, Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+use tauri::{AppHandle, Emitter, State};
+use tiny_http::{Header, Method, Request, Response, Server, StatusCode};
+use uuid::Uuid;
+
+const MCP_PROTOCOL_VERSION: &str = "2025-03-26";
+const MCP_SERVER_NAME: &str = "openscad-studio";
+const MCP_DEFAULT_PORT: u16 = 32123;
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum McpServerStateKind {
+    Starting,
+    Running,
+    Disabled,
+    PortConflict,
+    Error,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpServerStatus {
+    enabled: bool,
+    port: u16,
+    status: McpServerStateKind,
+    endpoint: Option<String>,
+    message: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct FrontendToolRequest {
+    request_id: String,
+    tool_name: String,
+    arguments: Value,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum McpContentItem {
+    Text {
+        text: String,
+    },
+    #[serde(rename_all = "camelCase")]
+    Image {
+        data: String,
+        mime_type: String,
+    },
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpToolResponse {
+    pub content: Vec<McpContentItem>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub is_error: bool,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
+struct RunningServer {
+    shutdown_tx: mpsc::Sender<()>,
+    join_handle: JoinHandle<()>,
+}
+
+struct McpStateInner {
+    running_server: Option<RunningServer>,
+    pending: HashMap<String, mpsc::Sender<McpToolResponse>>,
+    status: McpServerStatus,
+}
+
+#[derive(Clone)]
+pub struct McpServerState {
+    inner: Arc<Mutex<McpStateInner>>,
+}
+
+impl Default for McpServerState {
+    fn default() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(McpStateInner {
+                running_server: None,
+                pending: HashMap::new(),
+                status: McpServerStatus {
+                    enabled: true,
+                    port: MCP_DEFAULT_PORT,
+                    status: McpServerStateKind::Disabled,
+                    endpoint: None,
+                    message: None,
+                },
+            })),
+        }
+    }
+}
+
+fn endpoint_for_port(port: u16) -> String {
+    format!("http://127.0.0.1:{port}/mcp")
+}
+
+fn build_status(
+    enabled: bool,
+    port: u16,
+    status: McpServerStateKind,
+    message: Option<String>,
+) -> McpServerStatus {
+    McpServerStatus {
+        enabled,
+        port,
+        endpoint: if enabled {
+            Some(endpoint_for_port(port))
+        } else {
+            None
+        },
+        status,
+        message,
+    }
+}
+
+fn header(name: &'static [u8], value: &'static [u8]) -> Header {
+    Header::from_bytes(name, value).expect("valid static header")
+}
+
+fn text_tool_response(message: impl Into<String>, is_error: bool) -> McpToolResponse {
+    McpToolResponse {
+        content: vec![McpContentItem::Text {
+            text: message.into(),
+        }],
+        is_error,
+    }
+}
+
+fn json_response(status_code: u16, value: &Value) -> Response<std::io::Cursor<Vec<u8>>> {
+    let mut response =
+        Response::from_string(value.to_string()).with_status_code(StatusCode(status_code));
+    response.add_header(header(b"content-type", b"application/json"));
+    response.add_header(header(
+        b"mcp-protocol-version",
+        MCP_PROTOCOL_VERSION.as_bytes(),
+    ));
+    response
+}
+
+fn empty_response(status_code: u16) -> Response<std::io::Cursor<Vec<u8>>> {
+    Response::from_data(Vec::<u8>::new()).with_status_code(StatusCode(status_code))
+}
+
+fn jsonrpc_result(id: Value, result: Value) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": result,
+    })
+}
+
+fn jsonrpc_error(id: Value, code: i64, message: impl Into<String>) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": {
+            "code": code,
+            "message": message.into(),
+        }
+    })
+}
+
+fn remove_pending(
+    inner: &Arc<Mutex<McpStateInner>>,
+    request_id: &str,
+) -> Option<mpsc::Sender<McpToolResponse>> {
+    inner.lock().unwrap().pending.remove(request_id)
+}
+
+fn call_frontend_tool(
+    app: &AppHandle,
+    inner: &Arc<Mutex<McpStateInner>>,
+    tool_name: &str,
+    arguments: Value,
+) -> Result<McpToolResponse, String> {
+    let request_id = Uuid::new_v4().to_string();
+    let (tx, rx) = mpsc::channel();
+
+    inner.lock().unwrap().pending.insert(request_id.clone(), tx);
+
+    let payload = FrontendToolRequest {
+        request_id: request_id.clone(),
+        tool_name: tool_name.to_string(),
+        arguments,
+    };
+
+    if let Err(error) = app.emit("mcp:tool-request", payload) {
+        remove_pending(inner, &request_id);
+        return Err(format!("Failed to dispatch MCP tool request: {error}"));
+    }
+
+    match rx.recv_timeout(Duration::from_secs(30)) {
+        Ok(response) => Ok(response),
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            remove_pending(inner, &request_id);
+            Err("Timed out waiting for OpenSCAD Studio to complete the MCP tool request.".into())
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            remove_pending(inner, &request_id);
+            Err("OpenSCAD Studio could not deliver the MCP tool response.".into())
+        }
+    }
+}
+
+fn tool_definitions() -> Value {
+    json!([
+        {
+            "name": "get_project_context",
+            "description": "Get the current OpenSCAD Studio render target and workspace summary.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            }
+        },
+        {
+            "name": "set_render_target",
+            "description": "Change which workspace-relative file Studio compiles and previews.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "file_path": {
+                        "type": "string",
+                        "description": "Workspace-relative .scad path to use as the render target."
+                    }
+                },
+                "required": ["file_path"],
+                "additionalProperties": false
+            }
+        },
+        {
+            "name": "get_diagnostics",
+            "description": "Render the current Studio render target and return the latest diagnostics.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            }
+        },
+        {
+            "name": "trigger_render",
+            "description": "Render the current Studio render target and refresh the preview.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            }
+        },
+        {
+            "name": "get_preview_screenshot",
+            "description": "Capture a PNG screenshot of Studio's current preview.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "view": {
+                        "type": "string",
+                        "enum": ["current", "front", "back", "top", "bottom", "left", "right", "isometric"]
+                    },
+                    "azimuth": { "type": "number" },
+                    "elevation": { "type": "number" }
+                },
+                "additionalProperties": false
+            }
+        }
+    ])
+}
+
+fn handle_rpc_message(
+    app: &AppHandle,
+    inner: &Arc<Mutex<McpStateInner>>,
+    payload: Value,
+) -> Result<Option<Value>, Value> {
+    let id = payload.get("id").cloned().unwrap_or(Value::Null);
+    let Some(method) = payload.get("method").and_then(Value::as_str) else {
+        return Err(jsonrpc_error(id, -32600, "Missing JSON-RPC method."));
+    };
+
+    let params = payload.get("params").cloned().unwrap_or_else(|| json!({}));
+
+    match method {
+        "initialize" => Ok(Some(jsonrpc_result(
+            id,
+            json!({
+                "protocolVersion": MCP_PROTOCOL_VERSION,
+                "capabilities": {
+                    "tools": {}
+                },
+                "serverInfo": {
+                    "name": MCP_SERVER_NAME,
+                    "version": env!("CARGO_PKG_VERSION")
+                }
+            }),
+        ))),
+        "notifications/initialized" => Ok(None),
+        "ping" => Ok(Some(jsonrpc_result(id, json!({})))),
+        "tools/list" => Ok(Some(jsonrpc_result(
+            id,
+            json!({
+                "tools": tool_definitions()
+            }),
+        ))),
+        "tools/call" => {
+            let Some(name) = params.get("name").and_then(Value::as_str) else {
+                return Err(jsonrpc_error(
+                    id,
+                    -32602,
+                    "`tools/call` requires a string `name` parameter.",
+                ));
+            };
+
+            let arguments = params
+                .get("arguments")
+                .cloned()
+                .unwrap_or_else(|| Value::Object(Default::default()));
+
+            let result = call_frontend_tool(app, inner, name, arguments).map_err(|message| {
+                jsonrpc_result(id.clone(), json!(text_tool_response(message, true)))
+            })?;
+
+            Ok(Some(jsonrpc_result(
+                id,
+                serde_json::to_value(result).expect("serializable MCP tool response"),
+            )))
+        }
+        _ => Err(jsonrpc_error(
+            id,
+            -32601,
+            format!("Method not found: {method}"),
+        )),
+    }
+}
+
+fn respond_to_request(mut request: Request, app: &AppHandle, inner: &Arc<Mutex<McpStateInner>>) {
+    if request.method() != &Method::Post {
+        let _ = request.respond(empty_response(405));
+        return;
+    }
+
+    if request.url() != "/mcp" {
+        let _ = request.respond(empty_response(404));
+        return;
+    }
+
+    let mut body = String::new();
+    if request.as_reader().read_to_string(&mut body).is_err() {
+        let _ = request.respond(json_response(
+            400,
+            &jsonrpc_error(Value::Null, -32700, "Failed to read request body."),
+        ));
+        return;
+    }
+
+    let payload: Value = match serde_json::from_str(&body) {
+        Ok(value) => value,
+        Err(error) => {
+            let _ = request.respond(json_response(
+                400,
+                &jsonrpc_error(
+                    Value::Null,
+                    -32700,
+                    format!("Invalid JSON payload: {error}"),
+                ),
+            ));
+            return;
+        }
+    };
+
+    if payload.is_array() {
+        let _ = request.respond(json_response(
+            400,
+            &jsonrpc_error(Value::Null, -32600, "Batch requests are not supported."),
+        ));
+        return;
+    }
+
+    match handle_rpc_message(app, inner, payload) {
+        Ok(Some(response)) => {
+            let _ = request.respond(json_response(200, &response));
+        }
+        Ok(None) => {
+            let _ = request.respond(empty_response(202));
+        }
+        Err(error) => {
+            let _ = request.respond(json_response(400, &error));
+        }
+    }
+}
+
+fn run_mcp_server(
+    server: Server,
+    shutdown_rx: mpsc::Receiver<()>,
+    app: AppHandle,
+    inner: Arc<Mutex<McpStateInner>>,
+) {
+    loop {
+        if shutdown_rx.try_recv().is_ok() {
+            break;
+        }
+
+        match server.recv_timeout(Duration::from_millis(200)) {
+            Ok(Some(request)) => respond_to_request(request, &app, &inner),
+            Ok(None) => {}
+            Err(error) => {
+                inner.lock().unwrap().status = build_status(
+                    true,
+                    inner.lock().unwrap().status.port,
+                    McpServerStateKind::Error,
+                    Some(format!("MCP server stopped unexpectedly: {error}")),
+                );
+                break;
+            }
+        }
+    }
+}
+
+fn stop_running_server(running_server: Option<RunningServer>) {
+    if let Some(server) = running_server {
+        let _ = server.shutdown_tx.send(());
+        let _ = server.join_handle.join();
+    }
+}
+
+#[tauri::command]
+pub fn configure_mcp_server(
+    app: AppHandle,
+    enabled: bool,
+    port: u16,
+    state: State<'_, McpServerState>,
+) -> Result<McpServerStatus, String> {
+    let previous_server = {
+        let mut inner = state.inner.lock().unwrap();
+        inner.status = build_status(
+            enabled,
+            port,
+            if enabled {
+                McpServerStateKind::Starting
+            } else {
+                McpServerStateKind::Disabled
+            },
+            None,
+        );
+        inner.running_server.take()
+    };
+
+    stop_running_server(previous_server);
+
+    if !enabled {
+        let mut inner = state.inner.lock().unwrap();
+        inner.status = build_status(false, port, McpServerStateKind::Disabled, None);
+        return Ok(inner.status.clone());
+    }
+
+    let address = format!("127.0.0.1:{port}");
+    let server = match Server::http(&address) {
+        Ok(server) => server,
+        Err(error) => {
+            let kind = if error
+                .to_string()
+                .to_lowercase()
+                .contains("address already in use")
+            {
+                McpServerStateKind::PortConflict
+            } else {
+                McpServerStateKind::Error
+            };
+            let mut inner = state.inner.lock().unwrap();
+            inner.status = build_status(enabled, port, kind, Some(error.to_string()));
+            return Ok(inner.status.clone());
+        }
+    };
+
+    let (shutdown_tx, shutdown_rx) = mpsc::channel();
+    let inner = state.inner.clone();
+    let app_handle = app.clone();
+    let join_handle = thread::spawn(move || run_mcp_server(server, shutdown_rx, app_handle, inner));
+
+    let mut inner = state.inner.lock().unwrap();
+    inner.running_server = Some(RunningServer {
+        shutdown_tx,
+        join_handle,
+    });
+    inner.status = build_status(enabled, port, McpServerStateKind::Running, None);
+    Ok(inner.status.clone())
+}
+
+#[tauri::command]
+pub fn get_mcp_server_status(state: State<'_, McpServerState>) -> Result<McpServerStatus, String> {
+    Ok(state.inner.lock().unwrap().status.clone())
+}
+
+#[tauri::command]
+pub fn mcp_submit_tool_response(
+    request_id: String,
+    response: McpToolResponse,
+    state: State<'_, McpServerState>,
+) -> Result<(), String> {
+    let sender = state.inner.lock().unwrap().pending.remove(&request_id);
+    let Some(sender) = sender else {
+        return Err(format!(
+            "No pending MCP tool request found for {request_id}."
+        ));
+    };
+
+    sender
+        .send(response)
+        .map_err(|error| format!("Failed to send MCP tool response: {error}"))
+}
+
+pub fn shutdown_mcp_server(state: &McpServerState) {
+    let running_server = {
+        let mut inner = state.inner.lock().unwrap();
+        inner.status = build_status(false, inner.status.port, McpServerStateKind::Disabled, None);
+        inner.running_server.take()
+    };
+    stop_running_server(running_server);
+}

--- a/apps/ui/src-tauri/src/mcp.rs
+++ b/apps/ui/src-tauri/src/mcp.rs
@@ -1,20 +1,31 @@
+use rmcp::{
+    ErrorData as McpError, ServerHandler,
+    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+    model::{CallToolResult, Content, ServerCapabilities, ServerInfo, ClientJsonRpcMessage, ServerJsonRpcMessage},
+    schemars, tool, tool_handler, tool_router,
+    transport::streamable_http_server::{
+        StreamableHttpServerConfig, StreamableHttpService,
+        session::{
+            SessionManager, ServerSseMessage, SessionId,
+            local::{LocalSessionManager, LocalSessionManagerError, SessionTransport},
+        },
+    },
+};
+use futures::Stream;
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::Value;
 use std::collections::HashMap;
 use std::fs;
 use std::sync::{mpsc, Arc, Mutex};
-use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter, Manager, State, Window};
-use tiny_http::{Header, Method, Request, Response, Server, StatusCode};
 use uuid::Uuid;
 
 use crate::create_new_window_with_launch_intent;
 
-const MCP_PROTOCOL_VERSION: &str = "2025-03-26";
-const MCP_SERVER_NAME: &str = "openscad-studio";
 const MCP_DEFAULT_PORT: u16 = 32123;
-const MCP_SESSION_HEADER: &str = "mcp-session-id";
+
+// ── Public status types ──────────────────────────────────────────────────────
 
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -35,6 +46,8 @@ pub struct McpServerStatus {
     endpoint: Option<String>,
     message: Option<String>,
 }
+
+// ── IPC payloads ─────────────────────────────────────────────────────────────
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -65,6 +78,8 @@ pub struct McpToolResponse {
     pub is_error: bool,
 }
 
+// ── Workspace / session types ─────────────────────────────────────────────────
+
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WorkspaceDescriptor {
@@ -92,10 +107,6 @@ pub enum WindowLaunchIntent {
         request_id: String,
         folder_path: String,
         create_if_empty: bool,
-        /// Pre-read .scad file contents (relative path → content).
-        /// Avoids FS plugin IPC calls from secondary windows.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        files: Option<std::collections::HashMap<String, String>>,
     },
     OpenFile {
         request_id: String,
@@ -180,13 +191,17 @@ fn is_false(value: &bool) -> bool {
     !*value
 }
 
-struct RunningServer {
-    shutdown_tx: mpsc::Sender<()>,
-    join_handle: JoinHandle<()>,
+// ── Running server handle ─────────────────────────────────────────────────────
+
+struct RunningServerHandle {
+    cancellation_token: tokio_util::sync::CancellationToken,
+    join_handle: tokio::task::JoinHandle<()>,
 }
 
+// ── Shared state ──────────────────────────────────────────────────────────────
+
 struct McpStateInner {
-    running_server: Option<RunningServer>,
+    running_server: Option<RunningServerHandle>,
     pending: HashMap<String, mpsc::Sender<McpToolResponse>>,
     window_open_requests: HashMap<String, PendingWindowOpenRequest>,
     status: McpServerStatus,
@@ -222,78 +237,7 @@ impl Default for McpServerState {
     }
 }
 
-/// Read all `.scad` files from a directory tree, returning relative path → content.
-fn read_scad_files(dir: &std::path::Path) -> std::collections::HashMap<String, String> {
-    use std::collections::HashMap;
-    let mut files = HashMap::new();
-
-    fn walk(
-        base: &std::path::Path,
-        current: &std::path::Path,
-        files: &mut HashMap<String, String>,
-    ) {
-        let Ok(entries) = std::fs::read_dir(current) else {
-            return;
-        };
-        for entry in entries.flatten() {
-            let path = entry.path();
-            let name = entry.file_name();
-            let name_str = name.to_string_lossy();
-            if name_str.starts_with('.') {
-                continue;
-            }
-            if path.is_dir() {
-                walk(base, &path, files);
-            } else if name_str.ends_with(".scad") {
-                if let Ok(content) = std::fs::read_to_string(&path) {
-                    if let Ok(rel) = path.strip_prefix(base) {
-                        files.insert(rel.to_string_lossy().into_owned(), content);
-                    }
-                }
-            }
-        }
-    }
-
-    walk(dir, dir, &mut files);
-    files
-}
-
-pub(crate) fn record_window_startup_phase(
-    state: &McpServerState,
-    window_label: &str,
-    phase: impl Into<String>,
-    detail: Option<String>,
-) {
-    let phase = phase.into();
-    let mut inner = state.inner.lock().unwrap();
-    let workspace = inner
-        .workspaces
-        .entry(window_label.to_string())
-        .or_insert_with(|| RegisteredWorkspace {
-            descriptor: WorkspaceDescriptor {
-                window_id: window_label.to_string(),
-                title: "OpenSCAD Studio".into(),
-                workspace_root: None,
-                render_target_path: None,
-                is_focused: false,
-            },
-            show_welcome: true,
-            mode: RegisteredWindowMode::Welcome,
-            pending_request_id: None,
-            startup_phase: "created".into(),
-            startup_detail: None,
-            context_ready: false,
-            bridge_ready: false,
-            last_focused_order: 0,
-        });
-    workspace.startup_phase = phase;
-    workspace.startup_detail = detail;
-}
-
-struct RpcOutcome {
-    response: Option<Value>,
-    session_id: Option<String>,
-}
+// ── Utility functions ─────────────────────────────────────────────────────────
 
 fn endpoint_for_port(port: u16) -> String {
     format!("http://127.0.0.1:{port}/mcp")
@@ -318,14 +262,6 @@ fn build_status(
     }
 }
 
-fn static_header(name: &'static [u8], value: &'static [u8]) -> Header {
-    Header::from_bytes(name, value).expect("valid static header")
-}
-
-fn dynamic_header(name: &str, value: &str) -> Header {
-    Header::from_bytes(name.as_bytes(), value.as_bytes()).expect("valid dynamic header")
-}
-
 fn text_tool_response(message: impl Into<String>, is_error: bool) -> McpToolResponse {
     McpToolResponse {
         content: vec![McpContentItem::Text {
@@ -333,47 +269,6 @@ fn text_tool_response(message: impl Into<String>, is_error: bool) -> McpToolResp
         }],
         is_error,
     }
-}
-
-fn json_response(
-    status_code: u16,
-    value: &Value,
-    session_id: Option<&str>,
-) -> Response<std::io::Cursor<Vec<u8>>> {
-    let mut response =
-        Response::from_string(value.to_string()).with_status_code(StatusCode(status_code));
-    response.add_header(static_header(b"content-type", b"application/json"));
-    response.add_header(static_header(
-        b"mcp-protocol-version",
-        MCP_PROTOCOL_VERSION.as_bytes(),
-    ));
-    if let Some(session_id) = session_id {
-        response.add_header(dynamic_header(MCP_SESSION_HEADER, session_id));
-    }
-    response
-}
-
-fn empty_response(status_code: u16) -> Response<std::io::Cursor<Vec<u8>>> {
-    Response::from_data(Vec::<u8>::new()).with_status_code(StatusCode(status_code))
-}
-
-fn jsonrpc_result(id: Value, result: Value) -> Value {
-    json!({
-        "jsonrpc": "2.0",
-        "id": id,
-        "result": result,
-    })
-}
-
-fn jsonrpc_error(id: Value, code: i64, message: impl Into<String>) -> Value {
-    json!({
-        "jsonrpc": "2.0",
-        "id": id,
-        "error": {
-            "code": code,
-            "message": message.into(),
-        }
-    })
 }
 
 fn normalize_workspace_root(path: &str) -> Option<String> {
@@ -484,14 +379,8 @@ fn wait_for_window_tool_ready(
             ));
         }
 
-        thread::sleep(Duration::from_millis(50));
+        std::thread::sleep(Duration::from_millis(50));
     }
-}
-
-fn ensure_session_id(inner: &mut McpStateInner, existing_session_id: Option<String>) -> String {
-    let session_id = existing_session_id.unwrap_or_else(|| Uuid::new_v4().to_string());
-    inner.sessions.entry(session_id.clone()).or_default();
-    session_id
 }
 
 fn remove_window_and_invalidate_sessions_locked(inner: &mut McpStateInner, window_id: &str) {
@@ -668,10 +557,6 @@ fn dispatch_window_open_request(
         WindowOpenRequest::OpenFile { file_path } => file_path.clone(),
     };
     let (request_id, rx) = create_window_open_request(inner, window_id);
-    eprintln!(
-        "[mcp] dispatch_window_open_request window={} request_id={} target={}",
-        window_id, request_id, target_description
-    );
 
     let payload = WindowOpenRequestPayload {
         request_id: request_id.clone(),
@@ -721,103 +606,6 @@ fn dispatch_window_open_request(
     )
 }
 
-fn tool_definitions() -> Value {
-    json!([
-        {
-            "name": "get_or_create_workspace",
-            "description": "Ensure this MCP session is bound to the exact requested workspace folder by attaching to an already-open match or opening/initializing it in OpenSCAD Studio.",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "folder_path": {
-                        "type": "string",
-                        "description": "Absolute folder path to open as the Studio workspace."
-                    }
-                },
-                "required": ["folder_path"],
-                "additionalProperties": false
-            }
-        },
-        {
-            "name": "get_project_context",
-            "description": "Get the current OpenSCAD Studio render target and workspace summary for the selected workspace.",
-            "inputSchema": {
-                "type": "object",
-                "properties": {},
-                "additionalProperties": false
-            }
-        },
-        {
-            "name": "set_render_target",
-            "description": "Change which workspace-relative file Studio compiles and previews.",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "file_path": {
-                        "type": "string",
-                        "description": "Workspace-relative .scad path to use as the render target."
-                    }
-                },
-                "required": ["file_path"],
-                "additionalProperties": false
-            }
-        },
-        {
-            "name": "get_diagnostics",
-            "description": "Render the current Studio render target and return the latest diagnostics.",
-            "inputSchema": {
-                "type": "object",
-                "properties": {},
-                "additionalProperties": false
-            }
-        },
-        {
-            "name": "trigger_render",
-            "description": "Render the current Studio render target and refresh the preview.",
-            "inputSchema": {
-                "type": "object",
-                "properties": {},
-                "additionalProperties": false
-            }
-        },
-        {
-            "name": "get_preview_screenshot",
-            "description": "Capture a PNG screenshot of Studio's current preview.",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "view": {
-                        "type": "string",
-                        "enum": ["current", "front", "back", "top", "bottom", "left", "right", "isometric"]
-                    },
-                    "azimuth": { "type": "number" },
-                    "elevation": { "type": "number" }
-                },
-                "additionalProperties": false
-            }
-        },
-        {
-            "name": "export_file",
-            "description": "Export the current render target to a file path on desktop.",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "format": {
-                        "type": "string",
-                        "enum": ["stl", "obj", "amf", "3mf", "svg", "dxf"]
-                    },
-                    "file_path": {
-                        "type": "string",
-                        "description": "Absolute output path, or a project-relative path when a workspace root is open."
-                    }
-                },
-                "required": ["format", "file_path"],
-                "additionalProperties": false
-            }
-        }
-    ])
-}
-
 fn get_or_create_workspace_response(
     app: &AppHandle,
     inner: &Arc<Mutex<McpStateInner>>,
@@ -853,10 +641,6 @@ fn get_or_create_workspace_response(
     };
 
     if let Some(window_id) = existing_window_id {
-        eprintln!(
-            "[mcp] get_or_create_workspace matched existing window={} root={}",
-            window_id, normalized_root
-        );
         let response = {
             let mut locked = inner.lock().unwrap();
             bind_session_to_window(&mut locked, session_id, window_id.clone());
@@ -894,10 +678,6 @@ fn get_or_create_workspace_response(
     };
 
     let (target_window_id, detail) = if let Some(window_id) = target_window_id {
-        eprintln!(
-            "[mcp] get_or_create_workspace reusing blank welcome window={} root={}",
-            window_id, normalized_root
-        );
         match dispatch_window_open_request(
             app,
             inner,
@@ -926,20 +706,13 @@ fn get_or_create_workspace_response(
             Err(message) => return text_tool_response(message, true),
         }
     } else {
-        // Create a new window with the open-folder intent baked into the
-        // initialization script. The window consumes the intent during its
-        // own bootstrap and reports back via report_window_open_result.
         let (request_id, rx) = create_window_open_request(inner, "pending-new-window");
-        // Pre-read .scad files so the secondary window doesn't need FS plugin IPC.
-        let pre_read = read_scad_files(std::path::Path::new(&normalized_root));
-        let files = if pre_read.is_empty() { None } else { Some(pre_read) };
         let window_id = match create_new_window_with_launch_intent(
             app,
             WindowLaunchIntent::OpenFolder {
                 request_id: request_id.clone(),
                 folder_path: normalized_root.clone(),
                 create_if_empty: true,
-                files,
             },
         ) {
             Ok(id) => {
@@ -1002,15 +775,8 @@ fn get_or_create_workspace_response(
 
 fn get_project_context_response(
     inner: &Arc<Mutex<McpStateInner>>,
-    session_id: Option<&str>,
+    session_id: &str,
 ) -> McpToolResponse {
-    let Some(session_id) = session_id else {
-        return text_tool_response(
-            "No OpenSCAD Studio workspace is selected for this MCP session. Call `get_or_create_workspace(folder_path)` first.",
-            true,
-        );
-    };
-
     let mut locked = inner.lock().unwrap();
     let window_id = match require_bound_window_id(&mut locked, session_id) {
         Ok(window_id) => window_id,
@@ -1052,267 +818,348 @@ fn get_project_context_response(
     text_tool_response(parts.join("\n"), false)
 }
 
-fn handle_tool_call(
-    app: &AppHandle,
-    inner: &Arc<Mutex<McpStateInner>>,
-    session_id: Option<String>,
-    params: Value,
-    id: Value,
-) -> Result<RpcOutcome, Value> {
-    let session_id_for_response = session_id.clone();
-    let Some(name) = params.get("name").and_then(Value::as_str) else {
-        return Err(jsonrpc_error(
-            id,
-            -32602,
-            "`tools/call` requires a string `name` parameter.",
-        ));
-    };
+// ── Convert McpToolResponse → rmcp CallToolResult ────────────────────────────
 
-    let arguments = params
-        .get("arguments")
-        .cloned()
-        .unwrap_or_else(|| Value::Object(Default::default()));
+fn mcp_response_to_call_tool_result(response: McpToolResponse) -> CallToolResult {
+    let content: Vec<Content> = response
+        .content
+        .into_iter()
+        .map(|item| match item {
+            McpContentItem::Text { text } => Content::text(text),
+            McpContentItem::Image { data, mime_type } => Content::image(data, mime_type),
+        })
+        .collect();
 
-    let result = match name {
-        "get_or_create_workspace" => match session_id.as_deref() {
-            Some(session_id) => get_or_create_workspace_response(app, inner, session_id, &arguments),
-            None => text_tool_response(
-                "This MCP request does not have a session id yet. Reconnect your MCP client and retry workspace creation.",
-                true,
-            ),
-        },
-        "get_project_context" => get_project_context_response(inner, session_id.as_deref()),
-        _ => {
-            let window_id = {
-                let Some(session_id) = session_id.as_deref() else {
-                    return Ok(RpcOutcome {
-                        response: Some(jsonrpc_result(
-                            id,
-                            serde_json::to_value(text_tool_response(
-                                "No OpenSCAD Studio workspace is selected for this MCP session. Call `get_or_create_workspace(folder_path)` first.",
-                                true,
-                            ))
-                            .expect("serializable MCP tool response"),
-                        )),
-                        session_id: session_id_for_response.clone(),
-                    });
-                };
-
-                let mut inner = inner.lock().unwrap();
-                match require_bound_window_id(&mut inner, session_id) {
-                    Ok(window_id) => window_id,
-                    Err(response) => {
-                        return Ok(RpcOutcome {
-                            response: Some(jsonrpc_result(
-                                id,
-                                serde_json::to_value(response)
-                                    .expect("serializable MCP tool response"),
-                            )),
-                            session_id: session_id_for_response.clone(),
-                        })
-                    }
-                }
-            };
-
-            call_frontend_tool(app, inner, &window_id, name, arguments)
-                .unwrap_or_else(|message| text_tool_response(message, true))
-        }
-    };
-
-    Ok(RpcOutcome {
-        response: Some(jsonrpc_result(
-            id,
-            serde_json::to_value(result).expect("serializable MCP tool response"),
-        )),
-        session_id: session_id_for_response,
-    })
-}
-
-fn handle_rpc_message(
-    app: &AppHandle,
-    inner: &Arc<Mutex<McpStateInner>>,
-    payload: Value,
-    session_id: Option<String>,
-) -> Result<RpcOutcome, Value> {
-    let id = payload.get("id").cloned().unwrap_or(Value::Null);
-    let Some(method) = payload.get("method").and_then(Value::as_str) else {
-        return Err(jsonrpc_error(id, -32600, "Missing JSON-RPC method."));
-    };
-
-    let params = payload.get("params").cloned().unwrap_or_else(|| json!({}));
-
-    match method {
-        "initialize" => {
-            let session_id = {
-                let mut inner = inner.lock().unwrap();
-                ensure_session_id(&mut inner, session_id)
-            };
-
-            Ok(RpcOutcome {
-                response: Some(jsonrpc_result(
-                    id,
-                    json!({
-                        "protocolVersion": MCP_PROTOCOL_VERSION,
-                        "capabilities": {
-                            "tools": {}
-                        },
-                        "serverInfo": {
-                            "name": MCP_SERVER_NAME,
-                            "version": env!("CARGO_PKG_VERSION")
-                        }
-                    }),
-                )),
-                session_id: Some(session_id),
-            })
-        }
-        "notifications/initialized" => Ok(RpcOutcome {
-            response: None,
-            session_id,
-        }),
-        "ping" => Ok(RpcOutcome {
-            response: Some(jsonrpc_result(id, json!({}))),
-            session_id,
-        }),
-        "tools/list" => Ok(RpcOutcome {
-            response: Some(jsonrpc_result(
-                id,
-                json!({
-                    "tools": tool_definitions()
-                }),
-            )),
-            session_id,
-        }),
-        "tools/call" => handle_tool_call(app, inner, session_id, params, id),
-        _ => Err(jsonrpc_error(
-            id,
-            -32601,
-            format!("Method not found: {method}"),
-        )),
+    if response.is_error {
+        CallToolResult::error(content)
+    } else {
+        CallToolResult::success(content)
     }
 }
 
-fn find_request_header(request: &Request, name: &'static str) -> Option<String> {
-    request
-        .headers()
-        .iter()
-        .find(|header| header.field.equiv(name))
-        .map(|header| header.value.as_str().to_string())
+// ── Tool parameter structs ────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct GetOrCreateWorkspaceParams {
+    /// Absolute path to the folder to open as a workspace.
+    pub folder_path: String,
 }
 
-fn respond_to_request(mut request: Request, app: &AppHandle, inner: &Arc<Mutex<McpStateInner>>) {
-    if request.url() != "/mcp" {
-        let _ = request.respond(empty_response(404));
-        return;
-    }
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct SetRenderTargetParams {
+    /// Workspace-relative path to the .scad file to use as render target.
+    pub file_path: String,
+}
 
-    if request.method() == &Method::Delete {
-        if let Some(session_id) = find_request_header(&request, MCP_SESSION_HEADER) {
-            inner.lock().unwrap().sessions.remove(&session_id);
-        }
-        let _ = request.respond(empty_response(204));
-        return;
-    }
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct GetPreviewScreenshotParams {
+    /// View perspective: "current", "front", "back", "left", "right", "top", "bottom", or "isometric"
+    #[serde(default)]
+    pub view: Option<String>,
+    /// Camera azimuth angle in degrees
+    #[serde(default)]
+    pub azimuth: Option<f64>,
+    /// Camera elevation angle in degrees
+    #[serde(default)]
+    pub elevation: Option<f64>,
+}
 
-    if request.method() != &Method::Post {
-        let _ = request.respond(empty_response(405));
-        return;
-    }
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ExportFileParams {
+    /// Export format: stl, obj, amf, 3mf, svg, or dxf
+    pub format: String,
+    /// Absolute output path, or workspace-relative path when a workspace root is open
+    pub file_path: String,
+}
 
-    let mut body = String::new();
-    if request.as_reader().read_to_string(&mut body).is_err() {
-        let _ = request.respond(json_response(
-            400,
-            &jsonrpc_error(Value::Null, -32700, "Failed to read request body."),
-            None,
-        ));
-        return;
-    }
+// ── Logging session manager wrapper ───────────────────────────────────────────
 
-    let payload: Value = match serde_json::from_str(&body) {
-        Ok(value) => value,
-        Err(error) => {
-            let _ = request.respond(json_response(
-                400,
-                &jsonrpc_error(
-                    Value::Null,
-                    -32700,
-                    format!("Invalid JSON payload: {error}"),
-                ),
-                None,
-            ));
-            return;
-        }
-    };
+/// Wraps `LocalSessionManager` and logs every `close_session` call so we can
+/// see exactly when and why sessions are being dropped.
+struct LoggingSessionManager {
+    inner: LocalSessionManager,
+}
 
-    if payload.is_array() {
-        let _ = request.respond(json_response(
-            400,
-            &jsonrpc_error(Value::Null, -32600, "Batch requests are not supported."),
-            None,
-        ));
-        return;
-    }
-
-    let session_id = find_request_header(&request, MCP_SESSION_HEADER);
-    match handle_rpc_message(app, inner, payload, session_id) {
-        Ok(outcome) => match outcome.response {
-            Some(response) => {
-                let _ =
-                    request.respond(json_response(200, &response, outcome.session_id.as_deref()));
-            }
-            None => {
-                let _ = request.respond(empty_response(202));
-            }
-        },
-        Err(error) => {
-            let _ = request.respond(json_response(400, &error, None));
-        }
+impl LoggingSessionManager {
+    fn new() -> Self {
+        Self { inner: LocalSessionManager::default() }
     }
 }
 
-fn run_mcp_server(
-    server: Server,
-    shutdown_rx: mpsc::Receiver<()>,
+impl SessionManager for LoggingSessionManager {
+    type Error = LocalSessionManagerError;
+    type Transport = SessionTransport;
+
+    fn create_session(&self) -> impl std::future::Future<Output = Result<(SessionId, Self::Transport), Self::Error>> + Send {
+        self.inner.create_session()
+    }
+
+    fn initialize_session(
+        &self,
+        id: &SessionId,
+        message: ClientJsonRpcMessage,
+    ) -> impl std::future::Future<Output = Result<ServerJsonRpcMessage, Self::Error>> + Send {
+        self.inner.initialize_session(id, message)
+    }
+
+    fn has_session(
+        &self,
+        id: &SessionId,
+    ) -> impl std::future::Future<Output = Result<bool, Self::Error>> + Send {
+        self.inner.has_session(id)
+    }
+
+    fn close_session(
+        &self,
+        id: &SessionId,
+    ) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send {
+        let id_str = id.to_string();
+        eprintln!(
+            "[session-log] close_session called for {id_str} at {:?}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+        );
+        // Capture a backtrace to know who's calling close_session.
+        eprintln!("[session-log] Backtrace:\n{}", std::backtrace::Backtrace::force_capture());
+        self.inner.close_session(id)
+    }
+
+    fn create_stream(
+        &self,
+        id: &SessionId,
+        message: ClientJsonRpcMessage,
+    ) -> impl std::future::Future<Output = Result<impl Stream<Item = ServerSseMessage> + Send + Sync + 'static, Self::Error>> + Send {
+        self.inner.create_stream(id, message)
+    }
+
+    fn accept_message(
+        &self,
+        id: &SessionId,
+        message: ClientJsonRpcMessage,
+    ) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send {
+        self.inner.accept_message(id, message)
+    }
+
+    fn create_standalone_stream(
+        &self,
+        id: &SessionId,
+    ) -> impl std::future::Future<Output = Result<impl Stream<Item = ServerSseMessage> + Send + Sync + 'static, Self::Error>> + Send {
+        self.inner.create_standalone_stream(id)
+    }
+
+    fn resume(
+        &self,
+        id: &SessionId,
+        last_event_id: String,
+    ) -> impl std::future::Future<Output = Result<impl Stream<Item = ServerSseMessage> + Send + Sync + 'static, Self::Error>> + Send {
+        self.inner.resume(id, last_event_id)
+    }
+}
+
+// ── rmcp handler ──────────────────────────────────────────────────────────────
+
+#[derive(Clone)]
+struct OpenScadMcpHandler {
+    tool_router: ToolRouter<OpenScadMcpHandler>,
     app: AppHandle,
-    inner: Arc<Mutex<McpStateInner>>,
-) {
-    loop {
-        if shutdown_rx.try_recv().is_ok() {
-            break;
-        }
+    shared_state: Arc<Mutex<McpStateInner>>,
+    session_id: String,
+}
 
-        match server.recv_timeout(Duration::from_millis(200)) {
-            Ok(Some(request)) => respond_to_request(request, &app, &inner),
-            Ok(None) => {}
-            Err(error) => {
-                let port = inner.lock().unwrap().status.port;
-                inner.lock().unwrap().status = build_status(
-                    true,
-                    port,
-                    McpServerStateKind::Error,
-                    Some(format!("MCP server stopped unexpectedly: {error}")),
-                );
-                break;
-            }
-        }
+impl Drop for OpenScadMcpHandler {
+    fn drop(&mut self) {
+        eprintln!(
+            "[session-log] OpenScadMcpHandler DROPPED for session {} — serve_inner exited",
+            self.session_id
+        );
+        let mut inner = self.shared_state.lock().unwrap();
+        inner.sessions.remove(&self.session_id);
     }
 }
 
-fn stop_running_server(running_server: Option<RunningServer>) {
-    if let Some(server) = running_server {
-        let _ = server.shutdown_tx.send(());
-        let _ = server.join_handle.join();
+impl OpenScadMcpHandler {
+    fn new(app: AppHandle, shared_state: Arc<Mutex<McpStateInner>>) -> Self {
+        let session_id = Uuid::new_v4().to_string();
+        {
+            let mut inner = shared_state.lock().unwrap();
+            inner.sessions.entry(session_id.clone()).or_default();
+        }
+        Self {
+            tool_router: Self::tool_router(),
+            app,
+            shared_state,
+            session_id,
+        }
     }
+
+    async fn call_frontend(
+        &self,
+        tool_name: &str,
+        arguments: Value,
+    ) -> Result<CallToolResult, McpError> {
+        let window_id = {
+            let mut locked = self.shared_state.lock().unwrap();
+            match require_bound_window_id(&mut locked, &self.session_id) {
+                Ok(id) => id,
+                Err(resp) => return Ok(mcp_response_to_call_tool_result(resp)),
+            }
+        };
+
+        let app = self.app.clone();
+        let state = self.shared_state.clone();
+        let tool = tool_name.to_string();
+
+        let result = tokio::task::spawn_blocking(move || {
+            call_frontend_tool(&app, &state, &window_id, &tool, arguments)
+        })
+        .await
+        .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+
+        Ok(mcp_response_to_call_tool_result(
+            result.unwrap_or_else(|e| text_tool_response(e, true)),
+        ))
+    }
+}
+
+#[tool_router]
+impl OpenScadMcpHandler {
+    #[tool(description = "Ensure this MCP session is bound to the exact requested workspace folder by attaching to an already-open match or opening/initializing it in OpenSCAD Studio.")]
+    async fn get_or_create_workspace(
+        &self,
+        Parameters(params): Parameters<GetOrCreateWorkspaceParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let args = serde_json::json!({ "folder_path": params.folder_path });
+        let app = self.app.clone();
+        let state = self.shared_state.clone();
+        let session_id = self.session_id.clone();
+
+        let result = tokio::task::spawn_blocking(move || {
+            get_or_create_workspace_response(&app, &state, &session_id, &args)
+        })
+        .await
+        .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+
+        Ok(mcp_response_to_call_tool_result(result))
+    }
+
+    #[tool(description = "Get the current OpenSCAD Studio render target and workspace summary for the selected workspace.")]
+    async fn get_project_context(&self) -> Result<CallToolResult, McpError> {
+        let state = self.shared_state.clone();
+        let session_id = self.session_id.clone();
+
+        let result = tokio::task::spawn_blocking(move || {
+            get_project_context_response(&state, &session_id)
+        })
+        .await
+        .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+
+        Ok(mcp_response_to_call_tool_result(result))
+    }
+
+    #[tool(description = "Change which workspace-relative file Studio compiles and previews.")]
+    async fn set_render_target(
+        &self,
+        Parameters(params): Parameters<SetRenderTargetParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let args = serde_json::json!({ "file_path": params.file_path });
+        self.call_frontend("set_render_target", args).await
+    }
+
+    #[tool(description = "Render the current Studio render target and return the latest diagnostics.")]
+    async fn get_diagnostics(&self) -> Result<CallToolResult, McpError> {
+        self.call_frontend("get_diagnostics", serde_json::json!({}))
+            .await
+    }
+
+    #[tool(description = "Render the current Studio render target and refresh the preview.")]
+    async fn trigger_render(&self) -> Result<CallToolResult, McpError> {
+        self.call_frontend("trigger_render", serde_json::json!({}))
+            .await
+    }
+
+    #[tool(description = "Capture a PNG screenshot of Studio's current preview.")]
+    async fn get_preview_screenshot(
+        &self,
+        Parameters(params): Parameters<GetPreviewScreenshotParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let args = serde_json::json!({
+            "view": params.view,
+            "azimuth": params.azimuth,
+            "elevation": params.elevation,
+        });
+        self.call_frontend("get_preview_screenshot", args).await
+    }
+
+    #[tool(description = "Export the current render target to a file path on desktop.")]
+    async fn export_file(
+        &self,
+        Parameters(params): Parameters<ExportFileParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let args = serde_json::json!({
+            "format": params.format,
+            "file_path": params.file_path,
+        });
+        self.call_frontend("export_file", args).await
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for OpenScadMcpHandler {
+    fn get_info(&self) -> ServerInfo {
+        use rmcp::model::Implementation;
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_server_info(Implementation::new(
+                "openscad-studio",
+                env!("CARGO_PKG_VERSION"),
+            ))
+            .with_instructions("OpenSCAD Studio MCP server — controls the OpenSCAD Studio desktop editor.".to_string())
+    }
+}
+
+// ── Tauri commands ────────────────────────────────────────────────────────────
+
+pub(crate) fn record_window_startup_phase(
+    state: &McpServerState,
+    window_label: &str,
+    phase: impl Into<String>,
+    detail: Option<String>,
+) {
+    let phase = phase.into();
+    let mut inner = state.inner.lock().unwrap();
+    let workspace = inner
+        .workspaces
+        .entry(window_label.to_string())
+        .or_insert_with(|| RegisteredWorkspace {
+            descriptor: WorkspaceDescriptor {
+                window_id: window_label.to_string(),
+                title: "OpenSCAD Studio".into(),
+                workspace_root: None,
+                render_target_path: None,
+                is_focused: false,
+            },
+            show_welcome: true,
+            mode: RegisteredWindowMode::Welcome,
+            pending_request_id: None,
+            startup_phase: "created".into(),
+            startup_detail: None,
+            context_ready: false,
+            bridge_ready: false,
+            last_focused_order: 0,
+        });
+    workspace.startup_phase = phase;
+    workspace.startup_detail = detail;
 }
 
 #[tauri::command]
-pub fn configure_mcp_server(
+pub async fn configure_mcp_server(
     app: AppHandle,
     enabled: bool,
     port: u16,
     state: State<'_, McpServerState>,
 ) -> Result<McpServerStatus, String> {
-    let previous_server = {
+    // Take ownership of any existing server handle so we can stop it.
+    let previous = {
         let mut inner = state.inner.lock().unwrap();
         inner.status = build_status(
             enabled,
@@ -1327,7 +1174,11 @@ pub fn configure_mcp_server(
         inner.running_server.take()
     };
 
-    stop_running_server(previous_server);
+    // Stop the previous server if any.
+    if let Some(handle) = previous {
+        handle.cancellation_token.cancel();
+        let _ = handle.join_handle.await;
+    }
 
     if !enabled {
         let mut inner = state.inner.lock().unwrap();
@@ -1337,9 +1188,10 @@ pub fn configure_mcp_server(
         return Ok(inner.status.clone());
     }
 
+    // Try to bind the TCP listener before spawning anything.
     let address = format!("127.0.0.1:{port}");
-    let server = match Server::http(&address) {
-        Ok(server) => server,
+    let tcp_listener = match tokio::net::TcpListener::bind(&address).await {
+        Ok(l) => l,
         Err(error) => {
             let kind = if error
                 .to_string()
@@ -1356,14 +1208,32 @@ pub fn configure_mcp_server(
         }
     };
 
-    let (shutdown_tx, shutdown_rx) = mpsc::channel();
-    let inner = state.inner.clone();
+    let shared_state = state.inner.clone();
     let app_handle = app.clone();
-    let join_handle = thread::spawn(move || run_mcp_server(server, shutdown_rx, app_handle, inner));
+    let ct = tokio_util::sync::CancellationToken::new();
+    let ct_child = ct.child_token();
+
+    let join_handle = tokio::spawn(async move {
+        let service = StreamableHttpService::new(
+            move || {
+                let handler = OpenScadMcpHandler::new(app_handle.clone(), shared_state.clone());
+                Ok(handler)
+            },
+            std::sync::Arc::new(LoggingSessionManager::new()),
+            StreamableHttpServerConfig::default().with_cancellation_token(ct_child.clone()),
+        );
+
+        let router = axum::Router::new().nest_service("/mcp", service);
+        let _ = axum::serve(tcp_listener, router)
+            .with_graceful_shutdown(async move {
+                ct_child.cancelled().await;
+            })
+            .await;
+    });
 
     let mut inner = state.inner.lock().unwrap();
-    inner.running_server = Some(RunningServer {
-        shutdown_tx,
+    inner.running_server = Some(RunningServerHandle {
+        cancellation_token: ct,
         join_handle,
     });
     inner.status = build_status(enabled, port, McpServerStateKind::Running, None);
@@ -1375,233 +1245,24 @@ pub fn get_mcp_server_status(state: State<'_, McpServerState>) -> Result<McpServ
     Ok(state.inner.lock().unwrap().status.clone())
 }
 
-// ── Event-based handlers (used instead of invoke for secondary-window compat) ──
-
-fn parse_event<T: serde::de::DeserializeOwned>(raw: &str) -> Option<T> {
-    serde_json::from_str(raw)
-        .map_err(|e| eprintln!("[mcp] Failed to parse event payload: {e}"))
-        .ok()
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct EventEnvelope<T> {
-    window_label: String,
-    #[serde(flatten)]
-    inner: T,
-}
-
-#[derive(Deserialize)]
-struct EmptyPayload {}
-
-pub fn handle_bridge_ready_event(state: &McpServerState, raw: &str) {
-    let Some(env) = parse_event::<EventEnvelope<EmptyPayload>>(raw) else {
-        return;
-    };
-    let label = env.window_label;
+#[tauri::command]
+pub async fn mcp_mark_window_bridge_ready(
+    window: Window,
+    state: State<'_, McpServerState>,
+) -> Result<(), String> {
+    let label = window.label().to_string();
+    let is_focused = window.is_focused().unwrap_or(false);
     let mut inner = state.inner.lock().unwrap();
-    let workspace = inner
-        .workspaces
-        .entry(label.clone())
-        .or_insert_with(|| RegisteredWorkspace {
-            descriptor: WorkspaceDescriptor {
-                window_id: label.clone(),
-                title: "OpenSCAD Studio".into(),
-                workspace_root: None,
-                render_target_path: None,
-                is_focused: false,
-            },
-            show_welcome: true,
-            mode: RegisteredWindowMode::Welcome,
-            pending_request_id: None,
-            startup_phase: "created".into(),
-            startup_detail: None,
-            context_ready: false,
-            bridge_ready: false,
-            last_focused_order: 0,
-        });
+    let workspace = inner.workspaces.entry(label.clone()).or_insert_with(|| RegisteredWorkspace {
+        descriptor: WorkspaceDescriptor { window_id: label, title: "OpenSCAD Studio".into(), workspace_root: None, render_target_path: None, is_focused },
+        show_welcome: true, mode: RegisteredWindowMode::Welcome, pending_request_id: None,
+        startup_phase: "created".into(), startup_detail: None,
+        context_ready: false, bridge_ready: false, last_focused_order: 0,
+    });
     workspace.bridge_ready = true;
     workspace.startup_phase = "bridge_ready".into();
     workspace.startup_detail = None;
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct ToolResponsePayload {
-    request_id: String,
-    response: McpToolResponse,
-}
-
-pub fn handle_tool_response_event(state: &McpServerState, raw: &str) {
-    let Some(env) = parse_event::<EventEnvelope<ToolResponsePayload>>(raw) else {
-        return;
-    };
-    let sender = state.inner.lock().unwrap().pending.remove(&env.inner.request_id);
-    if let Some(sender) = sender {
-        let _ = sender.send(env.inner.response);
-    }
-}
-
-pub fn handle_window_context_event(state: &McpServerState, raw: &str) {
-    let Some(env) = parse_event::<EventEnvelope<WindowContextPayload>>(raw) else {
-        return;
-    };
-    let label = env.window_label;
-    let payload = env.inner;
-    let normalized_root = payload
-        .workspace_root
-        .as_deref()
-        .and_then(normalize_workspace_root);
-    let title = payload.title.unwrap_or_else(|| "OpenSCAD Studio".into());
-    let render_target_path = payload.render_target_path.clone();
-
-    let mut inner = state.inner.lock().unwrap();
-    let next_focus_order = inner
-        .workspaces
-        .get(&label)
-        .map(|w| w.last_focused_order)
-        .unwrap_or(0);
-    let previous_bridge_ready = inner
-        .workspaces
-        .get(&label)
-        .map(|w| w.bridge_ready)
-        .unwrap_or(false);
-    let previous_startup_phase = inner
-        .workspaces
-        .get(&label)
-        .map(|w| w.startup_phase.clone())
-        .unwrap_or_else(|| "context_updated".into());
-    let previous_startup_detail = inner
-        .workspaces
-        .get(&label)
-        .and_then(|w| w.startup_detail.clone());
-
-    inner.workspaces.insert(
-        label.clone(),
-        RegisteredWorkspace {
-            descriptor: WorkspaceDescriptor {
-                window_id: label,
-                title,
-                workspace_root: normalized_root,
-                render_target_path,
-                is_focused: false,
-            },
-            show_welcome: payload.show_welcome,
-            mode: payload.mode.unwrap_or(if payload.show_welcome {
-                RegisteredWindowMode::Welcome
-            } else {
-                RegisteredWindowMode::Ready
-            }),
-            pending_request_id: payload.pending_request_id,
-            startup_phase: previous_startup_phase,
-            startup_detail: previous_startup_detail,
-            context_ready: payload.ready,
-            bridge_ready: previous_bridge_ready,
-            last_focused_order: next_focus_order,
-        },
-    );
-}
-
-pub fn handle_window_open_result_event(state: &McpServerState, raw: &str) {
-    let Some(env) = parse_event::<EventEnvelope<WindowOpenResultPayload>>(raw) else {
-        return;
-    };
-    let label = env.window_label;
-    let payload = env.inner;
-    let mut inner = state.inner.lock().unwrap();
-
-    inner
-        .workspaces
-        .entry(label.clone())
-        .or_insert_with(|| RegisteredWorkspace {
-            descriptor: WorkspaceDescriptor {
-                window_id: label.clone(),
-                title: "OpenSCAD Studio".into(),
-                workspace_root: None,
-                render_target_path: None,
-                is_focused: false,
-            },
-            show_welcome: true,
-            mode: RegisteredWindowMode::Welcome,
-            pending_request_id: None,
-            startup_phase: "created".into(),
-            startup_detail: None,
-            context_ready: false,
-            bridge_ready: false,
-            last_focused_order: 0,
-        });
-
-    if let Some(pending) = inner.window_open_requests.remove(&payload.request_id) {
-        if let Some(workspace) = inner.workspaces.get_mut(&label) {
-            workspace.pending_request_id = None;
-            workspace.mode = if payload.success {
-                if payload.opened_workspace_root.is_some() {
-                    workspace.show_welcome = false;
-                    RegisteredWindowMode::Ready
-                } else if workspace.show_welcome {
-                    RegisteredWindowMode::Welcome
-                } else {
-                    RegisteredWindowMode::Ready
-                }
-            } else {
-                RegisteredWindowMode::OpenFailed
-            };
-            workspace.startup_phase = if payload.success {
-                "open_request_succeeded".into()
-            } else {
-                "open_request_failed".into()
-            };
-            workspace.startup_detail = payload.message.clone();
-        }
-
-        let result = if payload.success {
-            Ok(WindowOpenResult {
-                message: payload
-                    .message
-                    .unwrap_or_else(|| "Opened target successfully.".into()),
-                opened_workspace_root: payload
-                    .opened_workspace_root
-                    .as_deref()
-                    .and_then(normalize_workspace_root),
-            })
-        } else {
-            Err(payload
-                .message
-                .unwrap_or_else(|| "Failed to open target.".into()))
-        };
-        let _ = pending.sender.send(result);
-    }
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct StartupPhaseEventPayload {
-    phase: String,
-    detail: Option<String>,
-}
-
-pub fn handle_window_startup_phase_event(state: &McpServerState, raw: &str) {
-    let Some(env) = parse_event::<EventEnvelope<StartupPhaseEventPayload>>(raw) else {
-        return;
-    };
-    record_window_startup_phase(state, &env.window_label, env.inner.phase, env.inner.detail);
-}
-
-// ── Tauri command handlers (invoke-based) ──
-
-#[tauri::command]
-pub async fn mcp_submit_tool_response(
-    request_id: String,
-    response: McpToolResponse,
-    state: State<'_, McpServerState>,
-) -> Result<(), String> {
-    let sender = state.inner.lock().unwrap().pending.remove(&request_id);
-    let Some(sender) = sender else {
-        return Err(format!("No pending MCP tool request found for {request_id}."));
-    };
-    sender
-        .send(response)
-        .map_err(|error| format!("Failed to send MCP tool response: {error}"))
+    Ok(())
 }
 
 #[tauri::command]
@@ -1641,36 +1302,6 @@ pub async fn mcp_update_window_context(
     Ok(())
 }
 
-#[tauri::command]
-pub async fn mcp_mark_window_bridge_ready(
-    window: Window,
-    state: State<'_, McpServerState>,
-) -> Result<(), String> {
-    let label = window.label().to_string();
-    let is_focused = window.is_focused().unwrap_or(false);
-    let mut inner = state.inner.lock().unwrap();
-    let workspace = inner.workspaces.entry(label.clone()).or_insert_with(|| RegisteredWorkspace {
-        descriptor: WorkspaceDescriptor { window_id: label, title: "OpenSCAD Studio".into(), workspace_root: None, render_target_path: None, is_focused },
-        show_welcome: true, mode: RegisteredWindowMode::Welcome, pending_request_id: None,
-        startup_phase: "created".into(), startup_detail: None,
-        context_ready: false, bridge_ready: false, last_focused_order: 0,
-    });
-    workspace.bridge_ready = true;
-    workspace.startup_phase = "bridge_ready".into();
-    workspace.startup_detail = None;
-    Ok(())
-}
-
-#[tauri::command]
-pub async fn mcp_report_window_startup_phase(
-    window: Window,
-    payload: WindowStartupPhasePayload,
-    state: State<'_, McpServerState>,
-) -> Result<(), String> {
-    record_window_startup_phase(&state, window.label(), payload.phase, payload.detail);
-    Ok(())
-}
-
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WindowOpenResultPayload {
@@ -1703,8 +1334,6 @@ pub async fn report_window_open_result(
                 else if workspace.show_welcome { RegisteredWindowMode::Welcome }
                 else { RegisteredWindowMode::Ready }
             } else { RegisteredWindowMode::OpenFailed };
-            workspace.startup_phase = if payload.success { "open_request_succeeded".into() } else { "open_request_failed".into() };
-            workspace.startup_detail = payload.message.clone();
         }
         let result = if payload.success {
             Ok(WindowOpenResult {
@@ -1717,6 +1346,31 @@ pub async fn report_window_open_result(
         let _ = pending.sender.send(result);
     }
     Ok(())
+}
+
+#[tauri::command]
+pub async fn mcp_report_window_startup_phase(
+    window: Window,
+    payload: WindowStartupPhasePayload,
+    state: State<'_, McpServerState>,
+) -> Result<(), String> {
+    record_window_startup_phase(&state, window.label(), payload.phase, payload.detail);
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn mcp_submit_tool_response(
+    request_id: String,
+    response: McpToolResponse,
+    state: State<'_, McpServerState>,
+) -> Result<(), String> {
+    let sender = state.inner.lock().unwrap().pending.remove(&request_id);
+    let Some(sender) = sender else {
+        return Err(format!("No pending MCP tool request found for {request_id}."));
+    };
+    sender
+        .send(response)
+        .map_err(|error| format!("Failed to send MCP tool response: {error}"))
 }
 
 pub fn update_window_focus(state: &McpServerState, window_id: &str, is_focused: bool) {
@@ -1737,6 +1391,8 @@ pub fn remove_window(state: &McpServerState, window_id: &str) {
     let mut inner = state.inner.lock().unwrap();
     remove_window_and_invalidate_sessions_locked(&mut inner, window_id);
 }
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
@@ -1775,9 +1431,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn ensure_session_id_preserves_existing_id() {
-        let mut inner = McpStateInner {
+    fn make_inner() -> McpStateInner {
+        McpStateInner {
             running_server: None,
             pending: HashMap::new(),
             window_open_requests: HashMap::new(),
@@ -1785,25 +1440,13 @@ mod tests {
             workspaces: HashMap::new(),
             sessions: HashMap::new(),
             next_focus_order: 0,
-        };
-
-        let session_id = ensure_session_id(&mut inner, Some("session-1".into()));
-
-        assert_eq!(session_id, "session-1");
-        assert!(inner.sessions.contains_key("session-1"));
+        }
     }
 
     #[test]
     fn require_bound_window_id_errors_when_unbound() {
-        let mut inner = McpStateInner {
-            running_server: None,
-            pending: HashMap::new(),
-            window_open_requests: HashMap::new(),
-            status: build_status(false, MCP_DEFAULT_PORT, McpServerStateKind::Disabled, None),
-            workspaces: HashMap::new(),
-            sessions: HashMap::from([("session-1".into(), McpSessionBinding::default())]),
-            next_focus_order: 0,
-        };
+        let mut inner = make_inner();
+        inner.sessions.insert("session-1".into(), McpSessionBinding::default());
 
         let response = require_bound_window_id(&mut inner, "session-1").unwrap_err();
         assert!(response.is_error);
@@ -1815,23 +1458,17 @@ mod tests {
 
     #[test]
     fn remove_window_invalidates_bound_sessions() {
-        let mut inner = McpStateInner {
-            running_server: None,
-            pending: HashMap::new(),
-            window_open_requests: HashMap::new(),
-            status: build_status(false, MCP_DEFAULT_PORT, McpServerStateKind::Disabled, None),
-            workspaces: HashMap::from([(
-                "window-a".into(),
-                workspace("window-a", Some("/tmp/project-a"), "Project A", false),
-            )]),
-            sessions: HashMap::from([(
-                "session-1".into(),
-                McpSessionBinding {
-                    bound_window_id: Some("window-a".into()),
-                },
-            )]),
-            next_focus_order: 0,
-        };
+        let mut inner = make_inner();
+        inner.workspaces.insert(
+            "window-a".into(),
+            workspace("window-a", Some("/tmp/project-a"), "Project A", false),
+        );
+        inner.sessions.insert(
+            "session-1".into(),
+            McpSessionBinding {
+                bound_window_id: Some("window-a".into()),
+            },
+        );
 
         remove_window_and_invalidate_sessions_locked(&mut inner, "window-a");
 
@@ -1847,24 +1484,15 @@ mod tests {
 
     #[test]
     fn choose_existing_workspace_for_root_prefers_matching_workspace() {
-        let inner = McpStateInner {
-            running_server: None,
-            pending: HashMap::new(),
-            window_open_requests: HashMap::new(),
-            status: build_status(false, MCP_DEFAULT_PORT, McpServerStateKind::Disabled, None),
-            workspaces: HashMap::from([
-                (
-                    "window-a".into(),
-                    workspace("window-a", Some("/tmp/project-a"), "Project A", false),
-                ),
-                (
-                    "window-b".into(),
-                    workspace("window-b", None, "Welcome", true),
-                ),
-            ]),
-            sessions: HashMap::new(),
-            next_focus_order: 0,
-        };
+        let mut inner = make_inner();
+        inner.workspaces.insert(
+            "window-a".into(),
+            workspace("window-a", Some("/tmp/project-a"), "Project A", false),
+        );
+        inner.workspaces.insert(
+            "window-b".into(),
+            workspace("window-b", None, "Welcome", true),
+        );
 
         assert_eq!(
             choose_existing_workspace_for_root(&inner, "/tmp/project-a"),
@@ -1874,36 +1502,24 @@ mod tests {
 
     #[test]
     fn choose_blank_welcome_window_ignores_non_welcome_windows_without_roots() {
-        let inner = McpStateInner {
-            running_server: None,
-            pending: HashMap::new(),
-            window_open_requests: HashMap::new(),
-            status: build_status(false, MCP_DEFAULT_PORT, McpServerStateKind::Disabled, None),
-            workspaces: HashMap::from([
-                (
-                    "window-a".into(),
-                    workspace("window-a", None, "Unsaved Scratch", false),
-                ),
-                (
-                    "window-b".into(),
-                    workspace("window-b", None, "Welcome", true),
-                ),
-            ]),
-            sessions: HashMap::new(),
-            next_focus_order: 0,
-        };
+        let mut inner = make_inner();
+        inner.workspaces.insert(
+            "window-a".into(),
+            workspace("window-a", None, "Unsaved Scratch", false),
+        );
+        inner.workspaces.insert(
+            "window-b".into(),
+            workspace("window-b", None, "Welcome", true),
+        );
 
         assert_eq!(choose_blank_welcome_window(&inner), Some("window-b".into()));
     }
 
     #[test]
     fn wait_for_window_tool_ready_requires_bridge_listener() {
-        let inner = Arc::new(Mutex::new(McpStateInner {
-            running_server: None,
-            pending: HashMap::new(),
-            window_open_requests: HashMap::new(),
-            status: build_status(false, MCP_DEFAULT_PORT, McpServerStateKind::Disabled, None),
-            workspaces: HashMap::from([(
+        let inner = Arc::new(Mutex::new({
+            let mut s = make_inner();
+            s.workspaces.insert(
                 "main".into(),
                 RegisteredWorkspace {
                     descriptor: WorkspaceDescriptor {
@@ -1922,9 +1538,8 @@ mod tests {
                     bridge_ready: false,
                     last_focused_order: 1,
                 },
-            )]),
-            sessions: HashMap::new(),
-            next_focus_order: 0,
+            );
+            s
         }));
 
         let result = wait_for_window_tool_ready(&inner, "main", Duration::from_millis(0));
@@ -1937,12 +1552,9 @@ mod tests {
 
     #[test]
     fn wait_for_window_tool_ready_succeeds_when_context_and_bridge_are_ready() {
-        let inner = Arc::new(Mutex::new(McpStateInner {
-            running_server: None,
-            pending: HashMap::new(),
-            window_open_requests: HashMap::new(),
-            status: build_status(false, MCP_DEFAULT_PORT, McpServerStateKind::Disabled, None),
-            workspaces: HashMap::from([(
+        let inner = Arc::new(Mutex::new({
+            let mut s = make_inner();
+            s.workspaces.insert(
                 "main".into(),
                 RegisteredWorkspace {
                     descriptor: WorkspaceDescriptor {
@@ -1961,12 +1573,11 @@ mod tests {
                     bridge_ready: true,
                     last_focused_order: 1,
                 },
-            )]),
-            sessions: HashMap::new(),
-            next_focus_order: 0,
+            );
+            s
         }));
 
-        let result = wait_for_window_tool_ready(&inner, "main", Duration::from_millis(0));
+        let result = wait_for_window_tool_ready(&inner, "main", Duration::from_millis(100));
 
         assert!(result.is_ok());
     }

--- a/apps/ui/src-tauri/src/mcp.rs
+++ b/apps/ui/src-tauri/src/mcp.rs
@@ -1,16 +1,18 @@
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::HashMap;
+use std::fs;
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
-use tauri::{AppHandle, Emitter, State};
+use tauri::{AppHandle, Emitter, Manager, State, Window};
 use tiny_http::{Header, Method, Request, Response, Server, StatusCode};
 use uuid::Uuid;
 
 const MCP_PROTOCOL_VERSION: &str = "2025-03-26";
 const MCP_SERVER_NAME: &str = "openscad-studio";
 const MCP_DEFAULT_PORT: u16 = 32123;
+const MCP_SESSION_HEADER: &str = "mcp-session-id";
 
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -61,6 +63,42 @@ pub struct McpToolResponse {
     pub is_error: bool,
 }
 
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceDescriptor {
+    pub window_id: String,
+    pub title: String,
+    pub workspace_root: Option<String>,
+    pub render_target_path: Option<String>,
+    pub is_focused: bool,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WindowContextPayload {
+    pub title: Option<String>,
+    pub workspace_root: Option<String>,
+    pub render_target_path: Option<String>,
+    #[serde(default = "default_true")]
+    pub ready: bool,
+}
+
+#[derive(Clone, Debug)]
+struct RegisteredWorkspace {
+    descriptor: WorkspaceDescriptor,
+    ready: bool,
+    last_focused_order: u64,
+}
+
+#[derive(Clone, Debug, Default)]
+struct McpSessionBinding {
+    bound_window_id: Option<String>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
 fn is_false(value: &bool) -> bool {
     !*value
 }
@@ -74,6 +112,9 @@ struct McpStateInner {
     running_server: Option<RunningServer>,
     pending: HashMap<String, mpsc::Sender<McpToolResponse>>,
     status: McpServerStatus,
+    workspaces: HashMap<String, RegisteredWorkspace>,
+    sessions: HashMap<String, McpSessionBinding>,
+    next_focus_order: u64,
 }
 
 #[derive(Clone)]
@@ -94,9 +135,17 @@ impl Default for McpServerState {
                     endpoint: None,
                     message: None,
                 },
+                workspaces: HashMap::new(),
+                sessions: HashMap::new(),
+                next_focus_order: 0,
             })),
         }
     }
+}
+
+struct RpcOutcome {
+    response: Option<Value>,
+    session_id: Option<String>,
 }
 
 fn endpoint_for_port(port: u16) -> String {
@@ -122,8 +171,12 @@ fn build_status(
     }
 }
 
-fn header(name: &'static [u8], value: &'static [u8]) -> Header {
+fn static_header(name: &'static [u8], value: &'static [u8]) -> Header {
     Header::from_bytes(name, value).expect("valid static header")
+}
+
+fn dynamic_header(name: &str, value: &str) -> Header {
+    Header::from_bytes(name.as_bytes(), value.as_bytes()).expect("valid dynamic header")
 }
 
 fn text_tool_response(message: impl Into<String>, is_error: bool) -> McpToolResponse {
@@ -135,14 +188,21 @@ fn text_tool_response(message: impl Into<String>, is_error: bool) -> McpToolResp
     }
 }
 
-fn json_response(status_code: u16, value: &Value) -> Response<std::io::Cursor<Vec<u8>>> {
+fn json_response(
+    status_code: u16,
+    value: &Value,
+    session_id: Option<&str>,
+) -> Response<std::io::Cursor<Vec<u8>>> {
     let mut response =
         Response::from_string(value.to_string()).with_status_code(StatusCode(status_code));
-    response.add_header(header(b"content-type", b"application/json"));
-    response.add_header(header(
+    response.add_header(static_header(b"content-type", b"application/json"));
+    response.add_header(static_header(
         b"mcp-protocol-version",
         MCP_PROTOCOL_VERSION.as_bytes(),
     ));
+    if let Some(session_id) = session_id {
+        response.add_header(dynamic_header(MCP_SESSION_HEADER, session_id));
+    }
     response
 }
 
@@ -169,6 +229,17 @@ fn jsonrpc_error(id: Value, code: i64, message: impl Into<String>) -> Value {
     })
 }
 
+fn normalize_workspace_root(path: &str) -> Option<String> {
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    fs::canonicalize(trimmed)
+        .ok()
+        .and_then(|resolved| resolved.into_os_string().into_string().ok())
+}
+
 fn remove_pending(
     inner: &Arc<Mutex<McpStateInner>>,
     request_id: &str,
@@ -176,9 +247,113 @@ fn remove_pending(
     inner.lock().unwrap().pending.remove(request_id)
 }
 
+fn list_open_workspaces_locked(inner: &McpStateInner) -> Vec<WorkspaceDescriptor> {
+    let mut workspaces: Vec<_> = inner.workspaces.values().cloned().collect();
+    workspaces.sort_by(|a, b| {
+        b.descriptor
+            .is_focused
+            .cmp(&a.descriptor.is_focused)
+            .then_with(|| b.last_focused_order.cmp(&a.last_focused_order))
+            .then_with(|| a.descriptor.title.cmp(&b.descriptor.title))
+            .then_with(|| a.descriptor.window_id.cmp(&b.descriptor.window_id))
+    });
+    workspaces
+        .into_iter()
+        .map(|entry| entry.descriptor)
+        .collect()
+}
+
+fn format_workspace_list(workspaces: &[WorkspaceDescriptor]) -> String {
+    if workspaces.is_empty() {
+        return "No OpenSCAD Studio windows are currently available for MCP binding.".into();
+    }
+
+    let lines = workspaces
+        .iter()
+        .map(|workspace| {
+            let root = workspace
+                .workspace_root
+                .clone()
+                .unwrap_or_else(|| "(no workspace root)".into());
+            let render_target = workspace
+                .render_target_path
+                .clone()
+                .unwrap_or_else(|| "(no render target)".into());
+            let focused = if workspace.is_focused { "yes" } else { "no" };
+            format!(
+                "- window_id: {}\n  title: {}\n  workspace_root: {}\n  render_target_path: {}\n  focused: {}",
+                workspace.window_id, workspace.title, root, render_target, focused
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!("Open OpenSCAD Studio workspaces:\n{lines}")
+}
+
+fn ensure_session_id(inner: &mut McpStateInner, existing_session_id: Option<String>) -> String {
+    let session_id = existing_session_id.unwrap_or_else(|| Uuid::new_v4().to_string());
+    inner.sessions.entry(session_id.clone()).or_default();
+    session_id
+}
+
+fn remove_window_and_invalidate_sessions_locked(inner: &mut McpStateInner, window_id: &str) {
+    inner.workspaces.remove(window_id);
+    for session in inner.sessions.values_mut() {
+        if session.bound_window_id.as_deref() == Some(window_id) {
+            session.bound_window_id = None;
+        }
+    }
+}
+
+fn require_bound_window_id(
+    inner: &mut McpStateInner,
+    session_id: &str,
+) -> Result<String, McpToolResponse> {
+    let Some(session) = inner.sessions.get_mut(session_id) else {
+        return Err(text_tool_response(
+            "This MCP session is not initialized. Reconnect your client and call `select_workspace` before using Studio render tools.",
+            true,
+        ));
+    };
+
+    let Some(window_id) = session.bound_window_id.clone() else {
+        let workspaces = list_open_workspaces_locked(inner);
+        return Err(text_tool_response(
+            format!(
+                "No OpenSCAD Studio workspace is selected for this MCP session.\n\nCall `select_workspace` with a `workspace_root` or `window_id` first.\n\n{}",
+                format_workspace_list(&workspaces)
+            ),
+            true,
+        ));
+    };
+
+    match inner.workspaces.get(&window_id) {
+        Some(workspace) if workspace.ready => Ok(window_id),
+        Some(_) => Err(text_tool_response(
+            format!(
+                "The selected Studio window `{window_id}` is not ready for MCP requests yet. Wait a moment and try again."
+            ),
+            true,
+        )),
+        None => {
+            session.bound_window_id = None;
+            let workspaces = list_open_workspaces_locked(inner);
+            Err(text_tool_response(
+                format!(
+                    "The previously selected Studio window `{window_id}` is no longer available. Call `select_workspace` again.\n\n{}",
+                    format_workspace_list(&workspaces)
+                ),
+                true,
+            ))
+        }
+    }
+}
+
 fn call_frontend_tool(
     app: &AppHandle,
     inner: &Arc<Mutex<McpStateInner>>,
+    window_id: &str,
     tool_name: &str,
     arguments: Value,
 ) -> Result<McpToolResponse, String> {
@@ -193,9 +368,18 @@ fn call_frontend_tool(
         arguments,
     };
 
-    if let Err(error) = app.emit("mcp:tool-request", payload) {
+    let Some(window) = app.get_webview_window(window_id) else {
         remove_pending(inner, &request_id);
-        return Err(format!("Failed to dispatch MCP tool request: {error}"));
+        return Err(format!(
+            "OpenSCAD Studio window `{window_id}` is no longer available."
+        ));
+    };
+
+    if let Err(error) = window.emit("mcp:tool-request", payload) {
+        remove_pending(inner, &request_id);
+        return Err(format!(
+            "Failed to dispatch MCP tool request to OpenSCAD Studio window `{window_id}`: {error}"
+        ));
     }
 
     match rx.recv_timeout(Duration::from_secs(30)) {
@@ -214,8 +398,35 @@ fn call_frontend_tool(
 fn tool_definitions() -> Value {
     json!([
         {
+            "name": "list_open_workspaces",
+            "description": "List the currently open OpenSCAD Studio windows that can be selected for this MCP session.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            }
+        },
+        {
+            "name": "select_workspace",
+            "description": "Bind this MCP session to an open OpenSCAD Studio workspace by exact workspace root or explicit window id.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "workspace_root": {
+                        "type": "string",
+                        "description": "Exact absolute workspace root path already open in OpenSCAD Studio."
+                    },
+                    "window_id": {
+                        "type": "string",
+                        "description": "Explicit OpenSCAD Studio window id from list_open_workspaces()."
+                    }
+                },
+                "additionalProperties": false
+            }
+        },
+        {
             "name": "get_project_context",
-            "description": "Get the current OpenSCAD Studio render target and workspace summary.",
+            "description": "Get the current OpenSCAD Studio render target and workspace summary for the selected workspace.",
             "inputSchema": {
                 "type": "object",
                 "properties": {},
@@ -270,15 +481,280 @@ fn tool_definitions() -> Value {
                 },
                 "additionalProperties": false
             }
+        },
+        {
+            "name": "export_file",
+            "description": "Export the current render target to a file path on desktop.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "format": {
+                        "type": "string",
+                        "enum": ["stl", "obj", "amf", "3mf", "svg", "dxf"]
+                    },
+                    "file_path": {
+                        "type": "string",
+                        "description": "Absolute output path, or a project-relative path when a workspace root is open."
+                    }
+                },
+                "required": ["format", "file_path"],
+                "additionalProperties": false
+            }
         }
     ])
+}
+
+fn list_open_workspaces_response(inner: &McpStateInner) -> McpToolResponse {
+    let workspaces = list_open_workspaces_locked(inner);
+    text_tool_response(format_workspace_list(&workspaces), false)
+}
+
+fn select_workspace_response(
+    inner: &mut McpStateInner,
+    session_id: &str,
+    arguments: &Value,
+) -> McpToolResponse {
+    let workspace_root = arguments
+        .get("workspace_root")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let window_id = arguments
+        .get("window_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+
+    let selected_window_id = if let Some(window_id) = window_id {
+        match inner.workspaces.get(window_id) {
+            Some(_) => window_id.to_string(),
+            None => {
+                return text_tool_response(
+                    format!(
+                        "No open OpenSCAD Studio window matches `window_id` `{window_id}`.\n\n{}",
+                        format_workspace_list(&list_open_workspaces_locked(inner))
+                    ),
+                    true,
+                )
+            }
+        }
+    } else if let Some(workspace_root) = workspace_root {
+        let Some(normalized_root) = normalize_workspace_root(workspace_root) else {
+            return text_tool_response(
+                format!("Could not resolve workspace root `{workspace_root}`."),
+                true,
+            );
+        };
+
+        let matches: Vec<_> = inner
+            .workspaces
+            .values()
+            .filter(|workspace| {
+                workspace.descriptor.workspace_root.as_deref() == Some(normalized_root.as_str())
+            })
+            .map(|workspace| workspace.descriptor.clone())
+            .collect();
+
+        match matches.len() {
+            0 => {
+                return text_tool_response(
+                    format!(
+                        "No open OpenSCAD Studio workspace matches `{normalized_root}`.\n\n{}",
+                        format_workspace_list(&list_open_workspaces_locked(inner))
+                    ),
+                    true,
+                )
+            }
+            1 => matches[0].window_id.clone(),
+            _ => {
+                let options = matches
+                    .iter()
+                    .map(|workspace| format!("- {} ({})", workspace.window_id, workspace.title))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                return text_tool_response(
+                    format!(
+                        "Multiple OpenSCAD Studio windows are open for `{normalized_root}`. Re-run `select_workspace` with a `window_id`.\n\n{options}"
+                    ),
+                    true,
+                );
+            }
+        }
+    } else {
+        return text_tool_response(
+            "select_workspace requires either `workspace_root` or `window_id`.",
+            true,
+        );
+    };
+
+    inner
+        .sessions
+        .entry(session_id.to_string())
+        .or_default()
+        .bound_window_id = Some(selected_window_id.clone());
+
+    let workspace = inner
+        .workspaces
+        .get(&selected_window_id)
+        .map(|workspace| workspace.descriptor.clone());
+
+    if let Some(workspace) = workspace {
+        let root = workspace
+            .workspace_root
+            .unwrap_or_else(|| "(no workspace root)".into());
+        let render_target = workspace
+            .render_target_path
+            .unwrap_or_else(|| "(no render target)".into());
+        text_tool_response(
+            format!(
+                "✅ Bound this MCP session to OpenSCAD Studio window `{}`.\n\nWorkspace root: {}\nRender target: {}",
+                workspace.window_id, root, render_target
+            ),
+            false,
+        )
+    } else {
+        text_tool_response(
+            format!("The selected Studio window `{selected_window_id}` is no longer available."),
+            true,
+        )
+    }
+}
+
+fn handle_tool_call(
+    app: &AppHandle,
+    inner: &Arc<Mutex<McpStateInner>>,
+    session_id: Option<String>,
+    params: Value,
+    id: Value,
+) -> Result<RpcOutcome, Value> {
+    let session_id_for_response = session_id.clone();
+    let Some(name) = params.get("name").and_then(Value::as_str) else {
+        return Err(jsonrpc_error(
+            id,
+            -32602,
+            "`tools/call` requires a string `name` parameter.",
+        ));
+    };
+
+    let arguments = params
+        .get("arguments")
+        .cloned()
+        .unwrap_or_else(|| Value::Object(Default::default()));
+
+    let result = match name {
+        "list_open_workspaces" => {
+            let inner = inner.lock().unwrap();
+            list_open_workspaces_response(&inner)
+        }
+        "select_workspace" => {
+            match session_id.as_deref() {
+                Some(session_id) => {
+                    let mut inner = inner.lock().unwrap();
+                    select_workspace_response(&mut inner, session_id, &arguments)
+                }
+                None => text_tool_response(
+                    "This MCP request does not have a session id yet. Reconnect your MCP client and retry workspace selection.",
+                    true,
+                ),
+            }
+        }
+        "get_project_context" => {
+            let maybe_window_id = {
+                let mut inner = inner.lock().unwrap();
+                match session_id.as_deref() {
+                    Some(session_id) => match require_bound_window_id(&mut inner, session_id) {
+                        Ok(window_id) => Some(window_id),
+                        Err(response) => return Ok(RpcOutcome {
+                            response: Some(jsonrpc_result(
+                                id,
+                                serde_json::to_value(response)
+                                    .expect("serializable MCP tool response"),
+                            )),
+                            session_id: session_id_for_response.clone(),
+                        }),
+                    },
+                    None => {
+                        let workspaces = list_open_workspaces_locked(&inner);
+                        let response = text_tool_response(
+                            format!(
+                                "No OpenSCAD Studio workspace is selected for this MCP session.\n\nCall `select_workspace` with a `workspace_root` or `window_id` first.\n\n{}",
+                                format_workspace_list(&workspaces)
+                            ),
+                            true,
+                        );
+                        return Ok(RpcOutcome {
+                            response: Some(jsonrpc_result(
+                                id,
+                                serde_json::to_value(response)
+                                    .expect("serializable MCP tool response"),
+                            )),
+                            session_id: session_id_for_response.clone(),
+                        });
+                    }
+                }
+            };
+
+            call_frontend_tool(
+                app,
+                inner,
+                maybe_window_id.as_deref().expect("window id present"),
+                name,
+                arguments,
+            )
+            .unwrap_or_else(|message| text_tool_response(message, true))
+        }
+        _ => {
+            let window_id = {
+                let Some(session_id) = session_id.as_deref() else {
+                    return Ok(RpcOutcome {
+                        response: Some(jsonrpc_result(
+                            id,
+                            serde_json::to_value(text_tool_response(
+                                "No OpenSCAD Studio workspace is selected for this MCP session. Call `select_workspace` first.",
+                                true,
+                            ))
+                            .expect("serializable MCP tool response"),
+                        )),
+                        session_id: session_id_for_response.clone(),
+                    });
+                };
+
+                let mut inner = inner.lock().unwrap();
+                match require_bound_window_id(&mut inner, session_id) {
+                    Ok(window_id) => window_id,
+                    Err(response) => {
+                        return Ok(RpcOutcome {
+                            response: Some(jsonrpc_result(
+                                id,
+                                serde_json::to_value(response)
+                                    .expect("serializable MCP tool response"),
+                            )),
+                            session_id: session_id_for_response.clone(),
+                        })
+                    }
+                }
+            };
+
+            call_frontend_tool(app, inner, &window_id, name, arguments)
+                .unwrap_or_else(|message| text_tool_response(message, true))
+        }
+    };
+
+    Ok(RpcOutcome {
+        response: Some(jsonrpc_result(
+            id,
+            serde_json::to_value(result).expect("serializable MCP tool response"),
+        )),
+        session_id: session_id_for_response,
+    })
 }
 
 fn handle_rpc_message(
     app: &AppHandle,
     inner: &Arc<Mutex<McpStateInner>>,
     payload: Value,
-) -> Result<Option<Value>, Value> {
+    session_id: Option<String>,
+) -> Result<RpcOutcome, Value> {
     let id = payload.get("id").cloned().unwrap_or(Value::Null);
     let Some(method) = payload.get("method").and_then(Value::as_str) else {
         return Err(jsonrpc_error(id, -32600, "Missing JSON-RPC method."));
@@ -287,50 +763,47 @@ fn handle_rpc_message(
     let params = payload.get("params").cloned().unwrap_or_else(|| json!({}));
 
     match method {
-        "initialize" => Ok(Some(jsonrpc_result(
-            id,
-            json!({
-                "protocolVersion": MCP_PROTOCOL_VERSION,
-                "capabilities": {
-                    "tools": {}
-                },
-                "serverInfo": {
-                    "name": MCP_SERVER_NAME,
-                    "version": env!("CARGO_PKG_VERSION")
-                }
-            }),
-        ))),
-        "notifications/initialized" => Ok(None),
-        "ping" => Ok(Some(jsonrpc_result(id, json!({})))),
-        "tools/list" => Ok(Some(jsonrpc_result(
-            id,
-            json!({
-                "tools": tool_definitions()
-            }),
-        ))),
-        "tools/call" => {
-            let Some(name) = params.get("name").and_then(Value::as_str) else {
-                return Err(jsonrpc_error(
-                    id,
-                    -32602,
-                    "`tools/call` requires a string `name` parameter.",
-                ));
+        "initialize" => {
+            let session_id = {
+                let mut inner = inner.lock().unwrap();
+                ensure_session_id(&mut inner, session_id)
             };
 
-            let arguments = params
-                .get("arguments")
-                .cloned()
-                .unwrap_or_else(|| Value::Object(Default::default()));
-
-            let result = call_frontend_tool(app, inner, name, arguments).map_err(|message| {
-                jsonrpc_result(id.clone(), json!(text_tool_response(message, true)))
-            })?;
-
-            Ok(Some(jsonrpc_result(
-                id,
-                serde_json::to_value(result).expect("serializable MCP tool response"),
-            )))
+            Ok(RpcOutcome {
+                response: Some(jsonrpc_result(
+                    id,
+                    json!({
+                        "protocolVersion": MCP_PROTOCOL_VERSION,
+                        "capabilities": {
+                            "tools": {}
+                        },
+                        "serverInfo": {
+                            "name": MCP_SERVER_NAME,
+                            "version": env!("CARGO_PKG_VERSION")
+                        }
+                    }),
+                )),
+                session_id: Some(session_id),
+            })
         }
+        "notifications/initialized" => Ok(RpcOutcome {
+            response: None,
+            session_id,
+        }),
+        "ping" => Ok(RpcOutcome {
+            response: Some(jsonrpc_result(id, json!({}))),
+            session_id,
+        }),
+        "tools/list" => Ok(RpcOutcome {
+            response: Some(jsonrpc_result(
+                id,
+                json!({
+                    "tools": tool_definitions()
+                }),
+            )),
+            session_id,
+        }),
+        "tools/call" => handle_tool_call(app, inner, session_id, params, id),
         _ => Err(jsonrpc_error(
             id,
             -32601,
@@ -339,14 +812,30 @@ fn handle_rpc_message(
     }
 }
 
+fn find_request_header(request: &Request, name: &'static str) -> Option<String> {
+    request
+        .headers()
+        .iter()
+        .find(|header| header.field.equiv(name))
+        .map(|header| header.value.as_str().to_string())
+}
+
 fn respond_to_request(mut request: Request, app: &AppHandle, inner: &Arc<Mutex<McpStateInner>>) {
-    if request.method() != &Method::Post {
-        let _ = request.respond(empty_response(405));
+    if request.url() != "/mcp" {
+        let _ = request.respond(empty_response(404));
         return;
     }
 
-    if request.url() != "/mcp" {
-        let _ = request.respond(empty_response(404));
+    if request.method() == &Method::Delete {
+        if let Some(session_id) = find_request_header(&request, MCP_SESSION_HEADER) {
+            inner.lock().unwrap().sessions.remove(&session_id);
+        }
+        let _ = request.respond(empty_response(204));
+        return;
+    }
+
+    if request.method() != &Method::Post {
+        let _ = request.respond(empty_response(405));
         return;
     }
 
@@ -355,6 +844,7 @@ fn respond_to_request(mut request: Request, app: &AppHandle, inner: &Arc<Mutex<M
         let _ = request.respond(json_response(
             400,
             &jsonrpc_error(Value::Null, -32700, "Failed to read request body."),
+            None,
         ));
         return;
     }
@@ -369,6 +859,7 @@ fn respond_to_request(mut request: Request, app: &AppHandle, inner: &Arc<Mutex<M
                     -32700,
                     format!("Invalid JSON payload: {error}"),
                 ),
+                None,
             ));
             return;
         }
@@ -378,19 +869,24 @@ fn respond_to_request(mut request: Request, app: &AppHandle, inner: &Arc<Mutex<M
         let _ = request.respond(json_response(
             400,
             &jsonrpc_error(Value::Null, -32600, "Batch requests are not supported."),
+            None,
         ));
         return;
     }
 
-    match handle_rpc_message(app, inner, payload) {
-        Ok(Some(response)) => {
-            let _ = request.respond(json_response(200, &response));
-        }
-        Ok(None) => {
-            let _ = request.respond(empty_response(202));
-        }
+    let session_id = find_request_header(&request, MCP_SESSION_HEADER);
+    match handle_rpc_message(app, inner, payload, session_id) {
+        Ok(outcome) => match outcome.response {
+            Some(response) => {
+                let _ =
+                    request.respond(json_response(200, &response, outcome.session_id.as_deref()));
+            }
+            None => {
+                let _ = request.respond(empty_response(202));
+            }
+        },
         Err(error) => {
-            let _ = request.respond(json_response(400, &error));
+            let _ = request.respond(json_response(400, &error, None));
         }
     }
 }
@@ -410,9 +906,10 @@ fn run_mcp_server(
             Ok(Some(request)) => respond_to_request(request, &app, &inner),
             Ok(None) => {}
             Err(error) => {
+                let port = inner.lock().unwrap().status.port;
                 inner.lock().unwrap().status = build_status(
                     true,
-                    inner.lock().unwrap().status.port,
+                    port,
                     McpServerStateKind::Error,
                     Some(format!("MCP server stopped unexpectedly: {error}")),
                 );
@@ -456,6 +953,7 @@ pub fn configure_mcp_server(
     if !enabled {
         let mut inner = state.inner.lock().unwrap();
         inner.status = build_status(false, port, McpServerStateKind::Disabled, None);
+        inner.sessions.clear();
         return Ok(inner.status.clone());
     }
 
@@ -515,11 +1013,178 @@ pub fn mcp_submit_tool_response(
         .map_err(|error| format!("Failed to send MCP tool response: {error}"))
 }
 
-pub fn shutdown_mcp_server(state: &McpServerState) {
-    let running_server = {
-        let mut inner = state.inner.lock().unwrap();
-        inner.status = build_status(false, inner.status.port, McpServerStateKind::Disabled, None);
-        inner.running_server.take()
+#[tauri::command]
+pub fn mcp_update_window_context(
+    window: Window,
+    payload: WindowContextPayload,
+    state: State<'_, McpServerState>,
+) -> Result<(), String> {
+    let label = window.label().to_string();
+    let normalized_root = payload
+        .workspace_root
+        .as_deref()
+        .and_then(normalize_workspace_root);
+    let title = payload.title.unwrap_or_else(|| "OpenSCAD Studio".into());
+    let is_focused = window.is_focused().unwrap_or(false);
+
+    let mut inner = state.inner.lock().unwrap();
+    let next_focus_order = if is_focused {
+        inner.next_focus_order += 1;
+        inner.next_focus_order
+    } else {
+        inner
+            .workspaces
+            .get(&label)
+            .map(|workspace| workspace.last_focused_order)
+            .unwrap_or(0)
     };
-    stop_running_server(running_server);
+
+    inner.workspaces.insert(
+        label.clone(),
+        RegisteredWorkspace {
+            descriptor: WorkspaceDescriptor {
+                window_id: label,
+                title,
+                workspace_root: normalized_root,
+                render_target_path: payload.render_target_path,
+                is_focused,
+            },
+            ready: payload.ready,
+            last_focused_order: next_focus_order,
+        },
+    );
+
+    Ok(())
+}
+
+pub fn update_window_focus(state: &McpServerState, window_id: &str, is_focused: bool) {
+    let mut inner = state.inner.lock().unwrap();
+    if is_focused {
+        inner.next_focus_order += 1;
+    }
+    let next_focus_order = inner.next_focus_order;
+    if let Some(workspace) = inner.workspaces.get_mut(window_id) {
+        workspace.descriptor.is_focused = is_focused;
+        if is_focused {
+            workspace.last_focused_order = next_focus_order;
+        }
+    }
+}
+
+pub fn remove_window(state: &McpServerState, window_id: &str) {
+    let mut inner = state.inner.lock().unwrap();
+    remove_window_and_invalidate_sessions_locked(&mut inner, window_id);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn workspace(window_id: &str, root: Option<&str>, title: &str) -> RegisteredWorkspace {
+        RegisteredWorkspace {
+            descriptor: WorkspaceDescriptor {
+                window_id: window_id.into(),
+                title: title.into(),
+                workspace_root: root.map(|value| value.into()),
+                render_target_path: Some("main.scad".into()),
+                is_focused: false,
+            },
+            ready: true,
+            last_focused_order: 0,
+        }
+    }
+
+    #[test]
+    fn ensure_session_id_preserves_existing_id() {
+        let mut inner = McpStateInner {
+            running_server: None,
+            pending: HashMap::new(),
+            status: build_status(false, MCP_DEFAULT_PORT, McpServerStateKind::Disabled, None),
+            workspaces: HashMap::new(),
+            sessions: HashMap::new(),
+            next_focus_order: 0,
+        };
+
+        let session_id = ensure_session_id(&mut inner, Some("session-1".into()));
+
+        assert_eq!(session_id, "session-1");
+        assert!(inner.sessions.contains_key("session-1"));
+    }
+
+    #[test]
+    fn select_workspace_binds_by_window_id() {
+        let mut inner = McpStateInner {
+            running_server: None,
+            pending: HashMap::new(),
+            status: build_status(false, MCP_DEFAULT_PORT, McpServerStateKind::Disabled, None),
+            workspaces: HashMap::from([(
+                "window-a".into(),
+                workspace("window-a", Some("/tmp/project-a"), "Project A"),
+            )]),
+            sessions: HashMap::from([("session-1".into(), McpSessionBinding::default())]),
+            next_focus_order: 0,
+        };
+
+        let response =
+            select_workspace_response(&mut inner, "session-1", &json!({ "window_id": "window-a" }));
+
+        assert!(!response.is_error);
+        assert_eq!(
+            inner
+                .sessions
+                .get("session-1")
+                .and_then(|session| session.bound_window_id.clone()),
+            Some("window-a".into())
+        );
+    }
+
+    #[test]
+    fn require_bound_window_id_errors_when_unbound() {
+        let mut inner = McpStateInner {
+            running_server: None,
+            pending: HashMap::new(),
+            status: build_status(false, MCP_DEFAULT_PORT, McpServerStateKind::Disabled, None),
+            workspaces: HashMap::new(),
+            sessions: HashMap::from([("session-1".into(), McpSessionBinding::default())]),
+            next_focus_order: 0,
+        };
+
+        let response = require_bound_window_id(&mut inner, "session-1").unwrap_err();
+        assert!(response.is_error);
+        assert!(matches!(
+            response.content.first(),
+            Some(McpContentItem::Text { text }) if text.contains("No OpenSCAD Studio workspace is selected")
+        ));
+    }
+
+    #[test]
+    fn remove_window_invalidates_bound_sessions() {
+        let mut inner = McpStateInner {
+            running_server: None,
+            pending: HashMap::new(),
+            status: build_status(false, MCP_DEFAULT_PORT, McpServerStateKind::Disabled, None),
+            workspaces: HashMap::from([(
+                "window-a".into(),
+                workspace("window-a", Some("/tmp/project-a"), "Project A"),
+            )]),
+            sessions: HashMap::from([(
+                "session-1".into(),
+                McpSessionBinding {
+                    bound_window_id: Some("window-a".into()),
+                },
+            )]),
+            next_focus_order: 0,
+        };
+
+        remove_window_and_invalidate_sessions_locked(&mut inner, "window-a");
+
+        assert!(!inner.workspaces.contains_key("window-a"));
+        assert_eq!(
+            inner
+                .sessions
+                .get("session-1")
+                .and_then(|session| session.bound_window_id.clone()),
+            None
+        );
+    }
 }

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -84,7 +84,6 @@ import type { WorkspaceTab as WorkspaceDocumentTab } from './stores/workspaceTyp
 import {
   OPENSCAD_PROJECT_FILE_EXTENSIONS,
   isOpenScadProjectFilePath,
-  isRenderableOpenScadFilePath,
   pickOpenScadRenderTarget,
 } from '../../../packages/shared/src/openscadProjectFiles';
 

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -45,6 +45,12 @@ import { useHistory } from './hooks/useHistory';
 import { useMobileLayout } from './hooks/useMobileLayout';
 import { getPlatform, eventBus, type ExportFormat } from './platform';
 import { isExportValidationError } from './services/exportErrors';
+import {
+  initializeDesktopMcpBridge,
+  notifyDesktopMcpRenderSettled,
+  syncDesktopMcpConfig,
+  updateDesktopMcpPreviewState,
+} from './services/desktopMcp';
 import { getRenderService } from './services/renderService';
 import { getPreviewSceneStyle } from './services/previewSceneConfig';
 import { isShareEnabled } from './services/shareService';
@@ -345,6 +351,37 @@ function App() {
   }, [capabilities.hasFileSystem, settings.project.defaultProjectDirectory]);
 
   useEffect(() => {
+    if (!capabilities.hasFileSystem) return;
+
+    let disposed = false;
+    void syncDesktopMcpConfig({
+      enabled: settings.mcp.enabled,
+      port: settings.mcp.port,
+    }).catch((error) => {
+      if (!disposed) {
+        console.error('[App] Failed to sync MCP config:', error);
+      }
+    });
+
+    return () => {
+      disposed = true;
+    };
+  }, [capabilities.hasFileSystem, settings.mcp.enabled, settings.mcp.port]);
+
+  useEffect(() => {
+    if (!capabilities.hasFileSystem) return;
+
+    let dispose: (() => void) | null = null;
+    void initializeDesktopMcpBridge().then((cleanup) => {
+      dispose = cleanup;
+    });
+
+    return () => {
+      dispose?.();
+    };
+  }, [capabilities.hasFileSystem]);
+
+  useEffect(() => {
     const mq = window.matchMedia(HEADER_WORKSPACE_SWITCHER_MEDIA_QUERY);
     const handleChange = (event: MediaQueryListEvent) => {
       setIsHeaderWorkspaceSwitcherHidden(event.matches);
@@ -395,6 +432,8 @@ function App() {
       };
     },
     onRenderSettled: ({ owner, code, snapshot }) => {
+      notifyDesktopMcpRenderSettled(snapshot);
+
       if (!owner) {
         return;
       }
@@ -1084,6 +1123,15 @@ function App() {
   useEffect(() => {
     updateUseModelColors(settings.viewer.showModelColors);
   }, [settings.viewer.showModelColors, updateUseModelColors]);
+
+  useEffect(() => {
+    updateDesktopMcpPreviewState({
+      previewKind: activePreviewKind,
+      previewSrc: activePreviewSrc,
+      previewSceneStyle,
+      useModelColors: settings.viewer.showModelColors,
+    });
+  }, [activePreviewKind, activePreviewSrc, previewSceneStyle, settings.viewer.showModelColors]);
 
   useEffect(() => {
     if (isShareEntry) {

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -461,7 +461,9 @@ function App() {
     async (filePath: string | null, fileName: string, content: string) => {
       if (!filePath) {
         const name = fileName || DEFAULT_TAB_NAME;
-        getProjectStore().getState().openProject(null, { [name]: content }, name);
+        getProjectStore()
+          .getState()
+          .openProject(null, { [name]: content }, name);
         return;
       }
 

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -1028,9 +1028,11 @@ function App() {
     if (Object.keys(state.files).length === 0) {
       const tab = activeTabRef.current;
       const defaultContent = '// Type your OpenSCAD code here\ncube([10, 10, 10]);';
-      void initializeProject(tab.filePath, tab.name, defaultContent);
+      // Seed the untitled web project without hydrating workspace state.
+      // Explicit file/folder opens should transition out of welcome, but the
+      // initial empty project should stay behind the welcome screen.
+      state.openProject(null, { [tab.name]: defaultContent }, tab.name);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Keep refs in sync with state

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -49,6 +49,7 @@ import {
   initializeDesktopMcpBridge,
   notifyDesktopMcpRenderSettled,
   syncDesktopMcpConfig,
+  syncDesktopMcpWindowContext,
   updateDesktopMcpPreviewState,
 } from './services/desktopMcp';
 import { getRenderService } from './services/renderService';
@@ -288,6 +289,7 @@ function App() {
   // The render target tab holds the preview — use its render state regardless of
   // which tab is currently active in the editor.
   const renderTargetPath = useProjectStore((s) => s.renderTargetPath);
+  const projectRoot = useProjectStore((s) => s.projectRoot);
   const renderTargetTab = tabs.find((t) => t.projectPath === renderTargetPath);
   const renderTargetRender = renderTargetTab?.render ?? activeRender;
   const workingDir = useWorkspaceStore(selectWorkingDirectory);
@@ -2127,8 +2129,19 @@ function App() {
   useEffect(() => {
     const fileName = activeTab.name;
     const dirtyIndicator = activeFileDirty ? '\u2022 ' : '';
-    getPlatform().setWindowTitle(`${dirtyIndicator}${fileName} - OpenSCAD Studio`);
-  }, [activeTab.name, activeFileDirty]);
+    const title = `${dirtyIndicator}${fileName} - OpenSCAD Studio`;
+    getPlatform().setWindowTitle(title);
+
+    if (capabilities.hasFileSystem) {
+      void syncDesktopMcpWindowContext({
+        title,
+        workspaceRoot: projectRoot,
+        renderTargetPath,
+      }).catch((error) => {
+        console.error('[App] Failed to sync MCP window context:', error);
+      });
+    }
+  }, [activeFileDirty, activeTab.name, capabilities.hasFileSystem, projectRoot, renderTargetPath]);
 
   useEffect(() => {
     const platform = getPlatform();
@@ -2138,7 +2151,6 @@ function App() {
   }, [anyFileDirty]);
 
   // Watch project directory for external file changes (desktop only)
-  const projectRoot = useProjectStore((s) => s.projectRoot);
   useEffect(() => {
     if (!projectRoot) return;
     const platform = getPlatform();

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -286,7 +286,7 @@ function App() {
   const renderTargetTab = tabs.find((t) => t.projectPath === renderTargetPath);
   const renderTargetRender = renderTargetTab?.render ?? activeRender;
   const activeRenderArtifact = useRenderArtifactStore((state) =>
-    renderTargetPath ? state.artifactsByTarget[renderTargetPath] ?? null : null
+    renderTargetPath ? (state.artifactsByTarget[renderTargetPath] ?? null) : null
   );
   const createTab = useWorkspaceStore((state) => state.createTab);
   const setActiveTab = useWorkspaceStore((state) => state.setActiveTab);
@@ -428,7 +428,7 @@ function App() {
       const settledRenderTargetPath =
         getProjectStore().getState().renderTargetPath ??
         (owner
-          ? getWorkspaceState().tabs.find((tab) => tab.id === owner.tabId)?.projectPath ?? null
+          ? (getWorkspaceState().tabs.find((tab) => tab.id === owner.tabId)?.projectPath ?? null)
           : null);
       if (owner && settledRenderTargetPath) {
         getRenderArtifactState().publishSettledArtifact({

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -46,7 +46,6 @@ import { useMobileLayout } from './hooks/useMobileLayout';
 import { getPlatform, eventBus, type ExportFormat } from './platform';
 import { isExportValidationError } from './services/exportErrors';
 import {
-  initializeDesktopMcpBridge,
   notifyDesktopMcpRenderSettled,
   syncDesktopMcpConfig,
   syncDesktopMcpWindowContext,
@@ -55,6 +54,7 @@ import {
 import { getRenderService } from './services/renderService';
 import { getPreviewSceneStyle } from './services/previewSceneConfig';
 import { isShareEnabled } from './services/shareService';
+import { openFileInWindow, openWorkspaceFolderInWindow } from './services/windowOpenService';
 import { useSettings, loadSettings, updateSetting } from './stores/settingsStore';
 import { getApiKey, getProviderFromModel } from './stores/apiKeyStore';
 import {
@@ -68,9 +68,9 @@ import {
 import { useWorkspaceStore, getWorkspaceState } from './stores/workspaceStore';
 import { getProjectStore, useProjectStore, getRenderTargetContent } from './stores/projectStore';
 import { requestRender } from './stores/renderRequestStore';
-import { DEFAULT_TAB_NAME, DEFAULT_OPENSCAD_CODE } from './stores/workspaceFactories';
+import { DEFAULT_TAB_NAME } from './stores/workspaceFactories';
 import { formatOpenScadCode } from './utils/formatter';
-import { addRecentFile, addRecentFolder, removeRecentFile } from './utils/recentFiles';
+import { addRecentFile, removeRecentFile } from './utils/recentFiles';
 import { captureCurrentPreview } from './utils/capturePreview';
 import { normalizeAppError, notifyError, notifySuccess } from './utils/notifications';
 import { exportProjectZip } from './utils/projectZip';
@@ -262,17 +262,6 @@ function resolvePathConflict(candidatePath: string, existing: Set<string>): stri
   return `${stem}_${i}${ext}`;
 }
 
-/**
- * Given all subdirectory paths and all file paths in a project,
- * return the directories that have no file descendants (empty folders).
- */
-function findEmptyFolders(allDirs: string[], filePaths: string[]): string[] {
-  return allDirs.filter((dir) => {
-    const prefix = dir + '/';
-    return !filePaths.some((f) => f.startsWith(prefix));
-  });
-}
-
 function App() {
   const { isMobile } = useMobileLayout();
   const [isHeaderWorkspaceSwitcherHidden, setIsHeaderWorkspaceSwitcherHidden] = useState(
@@ -298,7 +287,6 @@ function App() {
   const markTabSaved = useWorkspaceStore((state) => state.markTabSaved);
   const renameTab = useWorkspaceStore((state) => state.renameTab);
   const closeTabLocal = useWorkspaceStore((state) => state.closeTabLocal);
-  const replaceWelcomeTab = useWorkspaceStore((state) => state.replaceWelcomeTab);
   const openSharedDocument = useWorkspaceStore((state) => state.openSharedDocument);
   const reorderWorkspaceTabs = useWorkspaceStore((state) => state.reorderTabs);
   const beginTabRender = useWorkspaceStore((state) => state.beginTabRender);
@@ -369,19 +357,6 @@ function App() {
       disposed = true;
     };
   }, [capabilities.hasFileSystem, settings.mcp.enabled, settings.mcp.port]);
-
-  useEffect(() => {
-    if (!capabilities.hasFileSystem) return;
-
-    let dispose: (() => void) | null = null;
-    void initializeDesktopMcpBridge().then((cleanup) => {
-      dispose = cleanup;
-    });
-
-    return () => {
-      dispose?.();
-    };
-  }, [capabilities.hasFileSystem]);
 
   useEffect(() => {
     const mq = window.matchMedia(HEADER_WORKSPACE_SWITCHER_MEDIA_QUERY);
@@ -471,6 +446,7 @@ function App() {
   const activePreviewKind = renderTargetRender?.previewKind ?? previewKind;
   const activeDiagnostics = renderTargetRender?.diagnostics ?? diagnostics;
   const activeError = renderTargetRender?.error ?? error;
+  const activePreviewViewerId = activeTabId;
 
   const handleOpenFallbackEditor = useCallback(() => {
     setShowNux(false);
@@ -482,62 +458,24 @@ function App() {
     }
   }, [renderTargetRender?.lastRenderedContent, hideWelcomeScreen, ready]);
 
-  // Project initialization helper
-  // Populates the projectStore when a file is opened on either platform.
   const initializeProject = useCallback(
     async (filePath: string | null, fileName: string, content: string) => {
-      const store = getProjectStore();
-      const platform = getPlatform();
-
-      if (filePath) {
-        // Desktop: derive project root from file path and scan for siblings
-        const separatorIndex = filePath.lastIndexOf('/');
-        const projectRoot = separatorIndex > 0 ? filePath.substring(0, separatorIndex) : null;
-        const relativeName = filePath.substring(separatorIndex + 1);
-
-        const files: Record<string, string> = { [relativeName]: content };
-
-        if (projectRoot && platform.capabilities.hasFileSystem) {
-          try {
-            const siblings = await platform.readDirectoryFiles(
-              projectRoot,
-              [...OPENSCAD_PROJECT_FILE_EXTENSIONS],
-              true
-            );
-            for (const [relPath, siblingContent] of Object.entries(siblings)) {
-              // Don't overwrite the primary file (we have the freshest content)
-              if (relPath !== relativeName) {
-                files[relPath] = siblingContent;
-              }
-            }
-          } catch (err) {
-            console.warn('[App] Failed to scan sibling files:', err);
-          }
-        }
-
-        const renderTarget =
-          pickOpenScadRenderTarget(
-            Object.keys(files),
-            isRenderableOpenScadFilePath(relativeName) ? relativeName : null
-          ) ?? relativeName;
-
-        store.getState().openProject(projectRoot, files, renderTarget);
-
-        // Discover empty folders on disk
-        if (projectRoot && platform.capabilities.hasFileSystem) {
-          try {
-            const allDirs = await platform.readSubdirectories(projectRoot);
-            const empty = findEmptyFolders(allDirs, Object.keys(files));
-            for (const dir of empty) store.getState().addFolder(dir);
-          } catch {
-            // Non-critical — empty folders just won't appear
-          }
-        }
-      } else {
-        // Web: single file project with no disk root
+      if (!filePath) {
         const name = fileName || DEFAULT_TAB_NAME;
-        store.getState().openProject(null, { [name]: content }, name);
+        getProjectStore().getState().openProject(null, { [name]: content }, name);
+        return;
       }
+
+      await openFileInWindow(
+        {
+          path: filePath,
+          name: fileName || DEFAULT_TAB_NAME,
+          content,
+        },
+        {
+          trackRecent: true,
+        }
+      );
     },
     []
   );
@@ -1110,13 +1048,14 @@ function App() {
   useEffect(() => {
     updateCapturePreview(() =>
       captureCurrentPreview({
+        viewerId: activePreviewViewerId,
         svgSourceUrl: activePreviewKind === 'svg' ? activePreviewSrc : null,
         targetWidth: 1200,
         targetHeight: 630,
       })
     );
     return () => updateCapturePreview(null);
-  }, [activePreviewKind, activePreviewSrc, updateCapturePreview]);
+  }, [activePreviewKind, activePreviewSrc, activePreviewViewerId, updateCapturePreview]);
 
   useEffect(() => {
     updatePreviewSceneStyle(previewSceneStyle);
@@ -1130,10 +1069,17 @@ function App() {
     updateDesktopMcpPreviewState({
       previewKind: activePreviewKind,
       previewSrc: activePreviewSrc,
+      previewViewerId: activePreviewViewerId,
       previewSceneStyle,
       useModelColors: settings.viewer.showModelColors,
     });
-  }, [activePreviewKind, activePreviewSrc, previewSceneStyle, settings.viewer.showModelColors]);
+  }, [
+    activePreviewKind,
+    activePreviewSrc,
+    activePreviewViewerId,
+    previewSceneStyle,
+    settings.viewer.showModelColors,
+  ]);
 
   useEffect(() => {
     if (isShareEntry) {
@@ -1396,26 +1342,7 @@ function App() {
     let dirPath: string | null;
 
     if (hasCustomProjectDir) {
-      // User explicitly chose this directory — use it directly, loading existing files
-      await platform.createDirectory(resolvedProjectDir);
       dirPath = resolvedProjectDir;
-
-      const diskFiles = await platform.readDirectoryFiles(
-        dirPath,
-        [...OPENSCAD_PROJECT_FILE_EXTENSIONS],
-        true
-      );
-      const renderTarget = pickOpenScadRenderTarget(Object.keys(diskFiles));
-
-      if (renderTarget) {
-        // Folder has existing renderable OpenSCAD files — open as project
-        getProjectStore().getState().openProject(dirPath, diskFiles, renderTarget);
-      } else {
-        // Empty folder — create a default main.scad
-        const files = { [DEFAULT_TAB_NAME]: DEFAULT_OPENSCAD_CODE };
-        getProjectStore().getState().openProject(dirPath, files, DEFAULT_TAB_NAME);
-        await platform.writeTextFile(`${dirPath}/${DEFAULT_TAB_NAME}`, DEFAULT_OPENSCAD_CODE);
-      }
     } else {
       // Default base dir — create a random-named subdirectory
       dirPath = await platform.createProjectDirectory(resolvedProjectDir, pendingProjectName);
@@ -1423,43 +1350,15 @@ function App() {
       setPendingProjectName(generateRandomProjectName());
 
       if (!dirPath) return null;
-
-      // Write default main.scad to disk
-      const files = { [DEFAULT_TAB_NAME]: DEFAULT_OPENSCAD_CODE };
-      getProjectStore().getState().openProject(dirPath, files, DEFAULT_TAB_NAME);
-      await platform.writeTextFile(`${dirPath}/${DEFAULT_TAB_NAME}`, DEFAULT_OPENSCAD_CODE);
     }
     if (!dirPath) return null;
 
-    // Update the welcome tab with real file path
-    const renderTarget = getProjectStore().getState().renderTargetPath || DEFAULT_TAB_NAME;
-    const firstTab = getWorkspaceState().tabs[0];
-    if (firstTab) {
-      replaceWelcomeTab({
-        filePath: `${dirPath}/${renderTarget}`,
-        name: renderTarget.split('/').pop() || renderTarget,
-        projectPath: renderTarget,
-      });
-    }
-
-    addRecentFolder(dirPath);
-
-    // Notify the editor to sync its model with the new content.
-    // This handles the case where the Monaco model was created before
-    // openProject updated the store (e.g. "Start in folder" with existing files).
-    const finalContent = getProjectStore().getState().files[renderTarget]?.content;
-    if (finalContent) {
-      eventBus.emit('code-updated', { code: finalContent, source: 'file-open' });
-    }
+    await openWorkspaceFolderInWindow(dirPath, {
+      createIfEmpty: true,
+    });
 
     return dirPath;
-  }, [
-    capabilities.hasFileSystem,
-    resolvedProjectDir,
-    pendingProjectName,
-    hasCustomProjectDir,
-    replaceWelcomeTab,
-  ]);
+  }, [capabilities.hasFileSystem, resolvedProjectDir, pendingProjectName, hasCustomProjectDir]);
 
   const handleStartWithDraft = useCallback(
     (draftOverride?: AiDraft) => {
@@ -1478,9 +1377,7 @@ function App() {
 
   const handleStartManually = useCallback(() => {
     hideWelcomeScreen();
-    void initProjectDirectory().then(() => {
-      requestRender('file_open', { immediate: true });
-    });
+    void initProjectDirectory();
   }, [hideWelcomeScreen, initProjectDirectory]);
 
   const handleChangeProjectDirectory = useCallback(async () => {
@@ -1491,6 +1388,64 @@ function App() {
       setHasEphemeralProjectDir(true);
     }
   }, []);
+
+  const openWorkspaceFolderInCurrentWindow = useCallback(
+    async (
+      dirPath: string,
+      options: {
+        createIfEmpty?: boolean;
+        source?: 'recent' | 'menu_open';
+      } = {}
+    ) => {
+      setIsProjectLoading(true);
+      try {
+        const result = await openWorkspaceFolderInWindow(dirPath, {
+          createIfEmpty: options.createIfEmpty,
+        });
+
+        if (options.source) {
+          analytics.track('folder opened', {
+            source: options.source,
+            file_count: result.fileCount,
+            created_default_file: result.createdDefaultFile,
+          });
+        }
+
+        return result;
+      } finally {
+        setIsProjectLoading(false);
+      }
+    },
+    [analytics]
+  );
+
+  const openFileInCurrentWindow = useCallback(
+    async (
+      result: { path: string | null; name: string; content: string },
+      options: {
+        source?: 'open' | 'menu_open' | 'recent';
+      } = {}
+    ) => {
+      setIsProjectLoading(true);
+      try {
+        const openResult = await openFileInWindow(result);
+
+        if (options.source) {
+          analytics.track('file opened', {
+            source: options.source,
+            has_disk_path: Boolean(result.path),
+            reused_existing_tab: openResult.reusedExistingTab,
+            replaced_welcome_tab: !openResult.reusedExistingTab,
+          });
+        }
+
+        return openResult;
+      } finally {
+        setIsProjectLoading(false);
+      }
+    },
+    [analytics]
+  );
 
   const handleNuxSelect = useCallback(
     (preset: 'default' | 'ai-first' | 'customizer-first') => {
@@ -1598,46 +1553,7 @@ function App() {
         if (type === 'folder' || !isOpenScadProjectFilePath(path)) {
           const platform = getPlatform();
           if (!platform.capabilities.hasFileSystem) return 'cancelled' as const;
-
-          const files = await platform.readDirectoryFiles(
-            path,
-            [...OPENSCAD_PROJECT_FILE_EXTENSIONS],
-            true
-          );
-          const renderTarget = pickOpenScadRenderTarget(Object.keys(files));
-          if (!renderTarget) return 'removed' as const;
-
-          getProjectStore().getState().openProject(path, files, renderTarget);
-
-          // Discover empty folders
-          try {
-            const allDirs = await platform.readSubdirectories(path);
-            const empty = findEmptyFolders(allDirs, Object.keys(files));
-            for (const dir of empty) getProjectStore().getState().addFolder(dir);
-          } catch {
-            // Non-critical
-          }
-
-          const firstTab = tabs[0];
-          const shouldReplace = firstTab && !firstTab.filePath && tabs.length === 1;
-          if (shouldReplace) {
-            revokeBlobUrl(firstTab.render.previewSrc);
-            replaceWelcomeTab({
-              filePath: `${path}/${renderTarget}`,
-              name: renderTarget,
-              projectPath: renderTarget,
-            });
-          } else {
-            createNewTab(`${path}/${renderTarget}`, files[renderTarget], renderTarget);
-          }
-          hideWelcomeScreen();
-          addRecentFolder(path);
-          analytics.track('folder opened', {
-            source: 'recent',
-            file_count: Object.keys(files).length,
-          });
-
-          requestRender('file_open', { immediate: true });
+          await openWorkspaceFolderInCurrentWindow(path, { source: 'recent' });
           return 'opened' as const;
         }
 
@@ -1669,36 +1585,7 @@ function App() {
         const result = await platform.fileRead(path);
         if (!result) return 'cancelled' as const;
 
-        setIsProjectLoading(true);
-        // Initialize project store and wait for all sibling files to load
-        // before proceeding — otherwise the render fires with missing includes
-        await initializeProject(result.path, result.name, result.content);
-
-        const firstTab = tabs[0];
-        const shouldReplaceFirstTab = showWelcome && tabs.length === 1 && !firstTab.filePath;
-
-        if (shouldReplaceFirstTab) {
-          revokeBlobUrl(firstTab.render.previewSrc);
-          replaceWelcomeTab({
-            filePath: result.path,
-            name: result.name,
-            projectPath: result.name,
-          });
-        } else {
-          createNewTab(result.path, result.content, result.name);
-        }
-
-        hideWelcomeScreen();
-        setIsProjectLoading(false);
-        if (result.path) addRecentFile(result.path);
-        analytics.track('file opened', {
-          source: 'recent',
-          has_disk_path: Boolean(result.path),
-          reused_existing_tab: false,
-          replaced_welcome_tab: shouldReplaceFirstTab,
-        });
-
-        requestRender('file_open', { immediate: true });
+        await openFileInCurrentWindow(result, { source: 'recent' });
         return 'opened' as const;
       } catch (err) {
         removeRecentFile(path);
@@ -1721,11 +1608,9 @@ function App() {
     },
     [
       analytics,
-      createNewTab,
       hideWelcomeScreen,
-      initializeProject,
-      replaceWelcomeTab,
-      showWelcome,
+      openWorkspaceFolderInCurrentWindow,
+      openFileInCurrentWindow,
       switchTab,
       tabs,
     ]
@@ -1735,54 +1620,7 @@ function App() {
     try {
       const result = await getPlatform().fileOpen(OPENSCAD_FILE_FILTERS);
       if (!result) return;
-
-      if (result.path) {
-        const existingTab = tabs.find((t) => t.filePath === result.path);
-        if (existingTab) {
-          await switchTab(existingTab.id);
-          hideWelcomeScreen();
-          analytics.track('file opened', {
-            source: 'open',
-            has_disk_path: true,
-            reused_existing_tab: true,
-            replaced_welcome_tab: false,
-          });
-          return;
-        }
-      }
-
-      // Show the rendering spinner while project files load from disk
-      setIsProjectLoading(true);
-
-      // Initialize project store and wait for all sibling files to load
-      // before proceeding — otherwise the render fires with missing includes
-      await initializeProject(result.path, result.name, result.content);
-
-      const firstTab = tabs[0];
-      const shouldReplaceFirstTab = showWelcome && tabs.length === 1 && !firstTab.filePath;
-
-      if (shouldReplaceFirstTab) {
-        revokeBlobUrl(firstTab.render.previewSrc);
-        replaceWelcomeTab({
-          filePath: result.path,
-          name: result.name,
-          projectPath: result.name,
-        });
-      } else {
-        createNewTab(result.path, result.content, result.name);
-      }
-
-      hideWelcomeScreen();
-      setIsProjectLoading(false);
-      if (result.path) addRecentFile(result.path);
-      analytics.track('file opened', {
-        source: 'open',
-        has_disk_path: Boolean(result.path),
-        reused_existing_tab: false,
-        replaced_welcome_tab: shouldReplaceFirstTab,
-      });
-
-      requestRender('file_open', { immediate: true });
+      await openFileInCurrentWindow(result, { source: 'open' });
     } catch (err) {
       notifyError({
         operation: 'open-file',
@@ -1792,16 +1630,7 @@ function App() {
         logLabel: 'Failed to open file',
       });
     }
-  }, [
-    analytics,
-    createNewTab,
-    hideWelcomeScreen,
-    initializeProject,
-    replaceWelcomeTab,
-    showWelcome,
-    switchTab,
-    tabs,
-  ]);
+  }, [openFileInCurrentWindow]);
 
   // Helper function to check for unsaved changes before destructive operations
   // Returns: true if ok to proceed, false if user wants to cancel
@@ -1861,38 +1690,7 @@ function App() {
         try {
           const result = await getPlatform().fileOpen(OPENSCAD_FILE_FILTERS);
           if (!result) return;
-
-          if (result.path) {
-            const existingTab = tabsRef.current.find((t) => t.filePath === result.path);
-            if (existingTab) {
-              await switchTab(existingTab.id);
-              hideWelcomeScreen();
-              analytics.track('file opened', {
-                source: 'menu_open',
-                has_disk_path: true,
-                reused_existing_tab: true,
-                replaced_welcome_tab: false,
-              });
-              return;
-            }
-          }
-
-          setIsProjectLoading(true);
-          // Initialize project store and wait for all sibling files to load
-          await initializeProject(result.path, result.name, result.content);
-          createNewTab(result.path, result.content, result.name);
-          hideWelcomeScreen();
-          setIsProjectLoading(false);
-
-          if (result.path) addRecentFile(result.path);
-          analytics.track('file opened', {
-            source: 'menu_open',
-            has_disk_path: Boolean(result.path),
-            reused_existing_tab: false,
-            replaced_welcome_tab: false,
-          });
-
-          requestRender('file_open', { immediate: true });
+          await openFileInCurrentWindow(result, { source: 'menu_open' });
         } catch (err) {
           notifyError({
             operation: 'open-file',
@@ -1916,53 +1714,7 @@ function App() {
           const platform = getPlatform();
           const dirPath = await platform.pickDirectory();
           if (!dirPath) return;
-
-          const files = await platform.readDirectoryFiles(
-            dirPath,
-            [...OPENSCAD_PROJECT_FILE_EXTENSIONS],
-            true
-          );
-          const renderTarget = pickOpenScadRenderTarget(Object.keys(files));
-          if (!renderTarget) {
-            notifyError({
-              operation: 'open-folder',
-              error: new Error('No renderable .scad files found'),
-              fallbackMessage: 'No renderable .scad files found in the selected folder',
-              toastId: 'open-folder-empty',
-              logLabel: 'Open folder empty',
-            });
-            return;
-          }
-
-          getProjectStore().getState().openProject(dirPath, files, renderTarget);
-
-          // Discover empty folders
-          try {
-            const allDirs = await platform.readSubdirectories(dirPath);
-            const empty = findEmptyFolders(allDirs, Object.keys(files));
-            for (const dir of empty) getProjectStore().getState().addFolder(dir);
-          } catch {
-            // Non-critical
-          }
-
-          const firstTab = tabsRef.current[0];
-          const shouldReplace = firstTab && !firstTab.filePath && tabsRef.current.length === 1;
-          if (shouldReplace) {
-            revokeBlobUrl(firstTab.render.previewSrc);
-            replaceWelcomeTab({
-              filePath: `${dirPath}/${renderTarget}`,
-              name: renderTarget,
-              projectPath: renderTarget,
-            });
-          } else {
-            createNewTab(`${dirPath}/${renderTarget}`, files[renderTarget], renderTarget);
-          }
-          hideWelcomeScreen();
-          addRecentFolder(dirPath);
-
-          analytics.track('folder opened', { file_count: Object.keys(files).length });
-
-          requestRender('file_open', { immediate: true });
+          await openWorkspaceFolderInCurrentWindow(dirPath, { source: 'menu_open' });
         } catch (err) {
           notifyError({
             operation: 'open-folder',
@@ -2102,11 +1854,10 @@ function App() {
     analytics,
     createNewTab,
     hideWelcomeScreen,
-    initializeProject,
+    openFileInCurrentWindow,
+    openWorkspaceFolderInCurrentWindow,
     saveAllFiles,
-    showWelcome,
     showWelcomeScreen,
-    switchTab,
   ]);
 
   useEffect(() => {
@@ -2127,9 +1878,13 @@ function App() {
   const anyFileDirty = useProjectStore((s) => Object.values(s.files).some((f) => f.isDirty));
 
   useEffect(() => {
-    const fileName = activeTab.name;
+    const workspaceName = projectRoot
+      ? (projectRoot.split('/').filter(Boolean).pop() ?? activeTab.name)
+      : activeTab.filePath
+        ? activeTab.name
+        : 'Untitled Project';
     const dirtyIndicator = activeFileDirty ? '\u2022 ' : '';
-    const title = `${dirtyIndicator}${fileName} - OpenSCAD Studio`;
+    const title = `${dirtyIndicator}${workspaceName} - OpenSCAD Studio`;
     getPlatform().setWindowTitle(title);
 
     if (capabilities.hasFileSystem) {
@@ -2137,11 +1892,21 @@ function App() {
         title,
         workspaceRoot: projectRoot,
         renderTargetPath,
+        showWelcome,
+        mode: showWelcome ? 'welcome' : 'ready',
       }).catch((error) => {
         console.error('[App] Failed to sync MCP window context:', error);
       });
     }
-  }, [activeFileDirty, activeTab.name, capabilities.hasFileSystem, projectRoot, renderTargetPath]);
+  }, [
+    activeFileDirty,
+    activeTab.filePath,
+    activeTab.name,
+    capabilities.hasFileSystem,
+    projectRoot,
+    renderTargetPath,
+    showWelcome,
+  ]);
 
   useEffect(() => {
     const platform = getPlatform();
@@ -2771,6 +2536,7 @@ function App() {
         forkedFrom={shareOrigin?.shareId ?? null}
         capturePreview={() =>
           captureCurrentPreview({
+            viewerId: activePreviewViewerId,
             svgSourceUrl: activePreviewKind === 'svg' ? activePreviewSrc : null,
             targetWidth: 1200,
             targetHeight: 630,

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -46,10 +46,10 @@ import { useMobileLayout } from './hooks/useMobileLayout';
 import { getPlatform, eventBus, type ExportFormat } from './platform';
 import { isExportValidationError } from './services/exportErrors';
 import {
+  notifyDesktopMcpRenderStarted,
   notifyDesktopMcpRenderSettled,
   syncDesktopMcpConfig,
   syncDesktopMcpWindowContext,
-  updateDesktopMcpPreviewState,
 } from './services/desktopMcp';
 import { getRenderService } from './services/renderService';
 import { getPreviewSceneStyle } from './services/previewSceneConfig';
@@ -63,15 +63,19 @@ import {
   selectActiveTabId,
   selectShowWelcome,
   selectTabs,
-  selectWorkingDirectory,
 } from './stores/workspaceSelectors';
 import { useWorkspaceStore, getWorkspaceState } from './stores/workspaceStore';
 import { getProjectStore, useProjectStore, getRenderTargetContent } from './stores/projectStore';
 import { requestRender } from './stores/renderRequestStore';
+import {
+  createSourceHash,
+  getRenderArtifactState,
+  useRenderArtifactStore,
+} from './stores/renderArtifactStore';
 import { DEFAULT_TAB_NAME } from './stores/workspaceFactories';
 import { formatOpenScadCode } from './utils/formatter';
 import { addRecentFile, removeRecentFile } from './utils/recentFiles';
-import { captureCurrentPreview } from './utils/capturePreview';
+import { captureCurrentPreview, MAIN_PREVIEW_VIEWER_ID } from './utils/capturePreview';
 import { normalizeAppError, notifyError, notifySuccess } from './utils/notifications';
 import { exportProjectZip } from './utils/projectZip';
 import { getRelativeProjectPath } from './utils/projectFilePaths';
@@ -101,7 +105,6 @@ type MacArch = 'aarch64' | 'x64';
 const OPENSCAD_FILE_FILTERS = [
   { name: 'OpenSCAD Files', extensions: [...OPENSCAD_PROJECT_FILE_EXTENSIONS] },
 ];
-
 /** Prompt the user to pick a folder and return its project files, or null if cancelled. */
 function pickFolder(): Promise<{ files: Record<string, string>; renderTargetPath: string } | null> {
   return new Promise((resolve) => {
@@ -116,19 +119,21 @@ function pickFolder(): Promise<{ files: Record<string, string>; renderTargetPath
       }
 
       const files: Record<string, string> = {};
+      let workspaceName: string | null = null;
       for (const file of Array.from(fileList)) {
         // webkitRelativePath gives "folderName/path/to/file.scad"
         const relativePath = file.webkitRelativePath;
         if (!isOpenScadProjectFilePath(relativePath)) continue;
         // Strip the top-level folder name
         const parts = relativePath.split('/');
+        workspaceName ??= parts[0] || null;
         const pathWithoutRoot = parts.slice(1).join('/');
         if (pathWithoutRoot) {
           files[pathWithoutRoot] = await file.text();
         }
       }
 
-      const renderTargetPath = pickOpenScadRenderTarget(Object.keys(files));
+      const renderTargetPath = pickOpenScadRenderTarget(Object.keys(files), null, workspaceName);
       if (!renderTargetPath) {
         resolve(null);
         return;
@@ -280,7 +285,9 @@ function App() {
   const projectRoot = useProjectStore((s) => s.projectRoot);
   const renderTargetTab = tabs.find((t) => t.projectPath === renderTargetPath);
   const renderTargetRender = renderTargetTab?.render ?? activeRender;
-  const workingDir = useWorkspaceStore(selectWorkingDirectory);
+  const activeRenderArtifact = useRenderArtifactStore((state) =>
+    renderTargetPath ? state.artifactsByTarget[renderTargetPath] ?? null : null
+  );
   const createTab = useWorkspaceStore((state) => state.createTab);
   const setActiveTab = useWorkspaceStore((state) => state.setActiveTab);
   const markTabSaved = useWorkspaceStore((state) => state.markTabSaved);
@@ -386,7 +393,7 @@ function App() {
     source: renderTargetContent,
     contentVersion,
     suppressInitialRender: Boolean(initialShareContext) || showWelcome,
-    workingDir,
+    workingDir: projectRoot,
     autoRenderOnIdle: settings.editor.autoRenderOnIdle,
     autoRenderDelayMs: settings.editor.autoRenderDelayMs,
     library: settings.library,
@@ -400,15 +407,46 @@ function App() {
       }
 
       const tab = rtTab ?? activeTabRef.current;
+      const requestId = beginTabRender(tabId, {
+        preferredDimension: tab?.render.dimensionMode,
+      });
+      const targetPath = rtPath ?? tab?.projectPath ?? activeTabRef.current.projectPath;
+      const currentProjectRoot = getProjectStore().getState().projectRoot;
+
+      getRenderArtifactState().setActiveRenderTarget(targetPath, currentProjectRoot);
+      notifyDesktopMcpRenderStarted({
+        renderTargetPath: targetPath,
+        requestId,
+      });
+
       return {
         tabId,
-        requestId: beginTabRender(tabId, {
-          preferredDimension: tab?.render.dimensionMode,
-        }),
+        requestId,
       };
     },
     onRenderSettled: ({ owner, code, snapshot }) => {
-      notifyDesktopMcpRenderSettled(snapshot);
+      const settledRenderTargetPath =
+        getProjectStore().getState().renderTargetPath ??
+        (owner
+          ? getWorkspaceState().tabs.find((tab) => tab.id === owner.tabId)?.projectPath ?? null
+          : null);
+      if (owner && settledRenderTargetPath) {
+        getRenderArtifactState().publishSettledArtifact({
+          requestId: owner.requestId,
+          renderTargetPath: settledRenderTargetPath,
+          workspaceRoot: getProjectStore().getState().projectRoot,
+          sourceHash: createSourceHash(code),
+          previewKind: snapshot.previewKind,
+          previewSrc: snapshot.previewSrc,
+          diagnostics: snapshot.diagnostics,
+          error: snapshot.error,
+          dimensionMode: snapshot.dimensionMode,
+          sceneStyle: previewSceneStyle,
+          useModelColors: settings.viewer.showModelColors,
+          createdAt: Date.now(),
+        });
+      }
+      notifyDesktopMcpRenderSettled(owner?.requestId ?? null);
 
       if (!owner) {
         return;
@@ -441,11 +479,12 @@ function App() {
       });
     },
   });
-  const activePreviewSrc = renderTargetRender?.previewSrc ?? '';
-  const activePreviewKind = renderTargetRender?.previewKind ?? previewKind;
-  const activeDiagnostics = renderTargetRender?.diagnostics ?? diagnostics;
-  const activeError = renderTargetRender?.error ?? error;
-  const activePreviewViewerId = activeTabId;
+  const activePreviewSrc = activeRenderArtifact?.previewSrc ?? renderTargetRender?.previewSrc ?? '';
+  const activePreviewKind =
+    activeRenderArtifact?.previewKind ?? renderTargetRender?.previewKind ?? previewKind;
+  const activeDiagnostics =
+    activeRenderArtifact?.diagnostics ?? renderTargetRender?.diagnostics ?? diagnostics;
+  const activeError = activeRenderArtifact?.error ?? renderTargetRender?.error ?? error;
 
   const handleOpenFallbackEditor = useCallback(() => {
     setShowNux(false);
@@ -456,6 +495,10 @@ function App() {
       requestRender('initial', { immediate: true });
     }
   }, [renderTargetRender?.lastRenderedContent, hideWelcomeScreen, ready]);
+
+  useEffect(() => {
+    getRenderArtifactState().setActiveRenderTarget(renderTargetPath ?? null, projectRoot);
+  }, [projectRoot, renderTargetPath]);
 
   const initializeProject = useCallback(
     async (filePath: string | null, fileName: string, content: string) => {
@@ -1051,14 +1094,14 @@ function App() {
   useEffect(() => {
     updateCapturePreview(() =>
       captureCurrentPreview({
-        viewerId: activePreviewViewerId,
+        viewerId: MAIN_PREVIEW_VIEWER_ID,
         svgSourceUrl: activePreviewKind === 'svg' ? activePreviewSrc : null,
         targetWidth: 1200,
         targetHeight: 630,
       })
     );
     return () => updateCapturePreview(null);
-  }, [activePreviewKind, activePreviewSrc, activePreviewViewerId, updateCapturePreview]);
+  }, [activePreviewKind, activePreviewSrc, updateCapturePreview]);
 
   useEffect(() => {
     updatePreviewSceneStyle(previewSceneStyle);
@@ -1067,22 +1110,6 @@ function App() {
   useEffect(() => {
     updateUseModelColors(settings.viewer.showModelColors);
   }, [settings.viewer.showModelColors, updateUseModelColors]);
-
-  useEffect(() => {
-    updateDesktopMcpPreviewState({
-      previewKind: activePreviewKind,
-      previewSrc: activePreviewSrc,
-      previewViewerId: activePreviewViewerId,
-      previewSceneStyle,
-      useModelColors: settings.viewer.showModelColors,
-    });
-  }, [
-    activePreviewKind,
-    activePreviewSrc,
-    activePreviewViewerId,
-    previewSceneStyle,
-    settings.viewer.showModelColors,
-  ]);
 
   useEffect(() => {
     if (isShareEntry) {
@@ -2528,7 +2555,7 @@ function App() {
         isOpen={showExportDialog}
         onClose={() => setShowExportDialog(false)}
         source={renderTargetContent}
-        workingDir={workingDir}
+        workingDir={projectRoot}
         previewKind={activePreviewKind}
       />
       <ShareDialog
@@ -2539,7 +2566,7 @@ function App() {
         forkedFrom={shareOrigin?.shareId ?? null}
         capturePreview={() =>
           captureCurrentPreview({
-            viewerId: activePreviewViewerId,
+            viewerId: MAIN_PREVIEW_VIEWER_ID,
             svgSourceUrl: activePreviewKind === 'svg' ? activePreviewSrc : null,
             targetWidth: 1200,
             targetHeight: 630,

--- a/apps/ui/src/components/AiAccessEmptyState.tsx
+++ b/apps/ui/src/components/AiAccessEmptyState.tsx
@@ -1,148 +1,15 @@
-import { useCallback, useMemo, useState } from 'react';
-import { TbChevronDown, TbChevronRight, TbCopy } from 'react-icons/tb';
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-  Button,
-  IconButton,
-  Text,
-} from './ui';
+import { Button, Text } from './ui';
 import { useSettings } from '../stores/settingsStore';
-import {
-  buildClaudeMcpCommand,
-  buildCodexMcpCommand,
-  buildCursorMcpConfig,
-  buildOpenCodeMcpConfig,
-} from '../services/desktopMcp';
-import { notifyError, notifySuccess } from '../utils/notifications';
+import { AgentSetupTabs } from './mcp/AgentSetupTabs';
 
 interface AiAccessEmptyStateProps {
   onOpenSettings?: () => void;
   variant?: 'panel' | 'inline';
 }
 
-interface AgentSetupItem {
-  id: string;
-  label: string;
-  command: string;
-  codeLabel: 'Shell' | 'JSON';
-  instruction: string;
-  instructionDetail?: string;
-}
-
-function SetupCodeBlock({
-  label,
-  value,
-  onCopy,
-}: {
-  label: string;
-  value: string;
-  onCopy: () => void;
-}) {
-  return (
-    <div
-      className="overflow-hidden rounded-lg border"
-      style={{
-        backgroundColor: 'color-mix(in srgb, var(--bg-tertiary) 75%, var(--bg-primary))',
-        borderColor: 'var(--border-primary)',
-      }}
-    >
-      <div
-        className="flex items-center justify-between px-3 py-2"
-        style={{
-          borderBottom: '1px solid var(--border-primary)',
-          backgroundColor: 'color-mix(in srgb, var(--bg-secondary) 88%, var(--bg-primary))',
-        }}
-      >
-        <Text variant="caption" weight="medium">
-          {label}
-        </Text>
-        <IconButton
-          size="sm"
-          variant="default"
-          aria-label="Copy setup"
-          title="Copy setup"
-          onClick={onCopy}
-        >
-          <TbCopy size={16} />
-        </IconButton>
-      </div>
-      <pre
-        className="m-0 overflow-x-auto px-4 py-3 text-xs leading-7"
-        style={{
-          color: 'var(--text-secondary)',
-          fontFamily: 'var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace)',
-          whiteSpace: 'pre-wrap',
-          wordBreak: 'break-word',
-        }}
-      >
-        {value}
-      </pre>
-    </div>
-  );
-}
-
 export function AiAccessEmptyState({ onOpenSettings, variant = 'panel' }: AiAccessEmptyStateProps) {
   const [settings] = useSettings();
-  const [openItem, setOpenItem] = useState('claude');
   const port = settings.mcp.port;
-  const commands = useMemo<AgentSetupItem[]>(
-    () => [
-      {
-        id: 'claude',
-        label: 'Claude Code',
-        command: buildClaudeMcpCommand(port),
-        codeLabel: 'Shell',
-        instruction:
-          'Run this command in your terminal to register OpenSCAD Studio as an MCP server, then call get_or_create_workspace with your repo root before using render tools.',
-      },
-      {
-        id: 'cursor',
-        label: 'Cursor',
-        command: buildCursorMcpConfig(port),
-        codeLabel: 'JSON',
-        instruction:
-          'Go to Cursor -> Settings -> Cursor Settings -> MCP and add the OpenSCAD Studio MCP server. Then call get_or_create_workspace with your repo root before using render tools.',
-        instructionDetail: 'You can also edit your mcp.json directly:',
-      },
-      {
-        id: 'codex',
-        label: 'Codex',
-        command: buildCodexMcpCommand(port),
-        codeLabel: 'Shell',
-        instruction:
-          'Run this command in your terminal to add the OpenSCAD Studio MCP endpoint, then call get_or_create_workspace with your repo root before using render tools.',
-      },
-      {
-        id: 'opencode',
-        label: 'OpenCode',
-        command: buildOpenCodeMcpConfig(port),
-        codeLabel: 'JSON',
-        instruction:
-          'Open OpenCode MCP settings and add the OpenSCAD Studio MCP server. Then call get_or_create_workspace with your repo root before using render tools.',
-        instructionDetail: 'You can also edit ~/.config/opencode/opencode.json directly:',
-      },
-    ],
-    [port]
-  );
-
-  const copyText = useCallback(async (label: string, value: string) => {
-    try {
-      await navigator.clipboard.writeText(value);
-      notifySuccess(`${label} copied`, {
-        toastId: `copy-${label.toLowerCase().replace(/\s+/g, '-')}`,
-      });
-    } catch (error) {
-      notifyError({
-        operation: 'copy-ai-access-setup',
-        error,
-        fallbackMessage: `Failed to copy ${label.toLowerCase()}`,
-      });
-    }
-  }, []);
-
   const isPanel = variant === 'panel';
 
   return (
@@ -176,61 +43,7 @@ export function AiAccessEmptyState({ onOpenSettings, variant = 'panel' }: AiAcce
             Desktop agent setup
           </Text>
 
-          <Accordion
-            type="single"
-            collapsible
-            value={openItem}
-            onValueChange={(value) => setOpenItem(value)}
-            className="space-y-2"
-          >
-            {commands.map((item) => {
-              const isOpen = openItem === item.id;
-              const ToggleIcon = isOpen ? TbChevronDown : TbChevronRight;
-
-              return (
-                <AccordionItem
-                  key={item.id}
-                  value={item.id}
-                  className="rounded-lg border overflow-hidden"
-                  style={{
-                    backgroundColor: 'var(--bg-tertiary)',
-                    borderColor: 'var(--border-primary)',
-                  }}
-                >
-                  <AccordionTrigger
-                    className="flex w-full items-center justify-between px-3 py-2 text-left"
-                    style={{ color: 'var(--text-primary)' }}
-                  >
-                    <span className="flex items-center gap-2">
-                      <ToggleIcon size={14} style={{ color: 'var(--text-secondary)' }} />
-                      <span className="text-sm font-medium">{item.label}</span>
-                    </span>
-                    <span className="text-xs" style={{ color: 'var(--text-secondary)' }}>
-                      {isOpen ? 'Hide command' : 'Show command'}
-                    </span>
-                  </AccordionTrigger>
-                  <AccordionContent
-                    className="space-y-3 px-3 pb-3 pt-3"
-                    style={{ borderTop: '1px solid var(--border-secondary)' }}
-                  >
-                    <div className="space-y-2">
-                      <Text variant="caption">{item.instruction}</Text>
-                      {item.instructionDetail ? (
-                        <Text variant="caption" color="secondary">
-                          {item.instructionDetail}
-                        </Text>
-                      ) : null}
-                    </div>
-                    <SetupCodeBlock
-                      label={item.codeLabel}
-                      value={item.command}
-                      onCopy={() => void copyText(`${item.label} MCP command`, item.command)}
-                    />
-                  </AccordionContent>
-                </AccordionItem>
-              );
-            })}
-          </Accordion>
+          <AgentSetupTabs port={port} surface="panel" />
 
           <Text variant="caption" color="secondary">
             Desktop only. Studio stays open while your external agent uses MCP, and each MCP session

--- a/apps/ui/src/components/AiAccessEmptyState.tsx
+++ b/apps/ui/src/components/AiAccessEmptyState.tsx
@@ -96,7 +96,7 @@ export function AiAccessEmptyState({ onOpenSettings, variant = 'panel' }: AiAcce
         command: buildClaudeMcpCommand(port),
         codeLabel: 'Shell',
         instruction:
-          'Run this command in your terminal to register OpenSCAD Studio as an MCP server, then call select_workspace with your repo root before using render tools.',
+          'Run this command in your terminal to register OpenSCAD Studio as an MCP server, then call get_or_create_workspace with your repo root before using render tools.',
       },
       {
         id: 'cursor',
@@ -104,7 +104,7 @@ export function AiAccessEmptyState({ onOpenSettings, variant = 'panel' }: AiAcce
         command: buildCursorMcpConfig(port),
         codeLabel: 'JSON',
         instruction:
-          'Go to Cursor -> Settings -> Cursor Settings -> MCP and add the OpenSCAD Studio MCP server. Then call select_workspace with your repo root before using render tools.',
+          'Go to Cursor -> Settings -> Cursor Settings -> MCP and add the OpenSCAD Studio MCP server. Then call get_or_create_workspace with your repo root before using render tools.',
         instructionDetail: 'You can also edit your mcp.json directly:',
       },
       {
@@ -113,7 +113,7 @@ export function AiAccessEmptyState({ onOpenSettings, variant = 'panel' }: AiAcce
         command: buildCodexMcpCommand(port),
         codeLabel: 'Shell',
         instruction:
-          'Run this command in your terminal to add the OpenSCAD Studio MCP endpoint, then call select_workspace with your repo root before using render tools.',
+          'Run this command in your terminal to add the OpenSCAD Studio MCP endpoint, then call get_or_create_workspace with your repo root before using render tools.',
       },
       {
         id: 'opencode',
@@ -121,7 +121,7 @@ export function AiAccessEmptyState({ onOpenSettings, variant = 'panel' }: AiAcce
         command: buildOpenCodeMcpConfig(port),
         codeLabel: 'JSON',
         instruction:
-          'Open OpenCode MCP settings and add the OpenSCAD Studio MCP server. Then call select_workspace with your repo root before using render tools.',
+          'Open OpenCode MCP settings and add the OpenSCAD Studio MCP server. Then call get_or_create_workspace with your repo root before using render tools.',
         instructionDetail: 'You can also edit ~/.config/opencode/opencode.json directly:',
       },
     ],

--- a/apps/ui/src/components/AiAccessEmptyState.tsx
+++ b/apps/ui/src/components/AiAccessEmptyState.tsx
@@ -1,0 +1,243 @@
+import { useCallback, useMemo, useState } from 'react';
+import { TbChevronDown, TbChevronRight, TbCopy } from 'react-icons/tb';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+  Button,
+  IconButton,
+  Text,
+} from './ui';
+import { useSettings } from '../stores/settingsStore';
+import {
+  buildClaudeMcpCommand,
+  buildCodexMcpCommand,
+  buildCursorMcpConfig,
+  buildOpenCodeMcpConfig,
+} from '../services/desktopMcp';
+import { notifyError, notifySuccess } from '../utils/notifications';
+
+interface AiAccessEmptyStateProps {
+  onOpenSettings?: () => void;
+  variant?: 'panel' | 'inline';
+}
+
+interface AgentSetupItem {
+  id: string;
+  label: string;
+  command: string;
+  codeLabel: 'Shell' | 'JSON';
+  instruction: string;
+  instructionDetail?: string;
+}
+
+function SetupCodeBlock({
+  label,
+  value,
+  onCopy,
+}: {
+  label: string;
+  value: string;
+  onCopy: () => void;
+}) {
+  return (
+    <div
+      className="overflow-hidden rounded-lg border"
+      style={{
+        backgroundColor: 'color-mix(in srgb, var(--bg-tertiary) 75%, var(--bg-primary))',
+        borderColor: 'var(--border-primary)',
+      }}
+    >
+      <div
+        className="flex items-center justify-between px-3 py-2"
+        style={{
+          borderBottom: '1px solid var(--border-primary)',
+          backgroundColor: 'color-mix(in srgb, var(--bg-secondary) 88%, var(--bg-primary))',
+        }}
+      >
+        <Text variant="caption" weight="medium">
+          {label}
+        </Text>
+        <IconButton
+          size="sm"
+          variant="default"
+          aria-label="Copy setup"
+          title="Copy setup"
+          onClick={onCopy}
+        >
+          <TbCopy size={16} />
+        </IconButton>
+      </div>
+      <pre
+        className="m-0 overflow-x-auto px-4 py-3 text-xs leading-7"
+        style={{
+          color: 'var(--text-secondary)',
+          fontFamily: 'var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace)',
+          whiteSpace: 'pre-wrap',
+          wordBreak: 'break-word',
+        }}
+      >
+        {value}
+      </pre>
+    </div>
+  );
+}
+
+export function AiAccessEmptyState({ onOpenSettings, variant = 'panel' }: AiAccessEmptyStateProps) {
+  const [settings] = useSettings();
+  const [openItem, setOpenItem] = useState('claude');
+  const port = settings.mcp.port;
+  const commands = useMemo<AgentSetupItem[]>(
+    () => [
+      {
+        id: 'claude',
+        label: 'Claude Code',
+        command: buildClaudeMcpCommand(port),
+        codeLabel: 'Shell',
+        instruction:
+          'Run this command in your terminal to register OpenSCAD Studio as an MCP server, then call select_workspace with your repo root before using render tools.',
+      },
+      {
+        id: 'cursor',
+        label: 'Cursor',
+        command: buildCursorMcpConfig(port),
+        codeLabel: 'JSON',
+        instruction:
+          'Go to Cursor -> Settings -> Cursor Settings -> MCP and add the OpenSCAD Studio MCP server. Then call select_workspace with your repo root before using render tools.',
+        instructionDetail: 'You can also edit your mcp.json directly:',
+      },
+      {
+        id: 'codex',
+        label: 'Codex',
+        command: buildCodexMcpCommand(port),
+        codeLabel: 'Shell',
+        instruction:
+          'Run this command in your terminal to add the OpenSCAD Studio MCP endpoint, then call select_workspace with your repo root before using render tools.',
+      },
+      {
+        id: 'opencode',
+        label: 'OpenCode',
+        command: buildOpenCodeMcpConfig(port),
+        codeLabel: 'JSON',
+        instruction:
+          'Open OpenCode MCP settings and add the OpenSCAD Studio MCP server. Then call select_workspace with your repo root before using render tools.',
+        instructionDetail: 'You can also edit ~/.config/opencode/opencode.json directly:',
+      },
+    ],
+    [port]
+  );
+
+  const copyText = useCallback(async (label: string, value: string) => {
+    try {
+      await navigator.clipboard.writeText(value);
+      notifySuccess(`${label} copied`, {
+        toastId: `copy-${label.toLowerCase().replace(/\s+/g, '-')}`,
+      });
+    } catch (error) {
+      notifyError({
+        operation: 'copy-ai-access-setup',
+        error,
+        fallbackMessage: `Failed to copy ${label.toLowerCase()}`,
+      });
+    }
+  }, []);
+
+  const isPanel = variant === 'panel';
+
+  return (
+    <div
+      data-testid={`ai-access-empty-state-${variant}`}
+      className={`rounded-xl border ${isPanel ? 'max-w-xl p-6' : 'p-4'} mx-auto`}
+      style={{
+        backgroundColor: 'var(--bg-secondary)',
+        borderColor: 'var(--border-secondary)',
+      }}
+    >
+      <div className="flex flex-col gap-5">
+        <div className="space-y-2 text-left">
+          <Text variant={isPanel ? 'section-heading' : 'body'} weight="medium">
+            Use built-in AI or Studio MCP
+          </Text>
+          <Text variant="caption" color="secondary">
+            Add an Anthropic or OpenAI API key in Settings, or connect a desktop agent to Studio
+            over MCP.
+          </Text>
+        </div>
+
+        <div className="flex justify-start gap-2">
+          <Button type="button" variant="primary" onClick={() => onOpenSettings?.()}>
+            Add API Key
+          </Button>
+        </div>
+
+        <div className="w-full space-y-2 text-left">
+          <Text variant="caption" weight="semibold" color="secondary">
+            Desktop agent setup
+          </Text>
+
+          <Accordion
+            type="single"
+            collapsible
+            value={openItem}
+            onValueChange={(value) => setOpenItem(value)}
+            className="space-y-2"
+          >
+            {commands.map((item) => {
+              const isOpen = openItem === item.id;
+              const ToggleIcon = isOpen ? TbChevronDown : TbChevronRight;
+
+              return (
+                <AccordionItem
+                  key={item.id}
+                  value={item.id}
+                  className="rounded-lg border overflow-hidden"
+                  style={{
+                    backgroundColor: 'var(--bg-tertiary)',
+                    borderColor: 'var(--border-primary)',
+                  }}
+                >
+                  <AccordionTrigger
+                    className="flex w-full items-center justify-between px-3 py-2 text-left"
+                    style={{ color: 'var(--text-primary)' }}
+                  >
+                    <span className="flex items-center gap-2">
+                      <ToggleIcon size={14} style={{ color: 'var(--text-secondary)' }} />
+                      <span className="text-sm font-medium">{item.label}</span>
+                    </span>
+                    <span className="text-xs" style={{ color: 'var(--text-secondary)' }}>
+                      {isOpen ? 'Hide command' : 'Show command'}
+                    </span>
+                  </AccordionTrigger>
+                  <AccordionContent
+                    className="space-y-3 px-3 pb-3 pt-3"
+                    style={{ borderTop: '1px solid var(--border-secondary)' }}
+                  >
+                    <div className="space-y-2">
+                      <Text variant="caption">{item.instruction}</Text>
+                      {item.instructionDetail ? (
+                        <Text variant="caption" color="secondary">
+                          {item.instructionDetail}
+                        </Text>
+                      ) : null}
+                    </div>
+                    <SetupCodeBlock
+                      label={item.codeLabel}
+                      value={item.command}
+                      onCopy={() => void copyText(`${item.label} MCP command`, item.command)}
+                    />
+                  </AccordionContent>
+                </AccordionItem>
+              );
+            })}
+          </Accordion>
+
+          <Text variant="caption" color="secondary">
+            Desktop only. Studio stays open while your external agent uses MCP, and each MCP session
+            must select a workspace before render tools will run.
+          </Text>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/components/AiAccessEmptyState.tsx
+++ b/apps/ui/src/components/AiAccessEmptyState.tsx
@@ -5,52 +5,96 @@ import { AgentSetupTabs } from './mcp/AgentSetupTabs';
 interface AiAccessEmptyStateProps {
   onOpenSettings?: () => void;
   variant?: 'panel' | 'inline';
+  panelLayout?: 'stacked' | 'split';
 }
 
-export function AiAccessEmptyState({ onOpenSettings, variant = 'panel' }: AiAccessEmptyStateProps) {
+export function AiAccessEmptyState({
+  onOpenSettings,
+  variant = 'panel',
+  panelLayout = 'stacked',
+}: AiAccessEmptyStateProps) {
   const [settings] = useSettings();
   const port = settings.mcp.port;
   const isPanel = variant === 'panel';
+  const useLandscapeLayout = isPanel && panelLayout === 'split';
 
   return (
     <div
       data-testid={`ai-access-empty-state-${variant}`}
-      className={`rounded-xl border ${isPanel ? 'max-w-xl p-6' : 'p-4'} mx-auto`}
+      className={`rounded-xl border ${isPanel ? (useLandscapeLayout ? 'w-full max-w-5xl p-5' : 'max-w-xl p-6') : 'p-4'} mx-auto`}
       style={{
         backgroundColor: 'var(--bg-secondary)',
         borderColor: 'var(--border-secondary)',
       }}
     >
-      <div className="flex flex-col gap-5">
-        <div className="space-y-2 text-left">
-          <Text variant={isPanel ? 'section-heading' : 'body'} weight="medium">
-            Use built-in AI or Studio MCP
-          </Text>
-          <Text variant="caption" color="secondary">
-            Add an Anthropic or OpenAI API key in Settings, or connect a desktop agent to Studio
-            over MCP.
-          </Text>
+      {isPanel && useLandscapeLayout ? (
+        <div className="grid grid-cols-[minmax(0,16rem)_minmax(0,1fr)] gap-5">
+          <div
+            className="flex min-w-0 flex-col gap-4 pr-5 text-left"
+            style={{ borderRight: '1px solid var(--border-secondary)' }}
+          >
+            <div className="space-y-2">
+              <Text variant="section-heading" weight="medium">
+                Built-in AI
+              </Text>
+              <Text variant="caption" color="secondary">
+                Add an Anthropic or OpenAI API key in Settings to use Studio&apos;s built-in AI
+                assistant.
+              </Text>
+            </div>
+
+            <div className="flex justify-start">
+              <Button type="button" variant="primary" onClick={() => onOpenSettings?.()}>
+                Add API Key
+              </Button>
+            </div>
+          </div>
+
+          <div className="min-w-0 space-y-3 text-left">
+            <Text variant="section-heading" weight="medium">
+              Desktop agent setup
+            </Text>
+
+            <AgentSetupTabs port={port} surface="panel" layout="split" />
+
+            <Text variant="caption" color="secondary">
+              Desktop only. Studio stays open while your external agent uses MCP, and each MCP
+              session must select a workspace before render tools will run.
+            </Text>
+          </div>
         </div>
+      ) : (
+        <div className="flex flex-col gap-5">
+          <div className="space-y-2 text-left">
+            <Text variant={isPanel ? 'section-heading' : 'body'} weight="medium">
+              Use built-in AI or Studio MCP
+            </Text>
+            <Text variant="caption" color="secondary">
+              Add an Anthropic or OpenAI API key in Settings, or connect a desktop agent to Studio
+              over MCP.
+            </Text>
+          </div>
 
-        <div className="flex justify-start gap-2">
-          <Button type="button" variant="primary" onClick={() => onOpenSettings?.()}>
-            Add API Key
-          </Button>
+          <div className="flex justify-start gap-2">
+            <Button type="button" variant="primary" onClick={() => onOpenSettings?.()}>
+              Add API Key
+            </Button>
+          </div>
+
+          <div className="w-full space-y-2 text-left">
+            <Text variant="caption" weight="semibold" color="secondary">
+              Desktop agent setup
+            </Text>
+
+            <AgentSetupTabs port={port} surface="panel" />
+
+            <Text variant="caption" color="secondary">
+              Desktop only. Studio stays open while your external agent uses MCP, and each MCP
+              session must select a workspace before render tools will run.
+            </Text>
+          </div>
         </div>
-
-        <div className="w-full space-y-2 text-left">
-          <Text variant="caption" weight="semibold" color="secondary">
-            Desktop agent setup
-          </Text>
-
-          <AgentSetupTabs port={port} surface="panel" />
-
-          <Text variant="caption" color="secondary">
-            Desktop only. Studio stays open while your external agent uses MCP, and each MCP session
-            must select a workspace before render tools will run.
-          </Text>
-        </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/apps/ui/src/components/AiPromptPanel.tsx
+++ b/apps/ui/src/components/AiPromptPanel.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, forwardRef, useImperativeHandle } from 'react';
+import { useRef, useEffect, useState, forwardRef, useImperativeHandle } from 'react';
 import { ChatImage, ChatImageGrid } from './ChatImage';
 import { Button } from './ui';
 import { MarkdownMessage } from './MarkdownMessage';
@@ -163,6 +163,10 @@ export const AiPromptPanel = forwardRef<AiPromptPanelRef, AiPromptPanelProps>(
     const hasApiKey = useHasApiKey();
     const responseRef = useRef<HTMLDivElement>(null);
     const composerRef = useRef<AiComposerRef>(null);
+    const emptyStateHostRef = useRef<HTMLDivElement>(null);
+    const [emptyStatePanelLayout, setEmptyStatePanelLayout] = useState<'stacked' | 'split'>(
+      'stacked'
+    );
     const { restoreToCheckpoint } = useHistory();
 
     useImperativeHandle(ref, () => ({
@@ -190,6 +194,32 @@ export const AiPromptPanel = forwardRef<AiPromptPanelRef, AiPromptPanelProps>(
       });
       // Only fire once per panel mount.
       // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    useEffect(() => {
+      if (typeof ResizeObserver === 'undefined') {
+        setEmptyStatePanelLayout('stacked');
+        return;
+      }
+
+      const node = emptyStateHostRef.current;
+      if (!node) return;
+
+      const updateLayout = (width: number, height: number) => {
+        setEmptyStatePanelLayout(width >= 760 && width / Math.max(height, 1) >= 1.45 ? 'split' : 'stacked');
+      };
+
+      const rect = node.getBoundingClientRect();
+      updateLayout(rect.width, rect.height);
+
+      const observer = new ResizeObserver((entries) => {
+        const entry = entries[0];
+        if (!entry) return;
+        updateLayout(entry.contentRect.width, entry.contentRect.height);
+      });
+
+      observer.observe(node);
+      return () => observer.disconnect();
     }, []);
 
     const handleRestoreCheckpoint = async (checkpointId: string, messageId: string) => {
@@ -239,11 +269,16 @@ export const AiPromptPanel = forwardRef<AiPromptPanelRef, AiPromptPanelProps>(
       const isDesktop = getPlatform().capabilities.hasFileSystem;
       return (
         <div
-          className="h-full flex items-center justify-center px-6"
+          ref={emptyStateHostRef}
+          className="h-full overflow-y-auto flex items-start justify-center px-6 py-6"
           style={{ backgroundColor: 'var(--bg-primary)' }}
         >
           {isDesktop ? (
-            <AiAccessEmptyState onOpenSettings={onOpenSettings} variant="panel" />
+            <AiAccessEmptyState
+              onOpenSettings={onOpenSettings}
+              variant="panel"
+              panelLayout={emptyStatePanelLayout}
+            />
           ) : (
             <div className="text-center max-w-xs">
               <div className="text-sm mb-3" style={{ color: 'var(--text-secondary)' }}>

--- a/apps/ui/src/components/AiPromptPanel.tsx
+++ b/apps/ui/src/components/AiPromptPanel.tsx
@@ -1,9 +1,10 @@
 import { useRef, useEffect, forwardRef, useImperativeHandle } from 'react';
 import { ChatImage, ChatImageGrid } from './ChatImage';
-import { Button, Text } from './ui';
+import { Button } from './ui';
 import { MarkdownMessage } from './MarkdownMessage';
 import { ModelSelector } from './ModelSelector';
 import { AiComposer, type AiComposerRef } from './AiComposer';
+import { AiAccessEmptyState } from './AiAccessEmptyState';
 import { useAnalytics, type ModelSelectionSurface } from '../analytics/runtime';
 import { useHistory } from '../hooks/useHistory';
 import { getPlatform } from '../platform';
@@ -235,19 +236,24 @@ export const AiPromptPanel = forwardRef<AiPromptPanelRef, AiPromptPanelProps>(
     };
 
     if (!hasApiKey) {
+      const isDesktop = getPlatform().capabilities.hasFileSystem;
       return (
         <div
           className="h-full flex items-center justify-center px-6"
           style={{ backgroundColor: 'var(--bg-primary)' }}
         >
-          <div className="text-center max-w-xs">
-            <Text variant="body" className="mb-3">
-              Add an API key to get started
-            </Text>
-            <Button type="button" variant="primary" onClick={() => onOpenSettings?.()}>
-              Open Settings
-            </Button>
-          </div>
+          {isDesktop ? (
+            <AiAccessEmptyState onOpenSettings={onOpenSettings} variant="panel" />
+          ) : (
+            <div className="text-center max-w-xs">
+              <div className="text-sm mb-3" style={{ color: 'var(--text-secondary)' }}>
+                Add an API key to get started
+              </div>
+              <Button type="button" variant="primary" onClick={() => onOpenSettings?.()}>
+                Open Settings
+              </Button>
+            </div>
+          )}
         </div>
       );
     }

--- a/apps/ui/src/components/AiPromptPanel.tsx
+++ b/apps/ui/src/components/AiPromptPanel.tsx
@@ -206,7 +206,9 @@ export const AiPromptPanel = forwardRef<AiPromptPanelRef, AiPromptPanelProps>(
       if (!node) return;
 
       const updateLayout = (width: number, height: number) => {
-        setEmptyStatePanelLayout(width >= 760 && width / Math.max(height, 1) >= 1.45 ? 'split' : 'stacked');
+        setEmptyStatePanelLayout(
+          width >= 760 && width / Math.max(height, 1) >= 1.45 ? 'split' : 'stacked'
+        );
       };
 
       const rect = node.getBoundingClientRect();

--- a/apps/ui/src/components/AiPromptPanel.tsx
+++ b/apps/ui/src/components/AiPromptPanel.tsx
@@ -272,7 +272,11 @@ export const AiPromptPanel = forwardRef<AiPromptPanelRef, AiPromptPanelProps>(
       return (
         <div
           ref={emptyStateHostRef}
-          className="h-full overflow-y-auto flex items-start justify-center px-6 py-6"
+          className={
+            isDesktop
+              ? 'h-full overflow-y-auto flex items-start justify-center px-6 py-6'
+              : 'h-full overflow-y-auto flex items-center justify-center px-6'
+          }
           style={{ backgroundColor: 'var(--bg-primary)' }}
         >
           {isDesktop ? (

--- a/apps/ui/src/components/Preview.tsx
+++ b/apps/ui/src/components/Preview.tsx
@@ -98,6 +98,7 @@ export function Preview({
       <SvgViewer
         key={src}
         src={src}
+        viewerId={viewerId}
         onVisualReady={onVisualReady}
         hasCurrentModelApiKey={hasCurrentModelApiKey}
         canAttachToAi={canAttachViewerAnnotation}

--- a/apps/ui/src/components/SvgViewer.tsx
+++ b/apps/ui/src/components/SvgViewer.tsx
@@ -54,6 +54,7 @@ import type Konva from 'konva';
 
 interface SvgViewerProps {
   src: string;
+  viewerId?: string;
   onVisualReady?: () => void;
   hasCurrentModelApiKey: boolean;
   canAttachToAi: boolean;
@@ -358,6 +359,7 @@ function StatusCard({
 
 export function SvgViewer({
   src,
+  viewerId,
   onVisualReady,
   hasCurrentModelApiKey,
   canAttachToAi,
@@ -1210,6 +1212,7 @@ export function SvgViewer({
           ref={containerRef}
           className="relative flex-1 min-w-0 outline-none"
           style={{ backgroundColor: themeColors.background, touchAction: 'none' }}
+          data-preview-root={viewerId ?? 'default-preview'}
           data-testid="preview-2d-container"
           tabIndex={0}
           onKeyDown={handleKeyDown}

--- a/apps/ui/src/components/ThreeViewer.tsx
+++ b/apps/ui/src/components/ThreeViewer.tsx
@@ -1645,7 +1645,11 @@ export function ThreeViewer({
             loadedModel={loadedModel}
           />
         )}
-        <div ref={previewSurfaceRef} className="relative flex-1 min-w-0">
+        <div
+          ref={previewSurfaceRef}
+          className="relative flex-1 min-w-0"
+          data-preview-root={viewerId ?? 'default-preview'}
+        >
           <div
             className="absolute top-2 right-2 z-10 flex gap-2"
             onClick={(event) => event.stopPropagation()}

--- a/apps/ui/src/components/__tests__/AiAccessEmptyState.test.tsx
+++ b/apps/ui/src/components/__tests__/AiAccessEmptyState.test.tsx
@@ -18,7 +18,7 @@ describe('AiAccessEmptyState', () => {
 
     expect(screen.getByText('Use built-in AI or Studio MCP')).toBeTruthy();
     expect(screen.getByText(/claude mcp add --transport http --scope user/i)).toBeTruthy();
-    expect(screen.getByText(/select_workspace with your repo root/i)).toBeTruthy();
+    expect(screen.getByText(/get_or_create_workspace with your repo root/i)).toBeTruthy();
     expect(screen.queryByText(/codex mcp add openscad-studio --url/i)).toBeNull();
   });
 });

--- a/apps/ui/src/components/__tests__/AiAccessEmptyState.test.tsx
+++ b/apps/ui/src/components/__tests__/AiAccessEmptyState.test.tsx
@@ -1,6 +1,6 @@
 /** @jest-environment jsdom */
 
-import { screen } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { renderWithProviders } from './test-utils';
 import { AiAccessEmptyState } from '../AiAccessEmptyState';
 
@@ -13,12 +13,24 @@ describe('AiAccessEmptyState', () => {
     localStorage.clear();
   });
 
-  it('expands Claude Code by default in the panel variant', () => {
+  it('selects Claude Code by default and switches setup tabs in the panel variant', async () => {
     renderWithProviders(<AiAccessEmptyState variant="panel" onOpenSettings={() => {}} />);
 
     expect(screen.getByText('Use built-in AI or Studio MCP')).toBeTruthy();
+    expect(screen.getByRole('tab', { name: /Claude Code/i })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
     expect(screen.getByText(/claude mcp add --transport http --scope user/i)).toBeTruthy();
     expect(screen.getByText(/get_or_create_workspace with your repo root/i)).toBeTruthy();
     expect(screen.queryByText(/codex mcp add openscad-studio --url/i)).toBeNull();
+
+    const cursorTab = screen.getByRole('tab', { name: /Cursor/i });
+    fireEvent.mouseDown(cursorTab, { button: 0, ctrlKey: false });
+
+    await waitFor(() => {
+      expect(cursorTab).toHaveAttribute('aria-selected', 'true');
+    });
+    expect(screen.getAllByText(/~\/\.cursor\/mcp\.json/i).length).toBeGreaterThan(0);
   });
 });

--- a/apps/ui/src/components/__tests__/AiAccessEmptyState.test.tsx
+++ b/apps/ui/src/components/__tests__/AiAccessEmptyState.test.tsx
@@ -24,9 +24,7 @@ describe('AiAccessEmptyState', () => {
       'true'
     );
     expect(screen.getByText(/claude mcp add --transport http --scope user/i)).toBeTruthy();
-    expect(
-      screen.getByText(/register OpenSCAD Studio as an MCP server\./i)
-    ).toBeTruthy();
+    expect(screen.getByText(/register OpenSCAD Studio as an MCP server\./i)).toBeTruthy();
     expect(screen.queryByText(/codex mcp add openscad-studio --url/i)).toBeNull();
 
     const cursorTab = screen.getByRole('tab', { name: /Cursor/i });

--- a/apps/ui/src/components/__tests__/AiAccessEmptyState.test.tsx
+++ b/apps/ui/src/components/__tests__/AiAccessEmptyState.test.tsx
@@ -14,7 +14,9 @@ describe('AiAccessEmptyState', () => {
   });
 
   it('selects Claude Code by default and switches setup tabs in the panel variant', async () => {
-    renderWithProviders(<AiAccessEmptyState variant="panel" onOpenSettings={() => {}} />);
+    renderWithProviders(
+      <AiAccessEmptyState variant="panel" onOpenSettings={() => {}} panelLayout="stacked" />
+    );
 
     expect(screen.getByText('Use built-in AI or Studio MCP')).toBeTruthy();
     expect(screen.getByRole('tab', { name: /Claude Code/i })).toHaveAttribute(
@@ -22,7 +24,9 @@ describe('AiAccessEmptyState', () => {
       'true'
     );
     expect(screen.getByText(/claude mcp add --transport http --scope user/i)).toBeTruthy();
-    expect(screen.getByText(/get_or_create_workspace with your repo root/i)).toBeTruthy();
+    expect(
+      screen.getByText(/register OpenSCAD Studio as an MCP server\./i)
+    ).toBeTruthy();
     expect(screen.queryByText(/codex mcp add openscad-studio --url/i)).toBeNull();
 
     const cursorTab = screen.getByRole('tab', { name: /Cursor/i });
@@ -32,5 +36,23 @@ describe('AiAccessEmptyState', () => {
       expect(cursorTab).toHaveAttribute('aria-selected', 'true');
     });
     expect(screen.getAllByText(/~\/\.cursor\/mcp\.json/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders a split layout when panelLayout is split', async () => {
+    renderWithProviders(
+      <AiAccessEmptyState variant="panel" onOpenSettings={() => {}} panelLayout="split" />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('tablist')).toHaveAttribute('aria-orientation', 'vertical');
+    });
+
+    expect(screen.getByRole('tab', { name: /Claude Code/i })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+    expect(screen.getByText('Built-in AI')).toBeTruthy();
+    expect(screen.getByText('Desktop agent setup')).toBeTruthy();
+    expect(screen.getByText(/register OpenSCAD Studio as an MCP server\./i)).toBeTruthy();
   });
 });

--- a/apps/ui/src/components/__tests__/AiAccessEmptyState.test.tsx
+++ b/apps/ui/src/components/__tests__/AiAccessEmptyState.test.tsx
@@ -1,0 +1,24 @@
+/** @jest-environment jsdom */
+
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from './test-utils';
+import { AiAccessEmptyState } from '../AiAccessEmptyState';
+
+describe('AiAccessEmptyState', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('expands Claude Code by default in the panel variant', () => {
+    renderWithProviders(<AiAccessEmptyState variant="panel" onOpenSettings={() => {}} />);
+
+    expect(screen.getByText('Use built-in AI or Studio MCP')).toBeTruthy();
+    expect(screen.getByText(/claude mcp add --transport http --scope user/i)).toBeTruthy();
+    expect(screen.getByText(/select_workspace with your repo root/i)).toBeTruthy();
+    expect(screen.queryByText(/codex mcp add openscad-studio --url/i)).toBeNull();
+  });
+});

--- a/apps/ui/src/components/__tests__/SettingsDialog.test.tsx
+++ b/apps/ui/src/components/__tests__/SettingsDialog.test.tsx
@@ -47,12 +47,27 @@ jest.unstable_mockModule('@/stores/layoutStore', () => ({
 }));
 
 jest.unstable_mockModule('@/services/desktopMcp', () => ({
-  buildAgentSnippet: (port: number) =>
-    `Use the OpenSCAD Studio MCP server at http://127.0.0.1:${port}/mcp for render tasks only.`,
   buildClaudeMcpCommand: (port: number) =>
     `claude mcp add --transport http --scope user openscad-studio http://127.0.0.1:${port}/mcp`,
   buildCodexMcpCommand: (port: number) =>
     `codex mcp add openscad-studio --url http://127.0.0.1:${port}/mcp`,
+  buildCursorMcpConfig: (port: number) => `{
+  "mcpServers": {
+    "openscad-studio": {
+      "url": "http://127.0.0.1:${port}/mcp"
+    }
+  }
+}`,
+  buildOpenCodeMcpConfig: (port: number) => `{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "openscad-studio": {
+      "type": "remote",
+      "url": "http://127.0.0.1:${port}/mcp",
+      "enabled": true
+    }
+  }
+}`,
   getDesktopMcpStatus: (...args: unknown[]) => mockGetDesktopMcpStatus(...args),
   syncDesktopMcpConfig: (...args: unknown[]) => mockSyncDesktopMcpConfig(...args),
 }));
@@ -213,7 +228,10 @@ describe('SettingsDialog privacy copy', () => {
     expect(screen.getByText('Enable local MCP server')).toBeTruthy();
     expect(screen.getByText('Claude Code')).toBeTruthy();
     expect(screen.getByText('Codex')).toBeTruthy();
-    expect(screen.getAllByRole('button', { name: 'Copy' }).length).toBeGreaterThanOrEqual(4);
+    expect(screen.getByText('Cursor')).toBeTruthy();
+    expect(screen.getByText('OpenCode')).toBeTruthy();
+    expect(screen.getByText(/select_workspace/i)).toBeTruthy();
+    expect(screen.getAllByRole('button', { name: 'Copy' }).length).toBeGreaterThanOrEqual(5);
     expect(screen.getAllByText(/http:\/\/127\.0\.0\.1:32123\/mcp/i).length).toBeGreaterThan(0);
     expect(mockGetDesktopMcpStatus).toHaveBeenCalled();
   });

--- a/apps/ui/src/components/__tests__/SettingsDialog.test.tsx
+++ b/apps/ui/src/components/__tests__/SettingsDialog.test.tsx
@@ -7,6 +7,8 @@ import { ThemeProvider } from '../../contexts/ThemeContext';
 const mockGetPlatform = jest.fn();
 const mockTrack = jest.fn();
 const mockApplyWorkspacePreset = jest.fn();
+const mockGetDesktopMcpStatus = jest.fn();
+const mockSyncDesktopMcpConfig = jest.fn();
 let platformMock: {
   getLibraryPaths: ReturnType<typeof jest.fn>;
   getDefaultProjectsDirectory: ReturnType<typeof jest.fn>;
@@ -44,6 +46,17 @@ jest.unstable_mockModule('@/stores/layoutStore', () => ({
   applyWorkspacePreset: (...args: unknown[]) => mockApplyWorkspacePreset(...args),
 }));
 
+jest.unstable_mockModule('@/services/desktopMcp', () => ({
+  buildAgentSnippet: (port: number) =>
+    `Use the OpenSCAD Studio MCP server at http://127.0.0.1:${port}/mcp for render tasks only.`,
+  buildClaudeMcpCommand: (port: number) =>
+    `claude mcp add --transport http --scope user openscad-studio http://127.0.0.1:${port}/mcp`,
+  buildCodexMcpCommand: (port: number) =>
+    `codex mcp add openscad-studio --url http://127.0.0.1:${port}/mcp`,
+  getDesktopMcpStatus: (...args: unknown[]) => mockGetDesktopMcpStatus(...args),
+  syncDesktopMcpConfig: (...args: unknown[]) => mockSyncDesktopMcpConfig(...args),
+}));
+
 let SettingsDialog: typeof import('../SettingsDialog').SettingsDialog;
 
 describe('SettingsDialog privacy copy', () => {
@@ -61,6 +74,20 @@ describe('SettingsDialog privacy copy', () => {
       capabilities: { hasFileSystem: true },
     };
     mockGetPlatform.mockReturnValue(platformMock);
+    mockGetDesktopMcpStatus.mockResolvedValue({
+      enabled: true,
+      port: 32123,
+      status: 'running',
+      endpoint: 'http://127.0.0.1:32123/mcp',
+      message: null,
+    });
+    mockSyncDesktopMcpConfig.mockResolvedValue({
+      enabled: true,
+      port: 32123,
+      status: 'running',
+      endpoint: 'http://127.0.0.1:32123/mcp',
+      message: null,
+    });
 
     Object.defineProperty(window, 'matchMedia', {
       writable: true,
@@ -173,6 +200,22 @@ describe('SettingsDialog privacy copy', () => {
 
     expect(await screen.findByText('Default Layout')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Customizer First' })).toBeTruthy();
+  });
+
+  it('shows external agent MCP onboarding in the AI settings tab', async () => {
+    render(
+      <ThemeProvider>
+        <SettingsDialog isOpen onClose={() => {}} initialTab="ai" />
+      </ThemeProvider>
+    );
+
+    expect(await screen.findByText('External Agents')).toBeTruthy();
+    expect(screen.getByText('Enable local MCP server')).toBeTruthy();
+    expect(screen.getByText('Claude Code')).toBeTruthy();
+    expect(screen.getByText('Codex')).toBeTruthy();
+    expect(screen.getAllByRole('button', { name: 'Copy' }).length).toBeGreaterThanOrEqual(4);
+    expect(screen.getAllByText(/http:\/\/127\.0\.0\.1:32123\/mcp/i).length).toBeGreaterThan(0);
+    expect(mockGetDesktopMcpStatus).toHaveBeenCalled();
   });
 
   it('tracks layout selection sources and viewer preference changes', async () => {

--- a/apps/ui/src/components/__tests__/SettingsDialog.test.tsx
+++ b/apps/ui/src/components/__tests__/SettingsDialog.test.tsx
@@ -226,12 +226,16 @@ describe('SettingsDialog privacy copy', () => {
 
     expect(await screen.findByText('External Agents')).toBeTruthy();
     expect(screen.getByText('Enable local MCP server')).toBeTruthy();
-    expect(screen.getByText('Claude Code')).toBeTruthy();
-    expect(screen.getByText('Codex')).toBeTruthy();
-    expect(screen.getByText('Cursor')).toBeTruthy();
-    expect(screen.getByText('OpenCode')).toBeTruthy();
-    expect(screen.getByText(/get_or_create_workspace/i)).toBeTruthy();
-    expect(screen.getAllByRole('button', { name: 'Copy' }).length).toBeGreaterThanOrEqual(5);
+    expect(screen.getByRole('tab', { name: /Claude Code/i })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+    expect(screen.getByRole('tab', { name: /Codex/i })).toBeTruthy();
+    expect(screen.getByRole('tab', { name: /Cursor/i })).toBeTruthy();
+    expect(screen.getByRole('tab', { name: /OpenCode/i })).toBeTruthy();
+    expect(screen.getByText(/claude mcp add --transport http --scope user/i)).toBeTruthy();
+    expect(screen.getAllByText(/get_or_create_workspace/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('button', { name: 'Copy' }).length).toBeGreaterThanOrEqual(2);
     expect(screen.getAllByText(/http:\/\/127\.0\.0\.1:32123\/mcp/i).length).toBeGreaterThan(0);
     expect(mockGetDesktopMcpStatus).toHaveBeenCalled();
   });

--- a/apps/ui/src/components/__tests__/SettingsDialog.test.tsx
+++ b/apps/ui/src/components/__tests__/SettingsDialog.test.tsx
@@ -230,7 +230,7 @@ describe('SettingsDialog privacy copy', () => {
     expect(screen.getByText('Codex')).toBeTruthy();
     expect(screen.getByText('Cursor')).toBeTruthy();
     expect(screen.getByText('OpenCode')).toBeTruthy();
-    expect(screen.getByText(/select_workspace/i)).toBeTruthy();
+    expect(screen.getByText(/get_or_create_workspace/i)).toBeTruthy();
     expect(screen.getAllByRole('button', { name: 'Copy' }).length).toBeGreaterThanOrEqual(5);
     expect(screen.getAllByText(/http:\/\/127\.0\.0\.1:32123\/mcp/i).length).toBeGreaterThan(0);
     expect(mockGetDesktopMcpStatus).toHaveBeenCalled();

--- a/apps/ui/src/components/__tests__/WelcomeScreen.test.tsx
+++ b/apps/ui/src/components/__tests__/WelcomeScreen.test.tsx
@@ -122,4 +122,34 @@ describe('WelcomeScreen', () => {
       { path: '/tmp/exists.scad', name: 'exists.scad', lastOpened: 2 },
     ]);
   });
+
+  it('keeps the desktop no-key welcome state focused on API key setup only', async () => {
+    clearApiKey('openai');
+    clearApiKey('anthropic');
+    mockGetPlatform.mockReturnValue({
+      capabilities: { hasFileSystem: true },
+      fileExists: jest.fn(async () => false),
+    });
+
+    renderWithProviders(
+      <WelcomeScreen
+        draft={{ text: '', attachmentIds: [] }}
+        attachments={{}}
+        draftErrors={[]}
+        canSubmitDraft={false}
+        isProcessingAttachments={false}
+        onDraftTextChange={() => {}}
+        onDraftFilesSelected={() => {}}
+        onDraftRemoveAttachment={() => {}}
+        onStartWithDraft={() => {}}
+        onStartManually={() => {}}
+        onOpenRecent={async () => 'opened'}
+        onOpenSettings={() => {}}
+        showRecentFiles={false}
+      />
+    );
+
+    expect(screen.getByText('Set up an API key to use the AI assistant')).toBeTruthy();
+    expect(screen.queryByText('Claude Code')).toBeNull();
+  });
 });

--- a/apps/ui/src/components/mcp/AgentSetupTabs.tsx
+++ b/apps/ui/src/components/mcp/AgentSetupTabs.tsx
@@ -1,0 +1,295 @@
+import { useCallback, useMemo, useState } from 'react';
+import { TbBraces, TbCopy, TbTerminal2 } from 'react-icons/tb';
+import { Button, IconButton, Tabs, TabsContent, TabsList, TabsTrigger, Text } from '../ui';
+import {
+  buildClaudeMcpCommand,
+  buildCodexMcpCommand,
+  buildCursorMcpConfig,
+  buildOpenCodeMcpConfig,
+} from '../../services/desktopMcp';
+import { notifyError, notifySuccess } from '../../utils/notifications';
+
+type AgentSetupId = 'claude' | 'cursor' | 'codex' | 'opencode';
+
+interface AgentSetupItem {
+  id: AgentSetupId;
+  label: string;
+  command: string;
+  codeLabel: 'Shell' | 'JSON';
+  locationLabel?: string;
+  instruction: string;
+  instructionDetail?: string;
+}
+
+interface AgentSetupTabsProps {
+  port: number;
+  surface?: 'panel' | 'settings';
+}
+
+function SetupCodeBlock({
+  label,
+  locationLabel,
+  value,
+  onCopy,
+  compact,
+}: {
+  label: string;
+  locationLabel?: string;
+  value: string;
+  onCopy: () => void;
+  compact: boolean;
+}) {
+  return (
+    <div
+      className="overflow-hidden rounded-xl border"
+      style={{
+        backgroundColor: 'color-mix(in srgb, var(--bg-tertiary) 78%, var(--bg-primary))',
+        borderColor: 'var(--border-primary)',
+        boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.03)',
+      }}
+    >
+      <div
+        className={`flex items-center justify-between ${compact ? 'px-3 py-2' : 'px-4 py-3'}`}
+        style={{
+          borderBottom: '1px solid var(--border-primary)',
+          backgroundColor: 'color-mix(in srgb, var(--bg-secondary) 92%, var(--bg-primary))',
+        }}
+      >
+        <div className="flex min-w-0 items-center gap-2">
+          <Text
+            as="span"
+            variant="caption"
+            weight="semibold"
+            className="rounded-full px-2 py-0.5"
+            style={{
+              backgroundColor: 'color-mix(in srgb, var(--accent-primary) 14%, transparent)',
+              color: 'var(--text-primary)',
+            }}
+          >
+            {label}
+          </Text>
+          {locationLabel ? (
+            <Text
+              as="span"
+              variant="caption"
+              color="tertiary"
+              className="truncate"
+              style={{ maxWidth: compact ? '10rem' : '18rem' }}
+              title={locationLabel}
+            >
+              {locationLabel}
+            </Text>
+          ) : null}
+        </div>
+        {compact ? (
+          <IconButton
+            size="sm"
+            variant="default"
+            aria-label="Copy setup"
+            title="Copy setup"
+            onClick={onCopy}
+          >
+            <TbCopy size={16} />
+          </IconButton>
+        ) : (
+          <Button type="button" size="sm" variant="ghost" onClick={onCopy}>
+            Copy
+          </Button>
+        )}
+      </div>
+      <pre
+        className={`m-0 overflow-x-auto ${compact ? 'px-3 py-3' : 'px-4 py-4'} text-xs leading-7`}
+        style={{
+          color: 'var(--text-secondary)',
+          fontFamily: 'var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace)',
+          whiteSpace: 'pre-wrap',
+          wordBreak: 'break-word',
+        }}
+      >
+        {value}
+      </pre>
+    </div>
+  );
+}
+
+export function AgentSetupTabs({ port, surface = 'settings' }: AgentSetupTabsProps) {
+  const compact = surface === 'panel';
+  const [selectedAgent, setSelectedAgent] = useState<AgentSetupId>('claude');
+  const commands = useMemo<AgentSetupItem[]>(
+    () => [
+      {
+        id: 'claude',
+        label: 'Claude Code',
+        command: buildClaudeMcpCommand(port),
+        codeLabel: 'Shell',
+        instruction:
+          'Run this command in your terminal to register OpenSCAD Studio as an MCP server, then call get_or_create_workspace with your repo root before using render tools.',
+      },
+      {
+        id: 'cursor',
+        label: 'Cursor',
+        command: buildCursorMcpConfig(port),
+        codeLabel: 'JSON',
+        locationLabel: '~/.cursor/mcp.json',
+        instruction:
+          'Open Cursor MCP settings and add the OpenSCAD Studio server, then call get_or_create_workspace with your repo root before using render tools.',
+        instructionDetail: 'You can also edit your mcp.json directly.',
+      },
+      {
+        id: 'codex',
+        label: 'Codex',
+        command: buildCodexMcpCommand(port),
+        codeLabel: 'Shell',
+        instruction:
+          'Run this command in your terminal to add the OpenSCAD Studio MCP endpoint, then call get_or_create_workspace with your repo root before using render tools.',
+      },
+      {
+        id: 'opencode',
+        label: 'OpenCode',
+        command: buildOpenCodeMcpConfig(port),
+        codeLabel: 'JSON',
+        locationLabel: '~/.config/opencode/opencode.json',
+        instruction:
+          'Open OpenCode MCP settings and add the OpenSCAD Studio server, then call get_or_create_workspace with your repo root before using render tools.',
+        instructionDetail: 'You can also edit the config file directly.',
+      },
+    ],
+    [port]
+  );
+
+  const copyText = useCallback(async (label: string, value: string) => {
+    try {
+      await navigator.clipboard.writeText(value);
+      notifySuccess(`${label} copied`, {
+        toastId: `copy-${label.toLowerCase().replace(/\s+/g, '-')}`,
+      });
+    } catch (error) {
+      notifyError({
+        operation: 'copy-mcp-agent-setup',
+        error,
+        fallbackMessage: `Failed to copy ${label.toLowerCase()}`,
+      });
+    }
+  }, []);
+
+  return (
+    <Tabs
+      value={selectedAgent}
+      onValueChange={(value) => setSelectedAgent(value as AgentSetupId)}
+      orientation="horizontal"
+      className="flex flex-col gap-3"
+    >
+      <div
+        className="overflow-x-auto rounded-xl border p-1"
+        style={{
+          backgroundColor: 'color-mix(in srgb, var(--bg-secondary) 92%, var(--bg-primary))',
+          borderColor: 'var(--border-primary)',
+        }}
+      >
+        <TabsList
+          aria-label="Desktop agent setup"
+          className="inline-flex min-w-full items-stretch gap-1"
+        >
+          {commands.map((item) => {
+            const isActive = selectedAgent === item.id;
+            const formatIcon =
+              item.codeLabel === 'JSON' ? <TbBraces size={14} /> : <TbTerminal2 size={14} />;
+            return (
+              <TabsTrigger
+                key={item.id}
+                value={item.id}
+                className="group inline-flex min-w-[8.5rem] flex-1 items-center justify-between rounded-lg px-3 py-2 text-left outline-none transition-colors"
+                style={{
+                  backgroundColor: isActive
+                    ? 'color-mix(in srgb, var(--accent-primary) 14%, var(--bg-tertiary))'
+                    : 'transparent',
+                  color: isActive ? 'var(--text-primary)' : 'var(--text-secondary)',
+                  boxShadow: isActive ? 'inset 0 1px 0 rgba(255,255,255,0.04)' : undefined,
+                }}
+              >
+                <span className="flex min-w-0 flex-col">
+                  <span className="text-sm font-medium leading-5">{item.label}</span>
+                  <span
+                    className="text-[11px] leading-4"
+                    style={{ color: isActive ? 'var(--text-secondary)' : 'var(--text-tertiary)' }}
+                  >
+                    {item.codeLabel}
+                  </span>
+                </span>
+                <span
+                  className="ml-3 shrink-0 rounded-full p-1"
+                  style={{
+                    backgroundColor: isActive
+                      ? 'color-mix(in srgb, var(--accent-primary) 16%, transparent)'
+                      : 'color-mix(in srgb, var(--bg-tertiary) 72%, transparent)',
+                    color: isActive ? 'var(--text-primary)' : 'var(--text-tertiary)',
+                  }}
+                >
+                  {formatIcon}
+                </span>
+              </TabsTrigger>
+            );
+          })}
+        </TabsList>
+      </div>
+
+      {commands.map((item) => (
+        <TabsContent
+          key={item.id}
+          value={item.id}
+          className="outline-none"
+        >
+          <div
+            className="rounded-xl border"
+            style={{
+              background:
+                'linear-gradient(180deg, color-mix(in srgb, var(--bg-secondary) 97%, var(--bg-primary)) 0%, color-mix(in srgb, var(--bg-tertiary) 90%, var(--bg-primary)) 100%)',
+              borderColor: 'var(--border-primary)',
+              boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.03)',
+            }}
+          >
+            <div
+              className={`${compact ? 'px-3 py-3' : 'px-4 py-4'} flex flex-col`}
+              style={{ gap: 'var(--space-helper-gap)' }}
+            >
+              <div className="flex items-center justify-between gap-3">
+                <div className="min-w-0">
+                  <Text variant="caption" weight="semibold" color="primary">
+                    {item.label}
+                  </Text>
+                  {item.locationLabel ? (
+                    <Text
+                      variant="caption"
+                      color="tertiary"
+                      className="mt-1 block"
+                      style={{ wordBreak: 'break-word' }}
+                    >
+                      {item.locationLabel}
+                    </Text>
+                  ) : null}
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <Text variant="caption">{item.instruction}</Text>
+                {item.instructionDetail ? (
+                  <Text variant="caption" color="tertiary">
+                    {item.instructionDetail}
+                  </Text>
+                ) : null}
+              </div>
+
+              <SetupCodeBlock
+                label={item.codeLabel}
+                locationLabel={item.locationLabel}
+                value={item.command}
+                compact={compact}
+                onCopy={() => void copyText(`${item.label} MCP setup`, item.command)}
+              />
+            </div>
+          </div>
+        </TabsContent>
+      ))}
+    </Tabs>
+  );
+}

--- a/apps/ui/src/components/mcp/AgentSetupTabs.tsx
+++ b/apps/ui/src/components/mcp/AgentSetupTabs.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
-import { TbBraces, TbCopy, TbTerminal2 } from 'react-icons/tb';
+import { TbCopy } from 'react-icons/tb';
 import { Button, IconButton, Tabs, TabsContent, TabsList, TabsTrigger, Text } from '../ui';
 import {
   buildClaudeMcpCommand,
@@ -24,6 +24,7 @@ interface AgentSetupItem {
 interface AgentSetupTabsProps {
   port: number;
   surface?: 'panel' | 'settings';
+  layout?: 'stacked' | 'split';
 }
 
 function SetupCodeBlock({
@@ -43,16 +44,15 @@ function SetupCodeBlock({
     <div
       className="overflow-hidden rounded-xl border"
       style={{
-        backgroundColor: 'color-mix(in srgb, var(--bg-tertiary) 78%, var(--bg-primary))',
-        borderColor: 'var(--border-primary)',
-        boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.03)',
+        backgroundColor: 'var(--bg-tertiary)',
+        borderColor: 'var(--border-secondary)',
       }}
     >
       <div
-        className={`flex items-center justify-between ${compact ? 'px-3 py-2' : 'px-4 py-3'}`}
+        className={`flex items-center justify-between ${compact ? 'px-3 py-1.5' : 'px-3 py-2'}`}
         style={{
-          borderBottom: '1px solid var(--border-primary)',
-          backgroundColor: 'color-mix(in srgb, var(--bg-secondary) 92%, var(--bg-primary))',
+          borderBottom: '1px solid var(--border-secondary)',
+          backgroundColor: 'var(--bg-primary)',
         }}
       >
         <div className="flex min-w-0 items-center gap-2">
@@ -62,7 +62,7 @@ function SetupCodeBlock({
             weight="semibold"
             className="rounded-full px-2 py-0.5"
             style={{
-              backgroundColor: 'color-mix(in srgb, var(--accent-primary) 14%, transparent)',
+              backgroundColor: 'var(--bg-tertiary)',
               color: 'var(--text-primary)',
             }}
           >
@@ -112,8 +112,13 @@ function SetupCodeBlock({
   );
 }
 
-export function AgentSetupTabs({ port, surface = 'settings' }: AgentSetupTabsProps) {
+export function AgentSetupTabs({
+  port,
+  surface = 'settings',
+  layout = 'stacked',
+}: AgentSetupTabsProps) {
   const compact = surface === 'panel';
+  const isSplit = layout === 'split';
   const [selectedAgent, setSelectedAgent] = useState<AgentSetupId>('claude');
   const commands = useMemo<AgentSetupItem[]>(
     () => [
@@ -122,8 +127,7 @@ export function AgentSetupTabs({ port, surface = 'settings' }: AgentSetupTabsPro
         label: 'Claude Code',
         command: buildClaudeMcpCommand(port),
         codeLabel: 'Shell',
-        instruction:
-          'Run this command in your terminal to register OpenSCAD Studio as an MCP server, then call get_or_create_workspace with your repo root before using render tools.',
+        instruction: 'Run this command in your terminal to register OpenSCAD Studio as an MCP server.',
       },
       {
         id: 'cursor',
@@ -131,17 +135,14 @@ export function AgentSetupTabs({ port, surface = 'settings' }: AgentSetupTabsPro
         command: buildCursorMcpConfig(port),
         codeLabel: 'JSON',
         locationLabel: '~/.cursor/mcp.json',
-        instruction:
-          'Open Cursor MCP settings and add the OpenSCAD Studio server, then call get_or_create_workspace with your repo root before using render tools.',
-        instructionDetail: 'You can also edit your mcp.json directly.',
+        instruction: 'Add this config in Cursor MCP settings or in ~/.cursor/mcp.json.',
       },
       {
         id: 'codex',
         label: 'Codex',
         command: buildCodexMcpCommand(port),
         codeLabel: 'Shell',
-        instruction:
-          'Run this command in your terminal to add the OpenSCAD Studio MCP endpoint, then call get_or_create_workspace with your repo root before using render tools.',
+        instruction: 'Run this command in your terminal to add the OpenSCAD Studio MCP endpoint.',
       },
       {
         id: 'opencode',
@@ -149,9 +150,7 @@ export function AgentSetupTabs({ port, surface = 'settings' }: AgentSetupTabsPro
         command: buildOpenCodeMcpConfig(port),
         codeLabel: 'JSON',
         locationLabel: '~/.config/opencode/opencode.json',
-        instruction:
-          'Open OpenCode MCP settings and add the OpenSCAD Studio server, then call get_or_create_workspace with your repo root before using render tools.',
-        instructionDetail: 'You can also edit the config file directly.',
+        instruction: 'Add this config in OpenCode MCP settings or in ~/.config/opencode/opencode.json.',
       },
     ],
     [port]
@@ -176,57 +175,53 @@ export function AgentSetupTabs({ port, surface = 'settings' }: AgentSetupTabsPro
     <Tabs
       value={selectedAgent}
       onValueChange={(value) => setSelectedAgent(value as AgentSetupId)}
-      orientation="horizontal"
-      className="flex flex-col gap-3"
+      orientation={isSplit ? 'vertical' : 'horizontal'}
+      className={
+        isSplit
+          ? 'grid grid-cols-[10rem_minmax(0,1fr)] items-stretch overflow-hidden rounded-xl border'
+          : 'overflow-hidden rounded-xl border'
+      }
+      style={{
+        backgroundColor: 'var(--bg-secondary)',
+        borderColor: 'var(--border-secondary)',
+      }}
     >
       <div
-        className="overflow-x-auto rounded-xl border p-1"
-        style={{
-          backgroundColor: 'color-mix(in srgb, var(--bg-secondary) 92%, var(--bg-primary))',
-          borderColor: 'var(--border-primary)',
-        }}
+        className={isSplit ? 'min-w-0 px-3 py-3' : 'overflow-x-auto px-2 py-2'}
+        style={
+          isSplit
+            ? { borderRight: '1px solid var(--border-secondary)' }
+            : {
+                borderBottom: '1px solid var(--border-secondary)',
+                backgroundColor: 'var(--bg-primary)',
+              }
+        }
       >
         <TabsList
           aria-label="Desktop agent setup"
-          className="inline-flex min-w-full items-stretch gap-1"
+          className={
+            isSplit
+              ? 'flex flex-col items-stretch gap-1'
+              : 'inline-flex min-w-full items-stretch gap-1'
+          }
         >
           {commands.map((item) => {
             const isActive = selectedAgent === item.id;
-            const formatIcon =
-              item.codeLabel === 'JSON' ? <TbBraces size={14} /> : <TbTerminal2 size={14} />;
             return (
               <TabsTrigger
                 key={item.id}
                 value={item.id}
-                className="group inline-flex min-w-[8.5rem] flex-1 items-center justify-between rounded-lg px-3 py-2 text-left outline-none transition-colors"
+                className={
+                  isSplit
+                    ? 'inline-flex w-full items-center justify-start whitespace-nowrap rounded-md px-2.5 py-2 text-left text-xs font-medium outline-none transition-colors'
+                    : 'inline-flex min-w-[5.5rem] flex-1 items-center justify-center whitespace-nowrap rounded-md px-2 py-1 text-center text-xs font-medium outline-none transition-colors'
+                }
                 style={{
-                  backgroundColor: isActive
-                    ? 'color-mix(in srgb, var(--accent-primary) 14%, var(--bg-tertiary))'
-                    : 'transparent',
+                  backgroundColor: isActive ? 'var(--bg-tertiary)' : 'transparent',
                   color: isActive ? 'var(--text-primary)' : 'var(--text-secondary)',
-                  boxShadow: isActive ? 'inset 0 1px 0 rgba(255,255,255,0.04)' : undefined,
                 }}
               >
-                <span className="flex min-w-0 flex-col">
-                  <span className="text-sm font-medium leading-5">{item.label}</span>
-                  <span
-                    className="text-[11px] leading-4"
-                    style={{ color: isActive ? 'var(--text-secondary)' : 'var(--text-tertiary)' }}
-                  >
-                    {item.codeLabel}
-                  </span>
-                </span>
-                <span
-                  className="ml-3 shrink-0 rounded-full p-1"
-                  style={{
-                    backgroundColor: isActive
-                      ? 'color-mix(in srgb, var(--accent-primary) 16%, transparent)'
-                      : 'color-mix(in srgb, var(--bg-tertiary) 72%, transparent)',
-                    color: isActive ? 'var(--text-primary)' : 'var(--text-tertiary)',
-                  }}
-                >
-                  {formatIcon}
-                </span>
+                {item.label}
               </TabsTrigger>
             );
           })}
@@ -234,59 +229,27 @@ export function AgentSetupTabs({ port, surface = 'settings' }: AgentSetupTabsPro
       </div>
 
       {commands.map((item) => (
-        <TabsContent
-          key={item.id}
-          value={item.id}
-          className="outline-none"
-        >
+        <TabsContent key={item.id} value={item.id} className="outline-none">
           <div
-            className="rounded-xl border"
-            style={{
-              background:
-                'linear-gradient(180deg, color-mix(in srgb, var(--bg-secondary) 97%, var(--bg-primary)) 0%, color-mix(in srgb, var(--bg-tertiary) 90%, var(--bg-primary)) 100%)',
-              borderColor: 'var(--border-primary)',
-              boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.03)',
-            }}
+            className={`${isSplit ? 'min-w-0 px-3 py-3' : compact ? 'px-3 py-3' : 'px-4 py-4'} flex flex-col`}
+            style={{ gap: 'var(--space-3)' }}
           >
-            <div
-              className={`${compact ? 'px-3 py-3' : 'px-4 py-4'} flex flex-col`}
-              style={{ gap: 'var(--space-helper-gap)' }}
-            >
-              <div className="flex items-center justify-between gap-3">
-                <div className="min-w-0">
-                  <Text variant="caption" weight="semibold" color="primary">
-                    {item.label}
-                  </Text>
-                  {item.locationLabel ? (
-                    <Text
-                      variant="caption"
-                      color="tertiary"
-                      className="mt-1 block"
-                      style={{ wordBreak: 'break-word' }}
-                    >
-                      {item.locationLabel}
-                    </Text>
-                  ) : null}
-                </div>
-              </div>
-
-              <div className="space-y-2">
-                <Text variant="caption">{item.instruction}</Text>
-                {item.instructionDetail ? (
-                  <Text variant="caption" color="tertiary">
-                    {item.instructionDetail}
-                  </Text>
-                ) : null}
-              </div>
-
-              <SetupCodeBlock
-                label={item.codeLabel}
-                locationLabel={item.locationLabel}
-                value={item.command}
-                compact={compact}
-                onCopy={() => void copyText(`${item.label} MCP setup`, item.command)}
-              />
+            <div className="space-y-2">
+              <Text variant="caption">{item.instruction}</Text>
+              {item.instructionDetail ? (
+                <Text variant="caption" color="tertiary">
+                  {item.instructionDetail}
+                </Text>
+              ) : null}
             </div>
+
+            <SetupCodeBlock
+              label={item.codeLabel}
+              locationLabel={item.locationLabel}
+              value={item.command}
+              compact={compact}
+              onCopy={() => void copyText(`${item.label} MCP setup`, item.command)}
+            />
           </div>
         </TabsContent>
       ))}

--- a/apps/ui/src/components/mcp/AgentSetupTabs.tsx
+++ b/apps/ui/src/components/mcp/AgentSetupTabs.tsx
@@ -127,7 +127,8 @@ export function AgentSetupTabs({
         label: 'Claude Code',
         command: buildClaudeMcpCommand(port),
         codeLabel: 'Shell',
-        instruction: 'Run this command in your terminal to register OpenSCAD Studio as an MCP server.',
+        instruction:
+          'Run this command in your terminal to register OpenSCAD Studio as an MCP server.',
       },
       {
         id: 'cursor',
@@ -150,7 +151,8 @@ export function AgentSetupTabs({
         command: buildOpenCodeMcpConfig(port),
         codeLabel: 'JSON',
         locationLabel: '~/.config/opencode/opencode.json',
-        instruction: 'Add this config in OpenCode MCP settings or in ~/.config/opencode/opencode.json.',
+        instruction:
+          'Add this config in OpenCode MCP settings or in ~/.config/opencode/opencode.json.',
       },
     ],
     [port]

--- a/apps/ui/src/components/panels/PanelComponents.tsx
+++ b/apps/ui/src/components/panels/PanelComponents.tsx
@@ -15,6 +15,7 @@ import { isExportValidationError } from '../../services/exportErrors';
 import { getRenderService } from '../../services/renderService';
 import { getPlatform } from '../../platform';
 import { notifyError } from '../../utils/notifications';
+import { MAIN_PREVIEW_VIEWER_ID } from '../../utils/capturePreview';
 import { useAnalytics } from '../../analytics/runtime';
 
 const EditorPanel: React.FC<IDockviewPanelProps> = () => {
@@ -58,7 +59,6 @@ const EditorPanel: React.FC<IDockviewPanelProps> = () => {
 
 const PreviewPanel: React.FC<IDockviewPanelProps> = () => {
   const {
-    activeTabId,
     previewSrc,
     previewKind,
     isRendering,
@@ -75,7 +75,7 @@ const PreviewPanel: React.FC<IDockviewPanelProps> = () => {
         kind={previewKind}
         isRendering={isRendering}
         error={error}
-        viewerId={activeTabId}
+        viewerId={MAIN_PREVIEW_VIEWER_ID}
         onVisualReady={onPreviewVisualReady}
         hasCurrentModelApiKey={hasCurrentModelApiKey}
         canAttachViewerAnnotation={canAttachViewerAnnotation}

--- a/apps/ui/src/components/settings/AiSettings.tsx
+++ b/apps/ui/src/components/settings/AiSettings.tsx
@@ -7,10 +7,12 @@ import {
   hasApiKeyForProvider,
   getAvailableProviders as getAvailableProvidersFromStore,
 } from '../../stores/apiKeyStore';
+import { useSettings } from '../../stores/settingsStore';
 import { getPlatform } from '../../platform';
 import { notifyError, notifySuccess } from '../../utils/notifications';
 import { SettingsSupportBlock } from './SettingsPrimitives';
 import { ApiProviderCard } from './ApiProviderCard';
+import { ExternalAgentsCard } from './ExternalAgentsCard';
 
 const MASKED_KEY = '••••••••••••••••••••••••••••••••••••••••••••';
 
@@ -35,6 +37,7 @@ export const AiSettings = forwardRef<AiSettingsHandle, AiSettingsProps>(
     const [error, setError] = useState<string | null>(null);
     const [showKey, setShowKey] = useState(false);
     const analytics = useAnalytics();
+    const [settings] = useSettings();
 
     const loadKeys = useCallback(() => {
       const availableProviders = getAvailableProvidersFromStore();
@@ -212,6 +215,10 @@ export const AiSettings = forwardRef<AiSettingsHandle, AiSettingsProps>(
             {error}
           </SettingsSupportBlock>
         )}
+
+        {getPlatform().capabilities.hasFileSystem ? (
+          <ExternalAgentsCard settings={settings} isOpen={isOpen} />
+        ) : null}
       </div>
     );
   }

--- a/apps/ui/src/components/settings/ExternalAgentsCard.tsx
+++ b/apps/ui/src/components/settings/ExternalAgentsCard.tsx
@@ -1,17 +1,14 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Button, Input, Text, Toggle } from '../ui';
 import type { Settings } from '../../stores/settingsStore';
 import { updateSetting } from '../../stores/settingsStore';
 import {
-  buildClaudeMcpCommand,
-  buildCodexMcpCommand,
-  buildCursorMcpConfig,
-  buildOpenCodeMcpConfig,
   getDesktopMcpStatus,
   syncDesktopMcpConfig,
   type McpServerStatus,
 } from '../../services/desktopMcp';
 import { notifyError, notifySuccess } from '../../utils/notifications';
+import { AgentSetupTabs } from '../mcp/AgentSetupTabs';
 import {
   SettingsCard,
   SettingsCardHeader,
@@ -95,10 +92,6 @@ export function ExternalAgentsCard({ settings, isOpen }: ExternalAgentsCardProps
   }, [isOpen, refreshStatus]);
 
   const endpoint = status.endpoint ?? `http://127.0.0.1:${status.port}/mcp`;
-  const claudeCommand = useMemo(() => buildClaudeMcpCommand(status.port), [status.port]);
-  const cursorConfig = useMemo(() => buildCursorMcpConfig(status.port), [status.port]);
-  const codexCommand = useMemo(() => buildCodexMcpCommand(status.port), [status.port]);
-  const openCodeConfig = useMemo(() => buildOpenCodeMcpConfig(status.port), [status.port]);
 
   const copyText = useCallback(async (label: string, value: string) => {
     try {
@@ -270,105 +263,7 @@ export function ExternalAgentsCard({ settings, isOpen }: ExternalAgentsCardProps
           </div>
         </SettingsSupportBlock>
 
-        <SettingsSupportBlock className="flex flex-col" style={{ gap: 'var(--space-helper-gap)' }}>
-          <Text variant="caption" weight="semibold">
-            Claude Code
-          </Text>
-          <div
-            className="flex items-start justify-between"
-            style={{ gap: 'var(--space-control-gap)' }}
-          >
-            <Text as="code" variant="caption" className="font-mono break-all">
-              {claudeCommand}
-            </Text>
-            <Button
-              type="button"
-              size="sm"
-              variant="ghost"
-              onClick={() => void copyText('Claude command', claudeCommand)}
-            >
-              Copy
-            </Button>
-          </div>
-        </SettingsSupportBlock>
-
-        <SettingsSupportBlock className="flex flex-col" style={{ gap: 'var(--space-helper-gap)' }}>
-          <Text variant="caption" weight="semibold">
-            Cursor
-          </Text>
-          <Text variant="caption" color="tertiary">
-            Add this to{' '}
-            <Text as="code" variant="caption" className="font-mono">
-              ~/.cursor/mcp.json
-            </Text>
-          </Text>
-          <div
-            className="flex items-start justify-between"
-            style={{ gap: 'var(--space-control-gap)' }}
-          >
-            <Text as="code" variant="caption" className="font-mono break-all whitespace-pre-wrap">
-              {cursorConfig}
-            </Text>
-            <Button
-              type="button"
-              size="sm"
-              variant="ghost"
-              onClick={() => void copyText('Cursor config', cursorConfig)}
-            >
-              Copy
-            </Button>
-          </div>
-        </SettingsSupportBlock>
-
-        <SettingsSupportBlock className="flex flex-col" style={{ gap: 'var(--space-helper-gap)' }}>
-          <Text variant="caption" weight="semibold">
-            Codex
-          </Text>
-          <div
-            className="flex items-start justify-between"
-            style={{ gap: 'var(--space-control-gap)' }}
-          >
-            <Text as="code" variant="caption" className="font-mono break-all">
-              {codexCommand}
-            </Text>
-            <Button
-              type="button"
-              size="sm"
-              variant="ghost"
-              onClick={() => void copyText('Codex command', codexCommand)}
-            >
-              Copy
-            </Button>
-          </div>
-        </SettingsSupportBlock>
-
-        <SettingsSupportBlock className="flex flex-col" style={{ gap: 'var(--space-helper-gap)' }}>
-          <Text variant="caption" weight="semibold">
-            OpenCode
-          </Text>
-          <Text variant="caption" color="tertiary">
-            Add this to{' '}
-            <Text as="code" variant="caption" className="font-mono">
-              ~/.config/opencode/opencode.json
-            </Text>
-          </Text>
-          <div
-            className="flex items-start justify-between"
-            style={{ gap: 'var(--space-control-gap)' }}
-          >
-            <Text as="code" variant="caption" className="font-mono break-all whitespace-pre-wrap">
-              {openCodeConfig}
-            </Text>
-            <Button
-              type="button"
-              size="sm"
-              variant="ghost"
-              onClick={() => void copyText('OpenCode config', openCodeConfig)}
-            >
-              Copy
-            </Button>
-          </div>
-        </SettingsSupportBlock>
+        <AgentSetupTabs port={status.port} surface="settings" />
 
         {status.message ? (
           <SettingsSupportBlock

--- a/apps/ui/src/components/settings/ExternalAgentsCard.tsx
+++ b/apps/ui/src/components/settings/ExternalAgentsCard.tsx
@@ -243,7 +243,7 @@ export function ExternalAgentsCard({ settings, isOpen }: ExternalAgentsCardProps
           Studio MCP is for render-oriented tasks only, and each agent session should call
           <Text as="code" variant="caption" className="font-mono">
             {' '}
-            select_workspace
+            get_or_create_workspace
           </Text>{' '}
           before using render tools.
         </Text>

--- a/apps/ui/src/components/settings/ExternalAgentsCard.tsx
+++ b/apps/ui/src/components/settings/ExternalAgentsCard.tsx
@@ -3,9 +3,10 @@ import { Button, Input, Text, Toggle } from '../ui';
 import type { Settings } from '../../stores/settingsStore';
 import { updateSetting } from '../../stores/settingsStore';
 import {
-  buildAgentSnippet,
   buildClaudeMcpCommand,
   buildCodexMcpCommand,
+  buildCursorMcpConfig,
+  buildOpenCodeMcpConfig,
   getDesktopMcpStatus,
   syncDesktopMcpConfig,
   type McpServerStatus,
@@ -95,8 +96,9 @@ export function ExternalAgentsCard({ settings, isOpen }: ExternalAgentsCardProps
 
   const endpoint = status.endpoint ?? `http://127.0.0.1:${status.port}/mcp`;
   const claudeCommand = useMemo(() => buildClaudeMcpCommand(status.port), [status.port]);
+  const cursorConfig = useMemo(() => buildCursorMcpConfig(status.port), [status.port]);
   const codexCommand = useMemo(() => buildCodexMcpCommand(status.port), [status.port]);
-  const agentSnippet = useMemo(() => buildAgentSnippet(status.port), [status.port]);
+  const openCodeConfig = useMemo(() => buildOpenCodeMcpConfig(status.port), [status.port]);
 
   const copyText = useCallback(async (label: string, value: string) => {
     try {
@@ -180,7 +182,7 @@ export function ExternalAgentsCard({ settings, isOpen }: ExternalAgentsCardProps
     <SettingsCard className="ph-no-capture">
       <SettingsCardHeader
         title="External Agents"
-        description="Expose OpenSCAD Studio's project context, render target, diagnostics, renders, and preview screenshots to Claude Code, Codex, and similar local agents."
+        description="Expose one local OpenSCAD Studio MCP server for render-target switching, diagnostics, renders, preview screenshots, and exports. Each external agent session binds to a specific Studio workspace window."
         action={
           <span
             className="text-xs px-2 py-0.5 rounded-full font-medium"
@@ -238,7 +240,12 @@ export function ExternalAgentsCard({ settings, isOpen }: ExternalAgentsCardProps
       >
         <Text variant="caption" color="tertiary">
           External agents should keep reading and editing files directly in your repo. OpenSCAD
-          Studio MCP is for render-oriented tasks only.
+          Studio MCP is for render-oriented tasks only, and each agent session should call
+          <Text as="code" variant="caption" className="font-mono">
+            {' '}
+            select_workspace
+          </Text>{' '}
+          before using render tools.
         </Text>
 
         <SettingsSupportBlock className="flex flex-col" style={{ gap: 'var(--space-helper-gap)' }}>
@@ -287,6 +294,34 @@ export function ExternalAgentsCard({ settings, isOpen }: ExternalAgentsCardProps
 
         <SettingsSupportBlock className="flex flex-col" style={{ gap: 'var(--space-helper-gap)' }}>
           <Text variant="caption" weight="semibold">
+            Cursor
+          </Text>
+          <Text variant="caption" color="tertiary">
+            Add this to{' '}
+            <Text as="code" variant="caption" className="font-mono">
+              ~/.cursor/mcp.json
+            </Text>
+          </Text>
+          <div
+            className="flex items-start justify-between"
+            style={{ gap: 'var(--space-control-gap)' }}
+          >
+            <Text as="code" variant="caption" className="font-mono break-all whitespace-pre-wrap">
+              {cursorConfig}
+            </Text>
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              onClick={() => void copyText('Cursor config', cursorConfig)}
+            >
+              Copy
+            </Button>
+          </div>
+        </SettingsSupportBlock>
+
+        <SettingsSupportBlock className="flex flex-col" style={{ gap: 'var(--space-helper-gap)' }}>
+          <Text variant="caption" weight="semibold">
             Codex
           </Text>
           <div
@@ -309,20 +344,26 @@ export function ExternalAgentsCard({ settings, isOpen }: ExternalAgentsCardProps
 
         <SettingsSupportBlock className="flex flex-col" style={{ gap: 'var(--space-helper-gap)' }}>
           <Text variant="caption" weight="semibold">
-            Agent snippet
+            OpenCode
+          </Text>
+          <Text variant="caption" color="tertiary">
+            Add this to{' '}
+            <Text as="code" variant="caption" className="font-mono">
+              ~/.config/opencode/opencode.json
+            </Text>
           </Text>
           <div
             className="flex items-start justify-between"
             style={{ gap: 'var(--space-control-gap)' }}
           >
-            <Text as="code" variant="caption" className="font-mono break-all">
-              {agentSnippet}
+            <Text as="code" variant="caption" className="font-mono break-all whitespace-pre-wrap">
+              {openCodeConfig}
             </Text>
             <Button
               type="button"
               size="sm"
               variant="ghost"
-              onClick={() => void copyText('Agent snippet', agentSnippet)}
+              onClick={() => void copyText('OpenCode config', openCodeConfig)}
             >
               Copy
             </Button>

--- a/apps/ui/src/components/settings/ExternalAgentsCard.tsx
+++ b/apps/ui/src/components/settings/ExternalAgentsCard.tsx
@@ -1,0 +1,347 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Button, Input, Text, Toggle } from '../ui';
+import type { Settings } from '../../stores/settingsStore';
+import { updateSetting } from '../../stores/settingsStore';
+import {
+  buildAgentSnippet,
+  buildClaudeMcpCommand,
+  buildCodexMcpCommand,
+  getDesktopMcpStatus,
+  syncDesktopMcpConfig,
+  type McpServerStatus,
+} from '../../services/desktopMcp';
+import { notifyError, notifySuccess } from '../../utils/notifications';
+import {
+  SettingsCard,
+  SettingsCardHeader,
+  SettingsCardSection,
+  SettingsControlRow,
+  SettingsSupportBlock,
+} from './SettingsPrimitives';
+
+interface ExternalAgentsCardProps {
+  settings: Settings;
+  isOpen: boolean;
+}
+
+const STATUS_LABELS: Record<McpServerStatus['status'], string> = {
+  starting: 'Starting',
+  running: 'Running',
+  disabled: 'Disabled',
+  port_conflict: 'Port conflict',
+  error: 'Error',
+};
+
+function getStatusPillStyle(status: McpServerStatus['status']) {
+  switch (status) {
+    case 'running':
+      return {
+        backgroundColor: 'rgba(133, 153, 0, 0.15)',
+        color: 'var(--color-success)',
+      };
+    case 'starting':
+      return {
+        backgroundColor: 'rgba(181, 137, 0, 0.14)',
+        color: 'var(--color-warning)',
+      };
+    case 'port_conflict':
+    case 'error':
+      return {
+        backgroundColor: 'rgba(220, 50, 47, 0.14)',
+        color: 'var(--color-error)',
+      };
+    default:
+      return {
+        backgroundColor: 'rgba(128, 128, 128, 0.1)',
+        color: 'var(--text-tertiary)',
+      };
+  }
+}
+
+export function ExternalAgentsCard({ settings, isOpen }: ExternalAgentsCardProps) {
+  const [status, setStatus] = useState<McpServerStatus>({
+    enabled: settings.mcp.enabled,
+    port: settings.mcp.port,
+    status: settings.mcp.enabled ? 'starting' : 'disabled',
+    endpoint: settings.mcp.enabled ? `http://127.0.0.1:${settings.mcp.port}/mcp` : null,
+    message: null,
+  });
+  const [draftPort, setDraftPort] = useState(String(settings.mcp.port));
+  const [isSyncing, setIsSyncing] = useState(false);
+
+  useEffect(() => {
+    setDraftPort(String(settings.mcp.port));
+  }, [settings.mcp.port]);
+
+  const refreshStatus = useCallback(async () => {
+    try {
+      setStatus(await getDesktopMcpStatus());
+    } catch (error) {
+      setStatus((prev) => ({
+        ...prev,
+        enabled: settings.mcp.enabled,
+        port: settings.mcp.port,
+        endpoint: settings.mcp.enabled ? `http://127.0.0.1:${settings.mcp.port}/mcp` : null,
+        status: 'error',
+        message: error instanceof Error ? error.message : String(error),
+      }));
+    }
+  }, [settings.mcp.enabled, settings.mcp.port]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    void refreshStatus();
+  }, [isOpen, refreshStatus]);
+
+  const endpoint = status.endpoint ?? `http://127.0.0.1:${status.port}/mcp`;
+  const claudeCommand = useMemo(() => buildClaudeMcpCommand(status.port), [status.port]);
+  const codexCommand = useMemo(() => buildCodexMcpCommand(status.port), [status.port]);
+  const agentSnippet = useMemo(() => buildAgentSnippet(status.port), [status.port]);
+
+  const copyText = useCallback(async (label: string, value: string) => {
+    try {
+      await navigator.clipboard.writeText(value);
+      notifySuccess(`${label} copied`, {
+        toastId: `copy-${label.toLowerCase().replace(/\s+/g, '-')}`,
+      });
+    } catch (error) {
+      notifyError({
+        operation: 'copy-external-agent-command',
+        error,
+        fallbackMessage: `Failed to copy ${label.toLowerCase()}`,
+      });
+    }
+  }, []);
+
+  const handleEnabledChange = useCallback(
+    async (enabled: boolean) => {
+      updateSetting('mcp', { enabled });
+      setIsSyncing(true);
+      setStatus((prev) => ({
+        ...prev,
+        enabled,
+        status: enabled ? 'starting' : 'disabled',
+        endpoint: enabled ? `http://127.0.0.1:${prev.port}/mcp` : null,
+        message: null,
+      }));
+
+      try {
+        setStatus(await syncDesktopMcpConfig({ enabled, port: settings.mcp.port }));
+      } catch (error) {
+        setStatus((prev) => ({
+          ...prev,
+          enabled,
+          status: 'error',
+          message: error instanceof Error ? error.message : String(error),
+        }));
+      } finally {
+        setIsSyncing(false);
+      }
+    },
+    [settings.mcp.port]
+  );
+
+  const handleApplyPort = useCallback(async () => {
+    const parsed = Number.parseInt(draftPort, 10);
+    if (!Number.isFinite(parsed) || parsed < 1 || parsed > 65535) {
+      notifyError({
+        operation: 'update-mcp-port',
+        error: new Error(`Invalid MCP port: ${draftPort}`),
+        fallbackMessage: 'Enter a port between 1 and 65535.',
+      });
+      return;
+    }
+
+    updateSetting('mcp', { port: parsed });
+    setIsSyncing(true);
+    setStatus((prev) => ({
+      ...prev,
+      port: parsed,
+      endpoint: prev.enabled ? `http://127.0.0.1:${parsed}/mcp` : null,
+      status: prev.enabled ? 'starting' : 'disabled',
+      message: null,
+    }));
+
+    try {
+      setStatus(await syncDesktopMcpConfig({ enabled: settings.mcp.enabled, port: parsed }));
+    } catch (error) {
+      setStatus((prev) => ({
+        ...prev,
+        port: parsed,
+        status: 'error',
+        message: error instanceof Error ? error.message : String(error),
+      }));
+    } finally {
+      setIsSyncing(false);
+    }
+  }, [draftPort, settings.mcp.enabled]);
+
+  return (
+    <SettingsCard className="ph-no-capture">
+      <SettingsCardHeader
+        title="External Agents"
+        description="Expose OpenSCAD Studio's project context, render target, diagnostics, renders, and preview screenshots to Claude Code, Codex, and similar local agents."
+        action={
+          <span
+            className="text-xs px-2 py-0.5 rounded-full font-medium"
+            style={getStatusPillStyle(status.status)}
+          >
+            {STATUS_LABELS[status.status]}
+          </span>
+        }
+      />
+
+      <SettingsControlRow
+        label="Enable local MCP server"
+        description="Starts a loopback-only MCP endpoint while the desktop app is open."
+        control={
+          <Toggle
+            checked={settings.mcp.enabled}
+            onChange={handleEnabledChange}
+            disabled={isSyncing}
+          />
+        }
+      />
+
+      <SettingsControlRow
+        divided
+        align="start"
+        label="MCP port"
+        description="Default endpoint: http://127.0.0.1:32123/mcp"
+        control={
+          <div className="flex items-center" style={{ gap: 'var(--space-control-gap)' }}>
+            <Input
+              type="number"
+              value={draftPort}
+              onChange={(event) => setDraftPort(event.target.value)}
+              className="w-28 font-mono"
+              min={1}
+              max={65535}
+            />
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              onClick={handleApplyPort}
+              disabled={isSyncing}
+            >
+              Apply
+            </Button>
+          </div>
+        }
+      />
+
+      <SettingsCardSection
+        divided
+        className="flex flex-col"
+        style={{ gap: 'var(--space-field-gap)' }}
+      >
+        <Text variant="caption" color="tertiary">
+          External agents should keep reading and editing files directly in your repo. OpenSCAD
+          Studio MCP is for render-oriented tasks only.
+        </Text>
+
+        <SettingsSupportBlock className="flex flex-col" style={{ gap: 'var(--space-helper-gap)' }}>
+          <Text variant="caption" weight="semibold">
+            Endpoint
+          </Text>
+          <div
+            className="flex items-center justify-between"
+            style={{ gap: 'var(--space-control-gap)' }}
+          >
+            <Text as="code" variant="caption" className="font-mono break-all">
+              {endpoint}
+            </Text>
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              onClick={() => void copyText('Endpoint', endpoint)}
+            >
+              Copy
+            </Button>
+          </div>
+        </SettingsSupportBlock>
+
+        <SettingsSupportBlock className="flex flex-col" style={{ gap: 'var(--space-helper-gap)' }}>
+          <Text variant="caption" weight="semibold">
+            Claude Code
+          </Text>
+          <div
+            className="flex items-start justify-between"
+            style={{ gap: 'var(--space-control-gap)' }}
+          >
+            <Text as="code" variant="caption" className="font-mono break-all">
+              {claudeCommand}
+            </Text>
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              onClick={() => void copyText('Claude command', claudeCommand)}
+            >
+              Copy
+            </Button>
+          </div>
+        </SettingsSupportBlock>
+
+        <SettingsSupportBlock className="flex flex-col" style={{ gap: 'var(--space-helper-gap)' }}>
+          <Text variant="caption" weight="semibold">
+            Codex
+          </Text>
+          <div
+            className="flex items-start justify-between"
+            style={{ gap: 'var(--space-control-gap)' }}
+          >
+            <Text as="code" variant="caption" className="font-mono break-all">
+              {codexCommand}
+            </Text>
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              onClick={() => void copyText('Codex command', codexCommand)}
+            >
+              Copy
+            </Button>
+          </div>
+        </SettingsSupportBlock>
+
+        <SettingsSupportBlock className="flex flex-col" style={{ gap: 'var(--space-helper-gap)' }}>
+          <Text variant="caption" weight="semibold">
+            Agent snippet
+          </Text>
+          <div
+            className="flex items-start justify-between"
+            style={{ gap: 'var(--space-control-gap)' }}
+          >
+            <Text as="code" variant="caption" className="font-mono break-all">
+              {agentSnippet}
+            </Text>
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              onClick={() => void copyText('Agent snippet', agentSnippet)}
+            >
+              Copy
+            </Button>
+          </div>
+        </SettingsSupportBlock>
+
+        {status.message ? (
+          <SettingsSupportBlock
+            className="text-sm"
+            style={{
+              backgroundColor: 'rgba(220, 50, 47, 0.1)',
+              border: '1px solid rgba(220, 50, 47, 0.3)',
+              color: 'var(--color-error)',
+            }}
+          >
+            {status.message}
+          </SettingsSupportBlock>
+        ) : null}
+      </SettingsCardSection>
+    </SettingsCard>
+  );
+}

--- a/apps/ui/src/components/ui/Accordion.tsx
+++ b/apps/ui/src/components/ui/Accordion.tsx
@@ -1,0 +1,35 @@
+import * as RadixAccordion from '@radix-ui/react-accordion';
+import { forwardRef } from 'react';
+
+export const Accordion = RadixAccordion.Root;
+
+export const AccordionItem = forwardRef<
+  HTMLDivElement,
+  RadixAccordion.AccordionItemProps & { className?: string }
+>(({ className = '', ...props }, ref) => (
+  <RadixAccordion.Item ref={ref} className={className} {...props} />
+));
+
+AccordionItem.displayName = 'AccordionItem';
+
+export const AccordionTrigger = forwardRef<
+  HTMLButtonElement,
+  RadixAccordion.AccordionTriggerProps & { className?: string }
+>(({ className = '', children, ...props }, ref) => (
+  <RadixAccordion.Header>
+    <RadixAccordion.Trigger ref={ref} className={className} {...props}>
+      {children}
+    </RadixAccordion.Trigger>
+  </RadixAccordion.Header>
+));
+
+AccordionTrigger.displayName = 'AccordionTrigger';
+
+export const AccordionContent = forwardRef<
+  HTMLDivElement,
+  RadixAccordion.AccordionContentProps & { className?: string }
+>(({ className = '', ...props }, ref) => (
+  <RadixAccordion.Content ref={ref} className={className} {...props} />
+));
+
+AccordionContent.displayName = 'AccordionContent';

--- a/apps/ui/src/components/ui/Tabs.tsx
+++ b/apps/ui/src/components/ui/Tabs.tsx
@@ -1,0 +1,31 @@
+import * as RadixTabs from '@radix-ui/react-tabs';
+import { forwardRef } from 'react';
+
+export const Tabs = RadixTabs.Root;
+
+export const TabsList = forwardRef<
+  HTMLDivElement,
+  RadixTabs.TabsListProps & { className?: string }
+>(({ className = '', ...props }, ref) => (
+  <RadixTabs.List ref={ref} className={className} {...props} />
+));
+
+TabsList.displayName = 'TabsList';
+
+export const TabsTrigger = forwardRef<
+  HTMLButtonElement,
+  RadixTabs.TabsTriggerProps & { className?: string }
+>(({ className = '', ...props }, ref) => (
+  <RadixTabs.Trigger ref={ref} className={className} {...props} />
+));
+
+TabsTrigger.displayName = 'TabsTrigger';
+
+export const TabsContent = forwardRef<
+  HTMLDivElement,
+  RadixTabs.TabsContentProps & { className?: string }
+>(({ className = '', ...props }, ref) => (
+  <RadixTabs.Content ref={ref} className={className} {...props} />
+));
+
+TabsContent.displayName = 'TabsContent';

--- a/apps/ui/src/components/ui/index.ts
+++ b/apps/ui/src/components/ui/index.ts
@@ -35,3 +35,4 @@ export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from './Tool
 export type { TooltipProviderProps } from './Tooltip';
 
 export { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from './Accordion';
+export { Tabs, TabsList, TabsTrigger, TabsContent } from './Tabs';

--- a/apps/ui/src/components/ui/index.ts
+++ b/apps/ui/src/components/ui/index.ts
@@ -33,3 +33,5 @@ export { RangeSlider } from './RangeSlider';
 
 export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from './Tooltip';
 export type { TooltipProviderProps } from './Tooltip';
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from './Accordion';

--- a/apps/ui/src/global.d.ts
+++ b/apps/ui/src/global.d.ts
@@ -6,6 +6,9 @@
  */
 interface Window {
   __PLAYWRIGHT__?: boolean;
+  __OPENSCAD_STUDIO_BOOTSTRAP__?: {
+    launchIntent?: import('./services/desktopMcp').DesktopWindowLaunchIntent | null;
+  };
   __TEST_EDITOR__?: import('monaco-editor').editor.IStandaloneCodeEditor;
   __TEST_MONACO__?: typeof import('monaco-editor');
   __TEST_OPENSCAD__?: {

--- a/apps/ui/src/hooks/__tests__/useAiAgent.test.tsx
+++ b/apps/ui/src/hooks/__tests__/useAiAgent.test.tsx
@@ -106,6 +106,17 @@ describe('useAiAgent', () => {
           listProjectFiles: () => string[];
           readProjectFile: (path: string) => string | null;
           getRenderTargetPath: () => string | null;
+          getRenderValidationInputs: () => Promise<{
+            code: string;
+            renderTargetPath: string | null;
+            renderOptions: {
+              auxiliaryFiles?: Record<string, string>;
+              inputPath?: string;
+              libraryFiles?: Record<string, string>;
+              libraryPaths?: string[];
+              workingDir?: string;
+            };
+          }>;
           createProjectFile: (path: string, content: string) => boolean;
           editProjectFile: (path: string, oldString: string, newString: string) => string | null;
           setRenderTarget: (path: string) => boolean;
@@ -151,6 +162,20 @@ describe('useAiAgent', () => {
     );
     expect(capturedCallbacks!.readProjectFile('../escape.scad')).toBeNull();
     expect(capturedCallbacks!.getRenderTargetPath()).toBe('main.scad');
+    await expect(capturedCallbacks!.getRenderValidationInputs()).resolves.toEqual({
+      code: 'use <lib/constants.h>\ncube(42);',
+      renderTargetPath: 'main.scad',
+      renderOptions: {
+        auxiliaryFiles: {
+          'lib/constants.h': 'wall = 2;',
+          'lib/utils.scad': 'module helper() {}',
+        },
+        inputPath: 'main.scad',
+        libraryFiles: undefined,
+        libraryPaths: undefined,
+        workingDir: undefined,
+      },
+    });
     expect(capturedCallbacks!.getMeasurementUnit()).toBe('cm');
 
     // Test editProjectFile

--- a/apps/ui/src/hooks/__tests__/useOpenScad.test.tsx
+++ b/apps/ui/src/hooks/__tests__/useOpenScad.test.tsx
@@ -387,4 +387,69 @@ describe('useOpenScad', () => {
     expect(renderService.render).toHaveBeenCalledTimes(1);
     expect(hook.current().diagnostics).toEqual([]);
   });
+
+  it('renders nested targets relative to the workspace root while preserving the nested input path', async () => {
+    const projectStore = getProjectStore();
+    projectStore.getState().openProject(
+      '/repo',
+      {
+        'openscad/poly555.scad': 'include <config.scad>;\nuse <lib/keys.scad>;\npoly555();',
+        'openscad/config.scad': 'SHOW_ENCLOSURE_BOTTOM = true;',
+        'openscad/lib/keys.scad': 'module poly555() cube(10);',
+      },
+      'openscad/poly555.scad'
+    );
+
+    const renderService = {
+      init: jest.fn(async () => undefined),
+      getCached: jest.fn(async () => null),
+      render: jest.fn(async () => ({
+        output: new Uint8Array([1]),
+        kind: 'mesh' as const,
+        diagnostics: [],
+      })),
+    };
+    const resolveDeps = jest.fn(async () => ({
+      'openscad/config.scad': 'SHOW_ENCLOSURE_BOTTOM = true;',
+      'openscad/lib/keys.scad': 'module poly555() cube(10);',
+    }));
+
+    const hook = createHarness({
+      suppressInitialRender: true,
+      source: projectStore.getState().files['openscad/poly555.scad']?.content ?? '',
+      contentVersion: projectStore.getState().contentVersion,
+      workingDir: '/repo',
+      testOverrides: {
+        renderService: renderService as never,
+        resolveWorkingDirDeps: resolveDeps as never,
+      },
+    });
+
+    await waitFor(() => {
+      expect(hook.current().ready).toBe(true);
+    });
+
+    await act(async () => {
+      await hook.current().manualRender();
+    });
+
+    expect(resolveDeps).toHaveBeenCalledWith(
+      'include <config.scad>;\nuse <lib/keys.scad>;\npoly555();',
+      expect.objectContaining({
+        workingDir: '/repo',
+        renderTargetDir: 'openscad',
+      })
+    );
+    expect(renderService.render).toHaveBeenCalledWith(
+      'include <config.scad>;\nuse <lib/keys.scad>;\npoly555();',
+      expect.objectContaining({
+        workingDir: '/repo',
+        inputPath: 'openscad/poly555.scad',
+        auxiliaryFiles: {
+          'openscad/config.scad': 'SHOW_ENCLOSURE_BOTTOM = true;',
+          'openscad/lib/keys.scad': 'module poly555() cube(10);',
+        },
+      })
+    );
+  });
 });

--- a/apps/ui/src/hooks/useAiAgent.ts
+++ b/apps/ui/src/hooks/useAiAgent.ts
@@ -15,6 +15,10 @@ import {
   type AiToolCallbacks,
 } from '../services/aiService';
 import {
+  buildProjectRenderInputs,
+  loadConfiguredLibraryAssets,
+} from '../services/projectRenderInputs';
+import {
   getApiKey,
   getProviderFromModel,
   getStoredModel,
@@ -297,6 +301,28 @@ export function useAiAgent(options: UseAiAgentOptions = {}) {
         return state.files[normalizedPath]?.content ?? null;
       },
       getRenderTargetPath: () => getProjectState().renderTargetPath,
+      getRenderValidationInputs: async () => {
+        const state = getProjectState();
+        const platform = getPlatform();
+        const settings = loadSettingsImpl();
+        const { libraryFiles, libraryPaths } = await loadConfiguredLibraryAssets(
+          settings.library,
+          platform
+        );
+
+        const renderInputs = await buildProjectRenderInputs({
+          state,
+          libraryFiles,
+          libraryPaths,
+          platform: state.projectRoot ? platform : undefined,
+        });
+
+        return {
+          code: renderInputs.code,
+          renderTargetPath: renderInputs.renderTargetPath,
+          renderOptions: renderInputs.renderOptions,
+        };
+      },
       createProjectFile: (path: string, content: string) => {
         const normalizedPath = normalizeProjectRelativePath(path);
         if (!normalizedPath) return false;
@@ -356,7 +382,7 @@ export function useAiAgent(options: UseAiAgentOptions = {}) {
         updateSettingImpl('viewer', { measurementUnit: unit });
       },
     }),
-    [updateSettingImpl]
+    [loadSettingsImpl, updateSettingImpl]
   );
 
   const tools: ToolSet = useMemo(() => buildToolsImpl(callbacks), [buildToolsImpl, callbacks]);

--- a/apps/ui/src/hooks/useOpenScad.ts
+++ b/apps/ui/src/hooks/useOpenScad.ts
@@ -6,11 +6,14 @@ import {
   type IRenderService,
   type Diagnostic,
 } from '../services/renderService';
+import {
+  buildProjectRenderInputs,
+  loadConfiguredLibraryAssets,
+} from '../services/projectRenderInputs';
 import { getPlatform } from '../platform';
 import type { LibrarySettings } from '../stores/settingsStore';
 import { resolveWorkingDirDeps } from '../utils/resolveWorkingDirDeps';
-import { getProjectState, getAuxiliaryFilesForRender } from '../stores/projectStore';
-import { normalizeProjectRelativePath } from '../utils/projectFilePaths';
+import { getProjectState } from '../stores/projectStore';
 import { notifyError } from '../utils/notifications';
 import { hasRenderableOutput } from './renderOutput';
 export type RenderKind = 'mesh' | 'svg';
@@ -131,26 +134,9 @@ export function useOpenScad(options: UseOpenScadOptions = {}) {
     const platform = getPlatformImpl();
 
     const loadLibraryFiles = async () => {
-      const files: Record<string, string> = {};
-
-      if (library) {
-        const systemPaths = library.autoDiscoverSystem ? await platform.getLibraryPaths() : [];
-        const allLibPaths = [...systemPaths, ...library.customPaths];
-        libraryPathsRef.current = allLibPaths;
-
-        for (const libPath of allLibPaths) {
-          try {
-            const libFiles = await platform.readDirectoryFiles(libPath);
-            Object.assign(files, libFiles);
-          } catch (err) {
-            console.warn(`[useOpenScad] Failed to read library path ${libPath}:`, err);
-          }
-        }
-      } else {
-        libraryPathsRef.current = [];
-      }
-
-      libraryFilesRef.current = files;
+      const { libraryFiles, libraryPaths } = await loadConfiguredLibraryAssets(library, platform);
+      libraryFilesRef.current = libraryFiles;
+      libraryPathsRef.current = libraryPaths;
       mergeAndSetAuxFiles();
     };
 
@@ -236,57 +222,24 @@ export function useOpenScad(options: UseOpenScadOptions = {}) {
         // instead of blindly scanning the entire working directory.
         // On web (no workingDir), project store files are the only source.
         const workingDir = workingDirRef.current;
-        const projectFiles = getAuxiliaryFilesForRender(getProjectState());
+        const renderInputs = await buildProjectRenderInputs({
+          code,
+          state: getProjectState(),
+          workingDir,
+          libraryFiles: libraryFilesRef.current,
+          libraryPaths: libraryPathsRef.current,
+          platform: workingDir ? getPlatformImpl() : undefined,
+          resolveWorkingDirDepsImpl,
+        });
 
-        // Build project-only auxiliary files (no library files — those are
-        // passed separately via libraryFiles/libraryPaths)
-        let projectAuxFiles: Record<string, string> = { ...projectFiles };
-
-        if (workingDir) {
-          const platform = getPlatformImpl();
-          const renderTargetPath = normalizeProjectRelativePath(
-            getProjectState().renderTargetPath ?? ''
-          );
-          const rtLastSlash = renderTargetPath?.lastIndexOf('/') ?? -1;
-          const renderTargetDir =
-            renderTargetPath && rtLastSlash > 0
-              ? renderTargetPath.substring(0, rtLastSlash)
-              : undefined;
-          const workingDirFiles = await resolveWorkingDirDepsImpl(code, {
-            workingDir,
-            libraryFiles: libraryFilesRef.current,
-            platform,
-            projectFiles,
-            renderTargetDir,
-          });
-
-          if (Object.keys(workingDirFiles).length > 0) {
-            projectAuxFiles = { ...projectAuxFiles, ...workingDirFiles };
-          }
-        }
-
-        // Update refs so the cache check uses consistent data on next render
-        workingDirFilesRef.current = Object.fromEntries(
-          Object.entries(projectAuxFiles).filter(([k]) => !(k in projectFiles))
-        );
+        // Update refs so the cache check uses consistent data on next render.
+        workingDirFilesRef.current = renderInputs.workingDirDependencyFiles;
         mergeAndSetAuxFiles();
 
-        const libraryFiles = libraryFilesRef.current;
-        // Merge all files for the render call — both services need library
-        // file contents (WASM for virtual FS, native because -L is not
-        // supported by the bundled OpenSCAD snapshot).  libraryPaths is
-        // passed so the native renderer can avoid writing library files
-        // into the project directory.
-        const allAuxFiles = { ...libraryFiles, ...projectAuxFiles };
         const renderOptions = {
+          ...renderInputs.renderOptions,
           view: dimension,
           backend: 'manifold',
-          auxiliaryFiles: Object.keys(allAuxFiles).length > 0 ? allAuxFiles : undefined,
-          libraryFiles: Object.keys(libraryFiles).length > 0 ? libraryFiles : undefined,
-          libraryPaths: libraryPathsRef.current.length > 0 ? libraryPathsRef.current : undefined,
-          inputPath:
-            normalizeProjectRelativePath(getProjectState().renderTargetPath ?? '') ?? undefined,
-          workingDir: workingDir || undefined,
         } as const;
 
         const cached = await renderServiceRef.current.getCached(code, renderOptions);

--- a/apps/ui/src/hooks/useOpenScad.ts
+++ b/apps/ui/src/hooks/useOpenScad.ts
@@ -10,6 +10,7 @@ import { getPlatform } from '../platform';
 import type { LibrarySettings } from '../stores/settingsStore';
 import { resolveWorkingDirDeps } from '../utils/resolveWorkingDirDeps';
 import { getProjectState, getAuxiliaryFilesForRender } from '../stores/projectStore';
+import { normalizeProjectRelativePath } from '../utils/projectFilePaths';
 import { notifyError } from '../utils/notifications';
 import { hasRenderableOutput } from './renderOutput';
 export type RenderKind = 'mesh' | 'svg';
@@ -243,7 +244,9 @@ export function useOpenScad(options: UseOpenScadOptions = {}) {
 
         if (workingDir) {
           const platform = getPlatformImpl();
-          const renderTargetPath = getProjectState().renderTargetPath;
+          const renderTargetPath = normalizeProjectRelativePath(
+            getProjectState().renderTargetPath ?? ''
+          );
           const rtLastSlash = renderTargetPath?.lastIndexOf('/') ?? -1;
           const renderTargetDir =
             renderTargetPath && rtLastSlash > 0
@@ -281,7 +284,8 @@ export function useOpenScad(options: UseOpenScadOptions = {}) {
           auxiliaryFiles: Object.keys(allAuxFiles).length > 0 ? allAuxFiles : undefined,
           libraryFiles: Object.keys(libraryFiles).length > 0 ? libraryFiles : undefined,
           libraryPaths: libraryPathsRef.current.length > 0 ? libraryPathsRef.current : undefined,
-          inputPath: getProjectState().renderTargetPath ?? undefined,
+          inputPath:
+            normalizeProjectRelativePath(getProjectState().renderTargetPath ?? '') ?? undefined,
           workingDir: workingDir || undefined,
         } as const;
 

--- a/apps/ui/src/hooks/useOpenScad.ts
+++ b/apps/ui/src/hooks/useOpenScad.ts
@@ -10,6 +10,7 @@ import { getPlatform } from '../platform';
 import type { LibrarySettings } from '../stores/settingsStore';
 import { resolveWorkingDirDeps } from '../utils/resolveWorkingDirDeps';
 import { getProjectState, getAuxiliaryFilesForRender } from '../stores/projectStore';
+import { signalAppReady } from '../services/desktopMcp';
 import { notifyError } from '../utils/notifications';
 import { hasRenderableOutput } from './renderOutput';
 export type RenderKind = 'mesh' | 'svg';
@@ -183,6 +184,7 @@ export function useOpenScad(options: UseOpenScadOptions = {}) {
       })
       .then(() => {
         setReady(true);
+        signalAppReady();
       })
       .catch((err) => {
         setError(`Failed to initialize OpenSCAD: ${err}`);

--- a/apps/ui/src/hooks/useOpenScad.ts
+++ b/apps/ui/src/hooks/useOpenScad.ts
@@ -10,7 +10,6 @@ import { getPlatform } from '../platform';
 import type { LibrarySettings } from '../stores/settingsStore';
 import { resolveWorkingDirDeps } from '../utils/resolveWorkingDirDeps';
 import { getProjectState, getAuxiliaryFilesForRender } from '../stores/projectStore';
-import { signalAppReady } from '../services/desktopMcp';
 import { notifyError } from '../utils/notifications';
 import { hasRenderableOutput } from './renderOutput';
 export type RenderKind = 'mesh' | 'svg';
@@ -184,7 +183,6 @@ export function useOpenScad(options: UseOpenScadOptions = {}) {
       })
       .then(() => {
         setReady(true);
-        signalAppReady();
       })
       .catch((err) => {
         setError(`Failed to initialize OpenSCAD: ${err}`);

--- a/apps/ui/src/main.tsx
+++ b/apps/ui/src/main.tsx
@@ -1,4 +1,7 @@
+/* eslint-disable react-refresh/only-export-components */
+
 import './sentry';
+import { useCallback, useEffect, useRef, useState, type CSSProperties } from 'react';
 import ReactDOM from 'react-dom/client';
 import posthog from 'posthog-js';
 import { PostHogProvider } from '@posthog/react';
@@ -6,32 +9,97 @@ import App from './App';
 import { captureAppOpened, captureBootstrapError, initializePostHog } from './analytics/bootstrap';
 import { shouldCaptureBootstrapAnalytics } from './analytics/bootstrapPolicy';
 import { AnalyticsRuntimeProvider } from './analytics/runtime';
+import { Button } from './components/ui';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { ThemeProvider } from './contexts/ThemeContext';
+import { getPlatform, initializePlatform } from './platform';
+import {
+  consumeDesktopBootstrapLaunchIntent,
+  initializeDesktopMcpBridge,
+  reportDesktopWindowOpenResult,
+  syncDesktopMcpWindowContext,
+  type DesktopWindowLaunchIntent,
+  type DesktopWindowOpenRequest,
+} from './services/desktopMcp';
+import { openFileInWindow, openWorkspaceFolderInWindow } from './services/windowOpenService';
 import { captureSentryException } from './sentry';
+import { getProjectState } from './stores/projectStore';
 import { loadSettings } from './stores/settingsStore';
+import { workspaceStore } from './stores/workspaceStore';
 import { initFormatter } from './utils/formatter';
-import { initializePlatform } from './platform';
 import './index.css';
 
-function renderApp() {
-  ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-    <PostHogProvider client={posthog}>
-      <ThemeProvider>
-        <AnalyticsRuntimeProvider>
-          <ErrorBoundary>
-            <App />
-          </ErrorBoundary>
-        </AnalyticsRuntimeProvider>
-      </ThemeProvider>
-    </PostHogProvider>
+type BootstrapWindowMode =
+  | 'booting'
+  | 'welcome'
+  | 'opening_folder'
+  | 'opening_file'
+  | 'ready'
+  | 'open_failed';
+
+interface BootstrapWindowState {
+  mode: BootstrapWindowMode;
+  targetPath?: string | null;
+  errorMessage?: string | null;
+  failedRequest?: DesktopWindowOpenRequest | null;
+}
+
+const INITIAL_WINDOW_STATE: BootstrapWindowState = {
+  mode: 'booting',
+  targetPath: null,
+  errorMessage: null,
+  failedRequest: null,
+};
+
+function renderLoadingScreen(
+  title = 'Starting OpenSCAD Studio',
+  body = 'Loading the editor and desktop services for this window.'
+) {
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'var(--bg-primary, #002b36)',
+        color: 'var(--text-primary, #eee8d5)',
+        padding: '2rem',
+        fontFamily: '-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif',
+      }}
+    >
+      <div
+        style={{
+          maxWidth: '420px',
+          width: '100%',
+          padding: '2rem',
+          borderRadius: '1rem',
+          background: 'rgba(7, 54, 66, 0.75)',
+          border: '1px solid rgba(131, 148, 150, 0.35)',
+          textAlign: 'center',
+        }}
+      >
+        <div
+          style={{
+            width: '2rem',
+            height: '2rem',
+            margin: '0 auto 1rem',
+            borderRadius: '999px',
+            border: '2px solid rgba(131, 148, 150, 0.35)',
+            borderTopColor: '#268bd2',
+            animation: 'spin 1s linear infinite',
+          }}
+        />
+        <h1 style={{ fontSize: '1.5rem', marginBottom: '0.75rem' }}>{title}</h1>
+        <p style={{ lineHeight: 1.6, color: '#93a1a1', whiteSpace: 'pre-wrap' }}>{body}</p>
+      </div>
+    </div>
   );
 }
 
 function renderBootstrapError(error: unknown) {
   const message = error instanceof Error ? error.message : String(error);
-
-  ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  return (
     <div
       style={{
         minHeight: '100vh',
@@ -74,25 +142,509 @@ function renderBootstrapError(error: unknown) {
         >
           {message}
         </pre>
-        {/* eslint-disable-next-line no-restricted-syntax -- bootstrap error screen runs before React context is mounted; <Button> depends on theme context which has not been initialized at this point */}
-        <button
+        <Button
           type="button"
           onClick={() => window.location.reload()}
+          variant="primary"
           style={{
             padding: '0.625rem 1.5rem',
-            background: '#268bd2',
-            color: '#002b36',
-            border: 'none',
             borderRadius: 'var(--radius-md, 8px)',
             fontSize: '0.9375rem',
             fontWeight: 600,
-            cursor: 'pointer',
           }}
         >
           Reload
-        </button>
+        </Button>
       </div>
     </div>
+  );
+}
+
+function renderOpenFailureScreen(args: {
+  state: BootstrapWindowState;
+  onRetry: () => void;
+  onOpenFolder: () => void;
+  onOpenFile: () => void;
+  onGoToWelcome: () => void;
+}) {
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'var(--bg-primary, #002b36)',
+        color: 'var(--text-primary, #eee8d5)',
+        padding: '2rem',
+        fontFamily: '-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif',
+      }}
+    >
+      <div
+        style={{
+          maxWidth: '560px',
+          width: '100%',
+          padding: '2rem',
+          borderRadius: '1rem',
+          background: 'rgba(7, 54, 66, 0.75)',
+          border: '1px solid rgba(131, 148, 150, 0.35)',
+        }}
+      >
+        <h1 style={{ fontSize: '1.75rem', marginBottom: '0.75rem' }}>
+          Couldn&apos;t open this workspace
+        </h1>
+        {args.state.targetPath ? (
+          <p style={{ lineHeight: 1.6, marginBottom: '0.75rem', color: '#93a1a1' }}>
+            Target: {args.state.targetPath}
+          </p>
+        ) : null}
+        <pre
+          style={{
+            background: '#073642',
+            color: '#cb4b16',
+            padding: '0.75rem 1rem',
+            borderRadius: '0.5rem',
+            fontSize: '0.8125rem',
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+            marginBottom: '1.5rem',
+          }}
+        >
+          {args.state.errorMessage ?? 'Failed to open the requested target.'}
+        </pre>
+        <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap' }}>
+          <Button type="button" onClick={args.onRetry} variant="primary" style={primaryButtonStyle}>
+            Retry
+          </Button>
+          <Button
+            type="button"
+            onClick={args.onOpenFolder}
+            variant="secondary"
+            style={secondaryButtonStyle}
+          >
+            Open Folder
+          </Button>
+          <Button
+            type="button"
+            onClick={args.onOpenFile}
+            variant="secondary"
+            style={secondaryButtonStyle}
+          >
+            Open File
+          </Button>
+          <Button
+            type="button"
+            onClick={args.onGoToWelcome}
+            variant="secondary"
+            style={secondaryButtonStyle}
+          >
+            Go to Welcome
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const primaryButtonStyle: CSSProperties = {
+  padding: '0.625rem 1.5rem',
+  background: '#268bd2',
+  color: '#002b36',
+  border: 'none',
+  borderRadius: 'var(--radius-md, 8px)',
+  fontSize: '0.9375rem',
+  fontWeight: 600,
+  cursor: 'pointer',
+};
+
+const secondaryButtonStyle: CSSProperties = {
+  padding: '0.625rem 1.5rem',
+  background: '#073642',
+  color: '#eee8d5',
+  border: '1px solid rgba(131, 148, 150, 0.35)',
+  borderRadius: 'var(--radius-md, 8px)',
+  fontSize: '0.9375rem',
+  fontWeight: 500,
+  cursor: 'pointer',
+};
+
+function intentToRequest(intent: DesktopWindowLaunchIntent): DesktopWindowOpenRequest | null {
+  switch (intent.kind) {
+    case 'welcome':
+      return null;
+    case 'open_folder':
+      return {
+        kind: 'open_folder',
+        folder_path: intent.folder_path,
+        create_if_empty: intent.create_if_empty,
+      };
+    case 'open_file':
+      return {
+        kind: 'open_file',
+        file_path: intent.file_path,
+      };
+  }
+}
+
+function normalizeErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback;
+}
+
+function BootstrapApp() {
+  const [startupError, setStartupError] = useState<unknown>(null);
+  const [platformReady, setPlatformReady] = useState(false);
+  const [windowState, setWindowState] = useState<BootstrapWindowState>(INITIAL_WINDOW_STATE);
+  const [bridgeReady, setBridgeReady] = useState(false);
+  const activeRequestRef = useRef<{
+    key: string;
+    promise: Promise<void>;
+  } | null>(null);
+
+  const syncWindowContext = useCallback(
+    async (
+      nextState: BootstrapWindowState,
+      args?: {
+        requestId?: string | null;
+        workspaceRoot?: string | null;
+        renderTargetPath?: string | null;
+      }
+    ) => {
+      if (!bridgeReady || !getPlatform().capabilities.hasFileSystem) {
+        return;
+      }
+
+      const projectState = getProjectState();
+      await syncDesktopMcpWindowContext({
+        title: document.title || 'OpenSCAD Studio',
+        workspaceRoot: args?.workspaceRoot ?? projectState.projectRoot,
+        renderTargetPath: args?.renderTargetPath ?? projectState.renderTargetPath,
+        showWelcome: nextState.mode === 'welcome',
+        mode:
+          nextState.mode === 'welcome'
+            ? 'welcome'
+            : nextState.mode === 'open_failed'
+              ? 'open_failed'
+              : nextState.mode === 'ready'
+                ? 'ready'
+                : 'opening',
+        pendingRequestId: args?.requestId ?? null,
+      });
+    },
+    [bridgeReady]
+  );
+
+  const runOpenRequest = useCallback(
+    async (
+      request: DesktopWindowOpenRequest,
+      options: {
+        requestId?: string;
+        reportResult?: boolean;
+      } = {}
+    ) => {
+      const key =
+        request.kind === 'open_folder'
+          ? `folder:${request.folder_path}`
+          : `file:${request.file_path}`;
+
+      if (activeRequestRef.current) {
+        if (activeRequestRef.current.key === key) {
+          await activeRequestRef.current.promise;
+          return;
+        }
+
+        const busyMessage = 'This window is already opening another target.';
+        if (options.reportResult && options.requestId) {
+          await reportDesktopWindowOpenResult({
+            requestId: options.requestId,
+            success: false,
+            message: busyMessage,
+          });
+        }
+        setWindowState((state) => ({
+          ...state,
+          mode: 'open_failed',
+          errorMessage: busyMessage,
+          failedRequest: request,
+          targetPath: request.kind === 'open_folder' ? request.folder_path : request.file_path,
+        }));
+        return;
+      }
+
+      const nextWindowState: BootstrapWindowState = {
+        mode: request.kind === 'open_folder' ? 'opening_folder' : 'opening_file',
+        targetPath: request.kind === 'open_folder' ? request.folder_path : request.file_path,
+        errorMessage: null,
+        failedRequest: null,
+      };
+      setWindowState(nextWindowState);
+      await syncWindowContext(nextWindowState, {
+        requestId: options.requestId ?? null,
+        workspaceRoot: null,
+        renderTargetPath: null,
+      });
+
+      const promise = (async () => {
+        try {
+          if (request.kind === 'open_folder') {
+            const result = await openWorkspaceFolderInWindow(request.folder_path, {
+              createIfEmpty: request.create_if_empty,
+            });
+            const readyState: BootstrapWindowState = {
+              mode: 'ready',
+              targetPath: null,
+              errorMessage: null,
+              failedRequest: null,
+            };
+            setWindowState(readyState);
+            await syncWindowContext(readyState, {
+              workspaceRoot: result.workspaceRoot,
+              renderTargetPath: result.renderTargetPath,
+            });
+            if (options.reportResult && options.requestId) {
+              const action = result.createdDefaultFile ? 'Created' : 'Opened';
+              await reportDesktopWindowOpenResult({
+                requestId: options.requestId,
+                success: true,
+                message: `✅ ${action} workspace at ${request.folder_path}.\n\nRender target: ${result.renderTargetPath}`,
+                openedWorkspaceRoot: result.workspaceRoot,
+              });
+            }
+            return;
+          }
+
+          const fileResult = await getPlatform().fileRead(request.file_path);
+          if (!fileResult) {
+            throw new Error(`Could not read file at ${request.file_path}.`);
+          }
+          const result = await openFileInWindow(fileResult);
+          const readyState: BootstrapWindowState = {
+            mode: 'ready',
+            targetPath: null,
+            errorMessage: null,
+            failedRequest: null,
+          };
+          setWindowState(readyState);
+          await syncWindowContext(readyState, {
+            workspaceRoot: result.projectRoot,
+            renderTargetPath: result.projectPath,
+          });
+          if (options.reportResult && options.requestId) {
+            await reportDesktopWindowOpenResult({
+              requestId: options.requestId,
+              success: true,
+              message: `✅ Opened file at ${request.file_path}.`,
+              openedFilePath: request.file_path,
+            });
+          }
+        } catch (error) {
+          const message = normalizeErrorMessage(error, 'Failed to open the requested target.');
+          const failedState: BootstrapWindowState = {
+            mode: 'open_failed',
+            targetPath: request.kind === 'open_folder' ? request.folder_path : request.file_path,
+            errorMessage: message,
+            failedRequest: request,
+          };
+          setWindowState(failedState);
+          await syncWindowContext(failedState, {
+            workspaceRoot: null,
+            renderTargetPath: null,
+          });
+          if (options.reportResult && options.requestId) {
+            await reportDesktopWindowOpenResult({
+              requestId: options.requestId,
+              success: false,
+              message,
+            });
+          }
+        }
+      })();
+
+      activeRequestRef.current = { key, promise };
+      try {
+        await promise;
+      } finally {
+        if (activeRequestRef.current?.promise === promise) {
+          activeRequestRef.current = null;
+        }
+      }
+    },
+    [syncWindowContext]
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    let bridgeCleanup: (() => void) | null = null;
+
+    void initializePlatform()
+      .then(async (platform) => {
+        if (cancelled) return;
+
+        if (shouldCaptureBootstrapEvents) {
+          captureAppOpened(posthog, {
+            analyticsEnabled,
+            capabilities: platform.capabilities,
+          });
+        }
+
+        setPlatformReady(true);
+        void initFormatter().catch((error) => {
+          captureSentryException(error, { tags: { phase: 'formatter-init' } });
+          console.warn('[main] Formatter warmup failed:', error);
+        });
+
+        if (platform.capabilities.hasFileSystem) {
+          bridgeCleanup = await initializeDesktopMcpBridge({
+            onOpenRequest: async (payload) => {
+              await runOpenRequest(payload.request, {
+                requestId: payload.requestId,
+                reportResult: true,
+              });
+            },
+          });
+          if (cancelled) {
+            bridgeCleanup?.();
+            return;
+          }
+          setBridgeReady(true);
+        }
+
+        const launchIntent = consumeDesktopBootstrapLaunchIntent();
+        if (launchIntent) {
+          const request = intentToRequest(launchIntent);
+          if (request) {
+            await runOpenRequest(request, {
+              requestId: launchIntent.kind === 'welcome' ? undefined : launchIntent.request_id,
+              reportResult: launchIntent.kind !== 'welcome',
+            });
+            return;
+          }
+        }
+
+        const welcomeState: BootstrapWindowState = {
+          mode: 'welcome',
+          targetPath: null,
+          errorMessage: null,
+          failedRequest: null,
+        };
+        setWindowState(welcomeState);
+        if (platform.capabilities.hasFileSystem) {
+          await syncDesktopMcpWindowContext({
+            title: document.title || 'OpenSCAD Studio',
+            workspaceRoot: null,
+            renderTargetPath: null,
+            showWelcome: true,
+            mode: 'welcome',
+          });
+        }
+      })
+      .catch((error) => {
+        if (cancelled) return;
+
+        captureSentryException(error, { tags: { phase: 'startup' } });
+        if (shouldCaptureBootstrapEvents) {
+          captureBootstrapError(posthog, error, {
+            analyticsEnabled,
+            capabilities: undefined,
+            operation: 'startup',
+          });
+        }
+        console.error('[main] Failed to initialize application:', error);
+        setStartupError(error);
+      });
+
+    return () => {
+      cancelled = true;
+      bridgeCleanup?.();
+    };
+  }, [runOpenRequest]);
+
+  const handleRetry = useCallback(() => {
+    const failedRequest = windowState.failedRequest;
+    if (!failedRequest) {
+      return;
+    }
+    void runOpenRequest(failedRequest);
+  }, [runOpenRequest, windowState.failedRequest]);
+
+  const handleOpenFolder = useCallback(() => {
+    const platform = getPlatform();
+    void platform.pickDirectory().then((dirPath) => {
+      if (!dirPath) {
+        return;
+      }
+      void runOpenRequest({
+        kind: 'open_folder',
+        folder_path: dirPath,
+        create_if_empty: true,
+      });
+    });
+  }, [runOpenRequest]);
+
+  const handleOpenFile = useCallback(() => {
+    void getPlatform()
+      .fileOpen([{ name: 'OpenSCAD Files', extensions: ['scad'] }])
+      .then((result) => {
+        if (!result?.path) {
+          return;
+        }
+        void runOpenRequest({
+          kind: 'open_file',
+          file_path: result.path,
+        });
+      });
+  }, [runOpenRequest]);
+
+  const handleGoToWelcome = useCallback(() => {
+    workspaceStore.getState().resetWorkspace();
+    const welcomeState: BootstrapWindowState = {
+      mode: 'welcome',
+      targetPath: null,
+      errorMessage: null,
+      failedRequest: null,
+    };
+    setWindowState(welcomeState);
+    void syncWindowContext(welcomeState, {
+      workspaceRoot: null,
+      renderTargetPath: null,
+    });
+  }, [syncWindowContext]);
+
+  if (startupError) {
+    return renderBootstrapError(startupError);
+  }
+
+  if (!platformReady || windowState.mode === 'booting') {
+    return renderLoadingScreen();
+  }
+
+  if (windowState.mode === 'opening_folder') {
+    return renderLoadingScreen('Opening workspace...', windowState.targetPath ?? '');
+  }
+
+  if (windowState.mode === 'opening_file') {
+    return renderLoadingScreen('Opening file...', windowState.targetPath ?? '');
+  }
+
+  if (windowState.mode === 'open_failed') {
+    return renderOpenFailureScreen({
+      state: windowState,
+      onRetry: handleRetry,
+      onOpenFolder: handleOpenFolder,
+      onOpenFile: handleOpenFile,
+      onGoToWelcome: handleGoToWelcome,
+    });
+  }
+
+  return (
+    <PostHogProvider client={posthog}>
+      <ThemeProvider>
+        <AnalyticsRuntimeProvider>
+          <ErrorBoundary>
+            <App />
+          </ErrorBoundary>
+        </AnalyticsRuntimeProvider>
+      </ThemeProvider>
+    </PostHogProvider>
   );
 }
 
@@ -106,26 +658,4 @@ const shouldCaptureBootstrapEvents = shouldCaptureBootstrapAnalytics(
   analyticsEnabled
 );
 
-Promise.all([initFormatter(), initializePlatform()])
-  .then(([, platform]) => {
-    if (shouldCaptureBootstrapEvents) {
-      captureAppOpened(posthog, {
-        analyticsEnabled,
-        capabilities: platform.capabilities,
-      });
-    }
-    renderApp();
-  })
-  .catch((error) => {
-    captureSentryException(error, { tags: { phase: 'startup' } });
-
-    if (shouldCaptureBootstrapEvents) {
-      captureBootstrapError(posthog, error, {
-        analyticsEnabled,
-        capabilities: undefined,
-        operation: 'startup',
-      });
-    }
-    console.error('[main] Failed to initialize application:', error);
-    renderBootstrapError(error);
-  });
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(<BootstrapApp />);

--- a/apps/ui/src/main.tsx
+++ b/apps/ui/src/main.tsx
@@ -361,7 +361,6 @@ function BootstrapApp() {
       options: {
         requestId?: string;
         reportResult?: boolean;
-        preReadFiles?: Record<string, string>;
       } = {}
     ) => {
       const key =
@@ -404,7 +403,7 @@ function BootstrapApp() {
         'open_request_started',
         request.kind === 'open_folder' ? request.folder_path : request.file_path
       );
-      void syncWindowContext(nextWindowState, {
+      await syncWindowContext(nextWindowState, {
         requestId: options.requestId ?? null,
         workspaceRoot: null,
         renderTargetPath: null,
@@ -415,7 +414,6 @@ function BootstrapApp() {
           if (request.kind === 'open_folder') {
             const result = await openWorkspaceFolderInWindow(request.folder_path, {
               createIfEmpty: request.create_if_empty,
-              preReadFiles: options.preReadFiles,
             });
             const readyState: BootstrapWindowState = {
               mode: 'ready',
@@ -431,7 +429,7 @@ function BootstrapApp() {
             });
             if (options.reportResult && options.requestId) {
               const action = result.createdDefaultFile ? 'Created' : 'Opened';
-              void reportDesktopWindowOpenResult({
+              await reportDesktopWindowOpenResult({
                 requestId: options.requestId,
                 success: true,
                 message: `✅ ${action} workspace at ${request.folder_path}.\n\nRender target: ${result.renderTargetPath}`,
@@ -589,10 +587,6 @@ function BootstrapApp() {
             await runOpenRequest(request, {
               requestId: launchIntent.kind === 'welcome' ? undefined : launchIntent.request_id,
               reportResult: launchIntent.kind !== 'welcome',
-              preReadFiles:
-                launchIntent.kind === 'open_folder' && launchIntent.files
-                  ? launchIntent.files
-                  : undefined,
             });
             return;
           }

--- a/apps/ui/src/main.tsx
+++ b/apps/ui/src/main.tsx
@@ -301,7 +301,9 @@ function BootstrapApp() {
   const [startupError, setStartupError] = useState<unknown>(null);
   const [platformReady, setPlatformReady] = useState(false);
   const [windowState, setWindowState] = useState<BootstrapWindowState>(INITIAL_WINDOW_STATE);
-  const [bootDetail, setBootDetail] = useState('Loading the editor and desktop services for this window.');
+  const [bootDetail, setBootDetail] = useState(
+    'Loading the editor and desktop services for this window.'
+  );
   const bridgeReadyRef = useRef(false);
   const bootstrapStartedRef = useRef(false);
   const activeRequestRef = useRef<{
@@ -758,7 +760,9 @@ window.addEventListener('error', (event) => {
 
 window.addEventListener('unhandledrejection', (event) => {
   const reason =
-    event.reason instanceof Error ? event.reason.stack || event.reason.message : String(event.reason);
+    event.reason instanceof Error
+      ? event.reason.stack || event.reason.message
+      : String(event.reason);
   reportEarlyStartupPhase('unhandled_rejection', reason);
 });
 

--- a/apps/ui/src/main.tsx
+++ b/apps/ui/src/main.tsx
@@ -423,7 +423,9 @@ function BootstrapApp() {
             };
             setWindowState(readyState);
             reportStartupPhase('open_request_succeeded', result.workspaceRoot);
-            void syncWindowContext(readyState, {
+            // Sync context before reporting open result so context_ready is set
+            // in Rust before the MCP server unblocks get_or_create_workspace.
+            await syncWindowContext(readyState, {
               workspaceRoot: result.workspaceRoot,
               renderTargetPath: result.renderTargetPath,
             });
@@ -452,7 +454,7 @@ function BootstrapApp() {
           };
           setWindowState(readyState);
           reportStartupPhase('open_request_succeeded', request.file_path);
-          void syncWindowContext(readyState, {
+          await syncWindowContext(readyState, {
             workspaceRoot: result.projectRoot,
             renderTargetPath: result.projectPath,
           });

--- a/apps/ui/src/main.tsx
+++ b/apps/ui/src/main.tsx
@@ -16,14 +16,16 @@ import { getPlatform, initializePlatform } from './platform';
 import {
   consumeDesktopBootstrapLaunchIntent,
   initializeDesktopMcpBridge,
+  reportDesktopWindowStartupPhase,
   reportDesktopWindowOpenResult,
   syncDesktopMcpWindowContext,
+  type DesktopWindowStartupPhase,
   type DesktopWindowLaunchIntent,
   type DesktopWindowOpenRequest,
 } from './services/desktopMcp';
 import { openFileInWindow, openWorkspaceFolderInWindow } from './services/windowOpenService';
 import { captureSentryException } from './sentry';
-import { getProjectState } from './stores/projectStore';
+import { getProjectState, getProjectStore } from './stores/projectStore';
 import { loadSettings } from './stores/settingsStore';
 import { workspaceStore } from './stores/workspaceStore';
 import { initFormatter } from './utils/formatter';
@@ -290,15 +292,35 @@ function normalizeErrorMessage(error: unknown, fallback: string): string {
   return error instanceof Error ? error.message : fallback;
 }
 
+function resetWindowToWelcomeState() {
+  getProjectStore().getState().resetToUntitledProject();
+  workspaceStore.getState().resetWorkspace();
+}
+
 function BootstrapApp() {
   const [startupError, setStartupError] = useState<unknown>(null);
   const [platformReady, setPlatformReady] = useState(false);
   const [windowState, setWindowState] = useState<BootstrapWindowState>(INITIAL_WINDOW_STATE);
-  const [bridgeReady, setBridgeReady] = useState(false);
+  const [bootDetail, setBootDetail] = useState('Loading the editor and desktop services for this window.');
+  const bridgeReadyRef = useRef(false);
+  const bootstrapStartedRef = useRef(false);
   const activeRequestRef = useRef<{
     key: string;
     promise: Promise<void>;
   } | null>(null);
+
+  const reportStartupPhase = useCallback(
+    (phase: DesktopWindowStartupPhase, detail?: string | null) => {
+      if (!getPlatform().capabilities.hasFileSystem) {
+        return;
+      }
+
+      void reportDesktopWindowStartupPhase({ phase, detail }).catch((error) => {
+        console.error('[main] Failed to report startup phase:', phase, error);
+      });
+    },
+    []
+  );
 
   const syncWindowContext = useCallback(
     async (
@@ -309,7 +331,7 @@ function BootstrapApp() {
         renderTargetPath?: string | null;
       }
     ) => {
-      if (!bridgeReady || !getPlatform().capabilities.hasFileSystem) {
+      if (!bridgeReadyRef.current || !getPlatform().capabilities.hasFileSystem) {
         return;
       }
 
@@ -330,7 +352,7 @@ function BootstrapApp() {
         pendingRequestId: args?.requestId ?? null,
       });
     },
-    [bridgeReady]
+    []
   );
 
   const runOpenRequest = useCallback(
@@ -339,6 +361,7 @@ function BootstrapApp() {
       options: {
         requestId?: string;
         reportResult?: boolean;
+        preReadFiles?: Record<string, string>;
       } = {}
     ) => {
       const key =
@@ -377,7 +400,11 @@ function BootstrapApp() {
         failedRequest: null,
       };
       setWindowState(nextWindowState);
-      await syncWindowContext(nextWindowState, {
+      reportStartupPhase(
+        'open_request_started',
+        request.kind === 'open_folder' ? request.folder_path : request.file_path
+      );
+      void syncWindowContext(nextWindowState, {
         requestId: options.requestId ?? null,
         workspaceRoot: null,
         renderTargetPath: null,
@@ -388,6 +415,7 @@ function BootstrapApp() {
           if (request.kind === 'open_folder') {
             const result = await openWorkspaceFolderInWindow(request.folder_path, {
               createIfEmpty: request.create_if_empty,
+              preReadFiles: options.preReadFiles,
             });
             const readyState: BootstrapWindowState = {
               mode: 'ready',
@@ -396,13 +424,14 @@ function BootstrapApp() {
               failedRequest: null,
             };
             setWindowState(readyState);
-            await syncWindowContext(readyState, {
+            reportStartupPhase('open_request_succeeded', result.workspaceRoot);
+            void syncWindowContext(readyState, {
               workspaceRoot: result.workspaceRoot,
               renderTargetPath: result.renderTargetPath,
             });
             if (options.reportResult && options.requestId) {
               const action = result.createdDefaultFile ? 'Created' : 'Opened';
-              await reportDesktopWindowOpenResult({
+              void reportDesktopWindowOpenResult({
                 requestId: options.requestId,
                 success: true,
                 message: `✅ ${action} workspace at ${request.folder_path}.\n\nRender target: ${result.renderTargetPath}`,
@@ -424,12 +453,13 @@ function BootstrapApp() {
             failedRequest: null,
           };
           setWindowState(readyState);
-          await syncWindowContext(readyState, {
+          reportStartupPhase('open_request_succeeded', request.file_path);
+          void syncWindowContext(readyState, {
             workspaceRoot: result.projectRoot,
             renderTargetPath: result.projectPath,
           });
           if (options.reportResult && options.requestId) {
-            await reportDesktopWindowOpenResult({
+            void reportDesktopWindowOpenResult({
               requestId: options.requestId,
               success: true,
               message: `✅ Opened file at ${request.file_path}.`,
@@ -445,12 +475,13 @@ function BootstrapApp() {
             failedRequest: request,
           };
           setWindowState(failedState);
-          await syncWindowContext(failedState, {
+          reportStartupPhase('open_request_failed', message);
+          void syncWindowContext(failedState, {
             workspaceRoot: null,
             renderTargetPath: null,
           });
           if (options.reportResult && options.requestId) {
-            await reportDesktopWindowOpenResult({
+            void reportDesktopWindowOpenResult({
               requestId: options.requestId,
               success: false,
               message,
@@ -468,13 +499,37 @@ function BootstrapApp() {
         }
       }
     },
-    [syncWindowContext]
+    [reportStartupPhase, syncWindowContext]
   );
 
   useEffect(() => {
+    const handleStartupPhase = (event: Event) => {
+      const detail = (event as CustomEvent<{ phase?: string; detail?: string | null }>).detail;
+      if (!detail?.phase) {
+        return;
+      }
+
+      setBootDetail(detail.detail ? `${detail.phase}: ${detail.detail}` : detail.phase);
+    };
+
+    window.addEventListener('openscad:startup-phase', handleStartupPhase as EventListener);
+    return () => {
+      window.removeEventListener('openscad:startup-phase', handleStartupPhase as EventListener);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (bootstrapStartedRef.current) {
+      return;
+    }
+    bootstrapStartedRef.current = true;
+
     let cancelled = false;
     let bridgeCleanup: (() => void) | null = null;
 
+    void reportStartupPhase('bootstrap_started');
+    void reportStartupPhase('platform_initializing');
+    setBootDetail('initializePlatform');
     void initializePlatform()
       .then(async (platform) => {
         if (cancelled) return;
@@ -486,6 +541,8 @@ function BootstrapApp() {
           });
         }
 
+        reportStartupPhase('platform_ready');
+        setBootDetail('platform_ready');
         setPlatformReady(true);
         void initFormatter().catch((error) => {
           captureSentryException(error, { tags: { phase: 'formatter-init' } });
@@ -493,6 +550,8 @@ function BootstrapApp() {
         });
 
         if (platform.capabilities.hasFileSystem) {
+          reportStartupPhase('bridge_initializing');
+          setBootDetail('initializeDesktopMcpBridge');
           bridgeCleanup = await initializeDesktopMcpBridge({
             onOpenRequest: async (payload) => {
               await runOpenRequest(payload.request, {
@@ -505,21 +564,43 @@ function BootstrapApp() {
             bridgeCleanup?.();
             return;
           }
-          setBridgeReady(true);
+          bridgeReadyRef.current = true;
+          reportStartupPhase('bridge_ready');
+          setBootDetail('bridge_ready');
         }
 
         const launchIntent = consumeDesktopBootstrapLaunchIntent();
         if (launchIntent) {
+          reportStartupPhase(
+            'launch_intent_consumed',
+            launchIntent.kind === 'welcome'
+              ? 'welcome'
+              : launchIntent.kind === 'open_folder'
+                ? launchIntent.folder_path
+                : launchIntent.file_path
+          );
           const request = intentToRequest(launchIntent);
           if (request) {
+            setBootDetail(
+              request.kind === 'open_folder'
+                ? `startup open folder: ${request.folder_path}`
+                : `startup open file: ${request.file_path}`
+            );
             await runOpenRequest(request, {
               requestId: launchIntent.kind === 'welcome' ? undefined : launchIntent.request_id,
               reportResult: launchIntent.kind !== 'welcome',
+              preReadFiles:
+                launchIntent.kind === 'open_folder' && launchIntent.files
+                  ? launchIntent.files
+                  : undefined,
             });
             return;
           }
         }
 
+        reportStartupPhase('launch_intent_none');
+        setBootDetail('welcome_ready');
+        resetWindowToWelcomeState();
         const welcomeState: BootstrapWindowState = {
           mode: 'welcome',
           targetPath: null,
@@ -527,6 +608,7 @@ function BootstrapApp() {
           failedRequest: null,
         };
         setWindowState(welcomeState);
+        reportStartupPhase('welcome_ready');
         if (platform.capabilities.hasFileSystem) {
           await syncDesktopMcpWindowContext({
             title: document.title || 'OpenSCAD Studio',
@@ -541,6 +623,11 @@ function BootstrapApp() {
         if (cancelled) return;
 
         captureSentryException(error, { tags: { phase: 'startup' } });
+        void reportStartupPhase(
+          'startup_error',
+          error instanceof Error ? error.message : String(error)
+        );
+        setBootDetail(error instanceof Error ? error.message : String(error));
         if (shouldCaptureBootstrapEvents) {
           captureBootstrapError(posthog, error, {
             analyticsEnabled,
@@ -556,7 +643,7 @@ function BootstrapApp() {
       cancelled = true;
       bridgeCleanup?.();
     };
-  }, [runOpenRequest]);
+  }, [reportStartupPhase, runOpenRequest]);
 
   const handleRetry = useCallback(() => {
     const failedRequest = windowState.failedRequest;
@@ -595,7 +682,7 @@ function BootstrapApp() {
   }, [runOpenRequest]);
 
   const handleGoToWelcome = useCallback(() => {
-    workspaceStore.getState().resetWorkspace();
+    resetWindowToWelcomeState();
     const welcomeState: BootstrapWindowState = {
       mode: 'welcome',
       targetPath: null,
@@ -614,15 +701,17 @@ function BootstrapApp() {
   }
 
   if (!platformReady || windowState.mode === 'booting') {
-    return renderLoadingScreen();
+    return renderLoadingScreen('Starting OpenSCAD Studio', bootDetail);
   }
 
   if (windowState.mode === 'opening_folder') {
-    return renderLoadingScreen('Opening workspace...', windowState.targetPath ?? '');
+    const detail = [windowState.targetPath, bootDetail].filter(Boolean).join('\n\n');
+    return renderLoadingScreen('Opening workspace...', detail);
   }
 
   if (windowState.mode === 'opening_file') {
-    return renderLoadingScreen('Opening file...', windowState.targetPath ?? '');
+    const detail = [windowState.targetPath, bootDetail].filter(Boolean).join('\n\n');
+    return renderLoadingScreen('Opening file...', detail);
   }
 
   if (windowState.mode === 'open_failed') {
@@ -657,5 +746,26 @@ const shouldCaptureBootstrapEvents = shouldCaptureBootstrapAnalytics(
   posthogReady,
   analyticsEnabled
 );
+
+function reportEarlyStartupPhase(phase: DesktopWindowStartupPhase, detail?: string | null) {
+  void reportDesktopWindowStartupPhase({ phase, detail }).catch((error) => {
+    console.error('[main] Failed to report early startup phase:', phase, error);
+  });
+}
+
+window.addEventListener('error', (event) => {
+  reportEarlyStartupPhase(
+    'window_error',
+    `${event.message} @ ${event.filename}:${event.lineno}:${event.colno}`
+  );
+});
+
+window.addEventListener('unhandledrejection', (event) => {
+  const reason =
+    event.reason instanceof Error ? event.reason.stack || event.reason.message : String(event.reason);
+  reportEarlyStartupPhase('unhandled_rejection', reason);
+});
+
+reportEarlyStartupPhase('module_loaded', document.readyState);
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(<BootstrapApp />);

--- a/apps/ui/src/platform/__tests__/index.test.tsx
+++ b/apps/ui/src/platform/__tests__/index.test.tsx
@@ -70,8 +70,10 @@ describe('platform bootstrap', () => {
   it('selects the tauri bridge when tauri internals are present', async () => {
     (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
     const listen = jest.fn(async () => jest.fn());
-    jest.unstable_mockModule('@tauri-apps/api/event', () => ({
-      listen,
+    jest.unstable_mockModule('@tauri-apps/api/window', () => ({
+      getCurrentWindow: () => ({
+        listen,
+      }),
     }));
 
     const platform = await import('../index');

--- a/apps/ui/src/platform/__tests__/index.test.tsx
+++ b/apps/ui/src/platform/__tests__/index.test.tsx
@@ -70,10 +70,12 @@ describe('platform bootstrap', () => {
   it('selects the tauri bridge when tauri internals are present', async () => {
     (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
     const listen = jest.fn(async () => jest.fn());
+    jest.unstable_mockModule('@tauri-apps/api/event', () => ({
+      listen,
+    }));
     const onFocusChanged = jest.fn(async () => jest.fn());
     jest.unstable_mockModule('@tauri-apps/api/window', () => ({
       getCurrentWindow: () => ({
-        listen,
         onFocusChanged,
         setTitle: jest.fn(),
       }),

--- a/apps/ui/src/platform/__tests__/index.test.tsx
+++ b/apps/ui/src/platform/__tests__/index.test.tsx
@@ -70,10 +70,35 @@ describe('platform bootstrap', () => {
   it('selects the tauri bridge when tauri internals are present', async () => {
     (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
     const listen = jest.fn(async () => jest.fn());
+    const onFocusChanged = jest.fn(async () => jest.fn());
     jest.unstable_mockModule('@tauri-apps/api/window', () => ({
       getCurrentWindow: () => ({
         listen,
+        onFocusChanged,
+        setTitle: jest.fn(),
       }),
+    }));
+    jest.unstable_mockModule('@tauri-apps/api/path', () => ({
+      homeDir: jest.fn(),
+      join: jest.fn(),
+      documentDir: jest.fn(),
+    }));
+    jest.unstable_mockModule('@tauri-apps/plugin-dialog', () => ({
+      open: jest.fn(),
+      save: jest.fn(),
+      confirm: jest.fn(),
+      ask: jest.fn(),
+    }));
+    jest.unstable_mockModule('@tauri-apps/plugin-fs', () => ({
+      readTextFile: jest.fn(),
+      writeTextFile: jest.fn(),
+      writeFile: jest.fn(),
+      readDir: jest.fn(),
+      exists: jest.fn(),
+      mkdir: jest.fn(),
+      remove: jest.fn(),
+      rename: jest.fn(),
+      watch: jest.fn(),
     }));
 
     const platform = await import('../index');

--- a/apps/ui/src/platform/index.ts
+++ b/apps/ui/src/platform/index.ts
@@ -19,6 +19,15 @@ import type {
   PlatformCapabilities,
 } from './types';
 
+function emitStartupPhase(phase: string, detail?: string) {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(
+    new CustomEvent('openscad:startup-phase', {
+      detail: { phase, detail: detail ?? null },
+    })
+  );
+}
+
 let _bridge: PlatformBridge | null = null;
 
 function isTauri(): boolean {
@@ -172,15 +181,21 @@ export async function initializePlatform(): Promise<PlatformBridge> {
   }
 
   if (isTauri()) {
+    emitStartupPhase('platform_import_tauri_bridge_begin');
     const { TauriBridge } = await import('./tauriBridge');
+    emitStartupPhase('platform_import_tauri_bridge_done');
     _bridge = new TauriBridge();
   } else {
+    emitStartupPhase('platform_import_web_bridge_begin');
     const { WebBridge } = await import('./webBridge');
+    emitStartupPhase('platform_import_web_bridge_done');
     _bridge = new WebBridge();
   }
 
   if (_bridge.initialize) {
+    emitStartupPhase('platform_bridge_initialize_begin');
     await _bridge.initialize();
+    emitStartupPhase('platform_bridge_initialize_done');
   }
 
   return _bridge;

--- a/apps/ui/src/platform/index.ts
+++ b/apps/ui/src/platform/index.ts
@@ -167,7 +167,9 @@ class BootstrapBridge implements PlatformBridge {
 const bootstrapBridge = new BootstrapBridge();
 
 export async function initializePlatform(): Promise<PlatformBridge> {
-  if (_bridge) return _bridge;
+  if (_bridge) {
+    return _bridge;
+  }
 
   if (isTauri()) {
     const { TauriBridge } = await import('./tauriBridge');

--- a/apps/ui/src/platform/index.ts
+++ b/apps/ui/src/platform/index.ts
@@ -19,15 +19,6 @@ import type {
   PlatformCapabilities,
 } from './types';
 
-function emitStartupPhase(phase: string, detail?: string) {
-  if (typeof window === 'undefined') return;
-  window.dispatchEvent(
-    new CustomEvent('openscad:startup-phase', {
-      detail: { phase, detail: detail ?? null },
-    })
-  );
-}
-
 let _bridge: PlatformBridge | null = null;
 
 function isTauri(): boolean {
@@ -181,21 +172,15 @@ export async function initializePlatform(): Promise<PlatformBridge> {
   }
 
   if (isTauri()) {
-    emitStartupPhase('platform_import_tauri_bridge_begin');
     const { TauriBridge } = await import('./tauriBridge');
-    emitStartupPhase('platform_import_tauri_bridge_done');
     _bridge = new TauriBridge();
   } else {
-    emitStartupPhase('platform_import_web_bridge_begin');
     const { WebBridge } = await import('./webBridge');
-    emitStartupPhase('platform_import_web_bridge_done');
     _bridge = new WebBridge();
   }
 
   if (_bridge.initialize) {
-    emitStartupPhase('platform_bridge_initialize_begin');
     await _bridge.initialize();
-    emitStartupPhase('platform_bridge_initialize_done');
   }
 
   return _bridge;

--- a/apps/ui/src/platform/tauriBridge.ts
+++ b/apps/ui/src/platform/tauriBridge.ts
@@ -412,27 +412,16 @@ export class TauriBridge implements PlatformBridge {
   }
 
   async initialize(): Promise<void> {
-    const { getCurrentWindow } = await import('@tauri-apps/api/window');
-    const currentWindow = getCurrentWindow();
+    const { listen } = await import('@tauri-apps/api/event');
 
-    void Promise.allSettled([
-      currentWindow.listen('menu:file:new', () => eventBus.emit('menu:file:new')),
-      currentWindow.listen('menu:file:open', () => eventBus.emit('menu:file:open')),
-      currentWindow.listen('menu:file:open_folder', () => eventBus.emit('menu:file:open_folder')),
-      currentWindow.listen('menu:file:save', () => eventBus.emit('menu:file:save')),
-      currentWindow.listen('menu:file:save_as', () => eventBus.emit('menu:file:save_as')),
-      currentWindow.listen('menu:file:save_all', () => eventBus.emit('menu:file:save_all')),
-      currentWindow.listen<string>('menu:file:export', (event) => {
-        eventBus.emit('menu:file:export', event.payload as import('./types').ExportFormat);
-      }),
-    ]).then((results) => {
-      const failed = results.filter((result) => result.status === 'rejected');
-      if (failed.length > 0) {
-        console.error(
-          '[TauriBridge] Failed to register one or more window menu listeners.',
-          failed
-        );
-      }
+    await listen('menu:file:new', () => eventBus.emit('menu:file:new'));
+    await listen('menu:file:open', () => eventBus.emit('menu:file:open'));
+    await listen('menu:file:open_folder', () => eventBus.emit('menu:file:open_folder'));
+    await listen('menu:file:save', () => eventBus.emit('menu:file:save'));
+    await listen('menu:file:save_as', () => eventBus.emit('menu:file:save_as'));
+    await listen('menu:file:save_all', () => eventBus.emit('menu:file:save_all'));
+    await listen<string>('menu:file:export', (event) => {
+      eventBus.emit('menu:file:export', event.payload as import('./types').ExportFormat);
     });
   }
 }

--- a/apps/ui/src/platform/tauriBridge.ts
+++ b/apps/ui/src/platform/tauriBridge.ts
@@ -412,15 +412,18 @@ export class TauriBridge implements PlatformBridge {
   }
 
   async initialize(): Promise<void> {
-    const { listen } = await import('@tauri-apps/api/event');
+    const { getCurrentWindow } = await import('@tauri-apps/api/window');
+    const currentWindow = getCurrentWindow();
 
-    await listen('menu:file:new', () => eventBus.emit('menu:file:new'));
-    await listen('menu:file:open', () => eventBus.emit('menu:file:open'));
-    await listen('menu:file:open_folder', () => eventBus.emit('menu:file:open_folder'));
-    await listen('menu:file:save', () => eventBus.emit('menu:file:save'));
-    await listen('menu:file:save_as', () => eventBus.emit('menu:file:save_as'));
-    await listen('menu:file:save_all', () => eventBus.emit('menu:file:save_all'));
-    await listen<string>('menu:file:export', (event) => {
+    await currentWindow.listen('menu:file:new', () => eventBus.emit('menu:file:new'));
+    await currentWindow.listen('menu:file:open', () => eventBus.emit('menu:file:open'));
+    await currentWindow.listen('menu:file:open_folder', () =>
+      eventBus.emit('menu:file:open_folder')
+    );
+    await currentWindow.listen('menu:file:save', () => eventBus.emit('menu:file:save'));
+    await currentWindow.listen('menu:file:save_as', () => eventBus.emit('menu:file:save_as'));
+    await currentWindow.listen('menu:file:save_all', () => eventBus.emit('menu:file:save_all'));
+    await currentWindow.listen<string>('menu:file:export', (event) => {
       eventBus.emit('menu:file:export', event.payload as import('./types').ExportFormat);
     });
   }

--- a/apps/ui/src/platform/tauriBridge.ts
+++ b/apps/ui/src/platform/tauriBridge.ts
@@ -415,16 +415,24 @@ export class TauriBridge implements PlatformBridge {
     const { getCurrentWindow } = await import('@tauri-apps/api/window');
     const currentWindow = getCurrentWindow();
 
-    await currentWindow.listen('menu:file:new', () => eventBus.emit('menu:file:new'));
-    await currentWindow.listen('menu:file:open', () => eventBus.emit('menu:file:open'));
-    await currentWindow.listen('menu:file:open_folder', () =>
-      eventBus.emit('menu:file:open_folder')
-    );
-    await currentWindow.listen('menu:file:save', () => eventBus.emit('menu:file:save'));
-    await currentWindow.listen('menu:file:save_as', () => eventBus.emit('menu:file:save_as'));
-    await currentWindow.listen('menu:file:save_all', () => eventBus.emit('menu:file:save_all'));
-    await currentWindow.listen<string>('menu:file:export', (event) => {
-      eventBus.emit('menu:file:export', event.payload as import('./types').ExportFormat);
+    void Promise.allSettled([
+      currentWindow.listen('menu:file:new', () => eventBus.emit('menu:file:new')),
+      currentWindow.listen('menu:file:open', () => eventBus.emit('menu:file:open')),
+      currentWindow.listen('menu:file:open_folder', () => eventBus.emit('menu:file:open_folder')),
+      currentWindow.listen('menu:file:save', () => eventBus.emit('menu:file:save')),
+      currentWindow.listen('menu:file:save_as', () => eventBus.emit('menu:file:save_as')),
+      currentWindow.listen('menu:file:save_all', () => eventBus.emit('menu:file:save_all')),
+      currentWindow.listen<string>('menu:file:export', (event) => {
+        eventBus.emit('menu:file:export', event.payload as import('./types').ExportFormat);
+      }),
+    ]).then((results) => {
+      const failed = results.filter((result) => result.status === 'rejected');
+      if (failed.length > 0) {
+        console.error(
+          '[TauriBridge] Failed to register one or more window menu listeners.',
+          failed
+        );
+      }
     });
   }
 }

--- a/apps/ui/src/services/__tests__/aiService.test.ts
+++ b/apps/ui/src/services/__tests__/aiService.test.ts
@@ -1,14 +1,15 @@
 import { jest } from '@jest/globals';
 
 const mockCaptureOffscreen = jest.fn(async () => 'data:image/png;base64,AAA=');
+const mockCheckSyntax = jest.fn(async () => ({ diagnostics: [] }));
 
 jest.unstable_mockModule('@/services/renderService', () => ({
   getRenderService: () => ({
-    checkSyntax: async () => ({ diagnostics: [] }),
+    checkSyntax: (...args: unknown[]) => mockCheckSyntax(...args),
   }),
   RenderService: {
     getInstance: () => ({
-      checkSyntax: async () => ({ diagnostics: [] }),
+      checkSyntax: (...args: unknown[]) => mockCheckSyntax(...args),
     }),
   },
 }));
@@ -50,6 +51,16 @@ function createCallbacks(overrides: Partial<AiToolCallbacks> = {}): AiToolCallba
       return files[path] ?? null;
     },
     getRenderTargetPath: () => 'main.scad',
+    getRenderValidationInputs: async () => ({
+      code: 'use <lib/utils.scad>\ncube(10);',
+      renderTargetPath: 'main.scad',
+      renderOptions: {
+        auxiliaryFiles: {
+          'lib/utils.scad': 'module helper() { cube(5); }',
+        },
+        inputPath: 'main.scad',
+      },
+    }),
     createProjectFile: () => true,
     editProjectFile: () => null,
     requestRender: () => {},
@@ -63,6 +74,11 @@ function createCallbacks(overrides: Partial<AiToolCallbacks> = {}): AiToolCallba
 describe('buildTools', () => {
   beforeAll(async () => {
     ({ buildTools } = await import('../aiService'));
+  });
+
+  beforeEach(() => {
+    mockCheckSyntax.mockClear();
+    mockCheckSyntax.mockResolvedValue({ diagnostics: [] });
   });
 
   describe('get_project_context', () => {
@@ -272,6 +288,45 @@ describe('buildTools', () => {
       })) as string;
 
       expect(result).toContain('❌ Failed to apply edit');
+    });
+  });
+
+  describe('get_diagnostics', () => {
+    it('validates with the shared multi-file render inputs', async () => {
+      const tools = buildTools(createCallbacks()) as Record<string, ExecutableTool>;
+
+      await tools.get_diagnostics.execute({});
+
+      expect(mockCheckSyntax).toHaveBeenCalledWith(
+        'use <lib/utils.scad>\ncube(10);',
+        expect.objectContaining({
+          auxiliaryFiles: {
+            'lib/utils.scad': 'module helper() { cube(5); }',
+          },
+          inputPath: 'main.scad',
+        })
+      );
+    });
+
+    it('formats returned diagnostics', async () => {
+      mockCheckSyntax.mockResolvedValue({
+        diagnostics: [
+          {
+            severity: 'warning',
+            line: 13,
+            col: undefined,
+            message: "WARNING: Can't open include file 'lib/base.scad'.",
+          },
+        ],
+      });
+      const tools = buildTools(createCallbacks()) as Record<string, ExecutableTool>;
+
+      const result = (await tools.get_diagnostics.execute({})) as string;
+
+      expect(result).toContain('Current diagnostics:');
+      expect(result).toContain(
+        "[Warning] (line 13): WARNING: Can't open include file 'lib/base.scad'."
+      );
     });
   });
 

--- a/apps/ui/src/services/__tests__/desktopMcp.test.ts
+++ b/apps/ui/src/services/__tests__/desktopMcp.test.ts
@@ -49,18 +49,11 @@ const projectStoreModule = new URL('../../stores/projectStore.ts', import.meta.u
 const settingsStoreModule = new URL('../../stores/settingsStore.ts', import.meta.url).pathname;
 const workspaceStoreModule = new URL('../../stores/workspaceStore.ts', import.meta.url).pathname;
 const platformModule = new URL('../../platform/index.ts', import.meta.url).pathname;
-const renderRequestStoreModule = new URL(
-  '../../stores/renderRequestStore.ts',
-  import.meta.url
-).pathname;
-const projectFilePathsModule = new URL(
-  '../../utils/projectFilePaths.ts',
-  import.meta.url
-).pathname;
-const resolveWorkingDirDepsModule = new URL(
-  '../../utils/resolveWorkingDirDeps.ts',
-  import.meta.url
-).pathname;
+const renderRequestStoreModule = new URL('../../stores/renderRequestStore.ts', import.meta.url)
+  .pathname;
+const projectFilePathsModule = new URL('../../utils/projectFilePaths.ts', import.meta.url).pathname;
+const resolveWorkingDirDepsModule = new URL('../../utils/resolveWorkingDirDeps.ts', import.meta.url)
+  .pathname;
 const desktopMcpModule = new URL('../desktopMcp.ts', import.meta.url).pathname;
 
 jest.unstable_mockModule('@tauri-apps/api/core', () => ({
@@ -172,13 +165,18 @@ let getRenderArtifactState: typeof import('../../stores/renderArtifactStore').ge
 let resetRenderArtifactStoreForTests: typeof import('../../stores/renderArtifactStore').__resetRenderArtifactStoreForTests;
 
 type ToolResponse = {
-  content: Array<{ type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }>;
+  content: Array<
+    { type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }
+  >;
   isError?: boolean;
 };
 
 function getText(response: ToolResponse): string {
   return response.content
-    .filter((entry): entry is Extract<ToolResponse['content'][number], { type: 'text' }> => entry.type === 'text')
+    .filter(
+      (entry): entry is Extract<ToolResponse['content'][number], { type: 'text' }> =>
+        entry.type === 'text'
+    )
     .map((entry) => entry.text)
     .join('\n');
 }
@@ -200,7 +198,10 @@ function setProjectState(
   };
 }
 
-function createMockProjectFile(content: string, overrides: Partial<MockProjectFile> = {}): MockProjectFile {
+function createMockProjectFile(
+  content: string,
+  overrides: Partial<MockProjectFile> = {}
+): MockProjectFile {
   return {
     content,
     savedContent: content,
@@ -275,7 +276,7 @@ describe('desktopMcp', () => {
     });
     mockGetRenderTargetContent.mockImplementation((state: typeof mockProjectState) => {
       const renderTargetPath = state.renderTargetPath;
-      return renderTargetPath ? state.files[renderTargetPath]?.content ?? null : null;
+      return renderTargetPath ? (state.files[renderTargetPath]?.content ?? null) : null;
     });
     mockCaptureOffscreen.mockReset();
     mockCaptureOffscreen.mockResolvedValue('data:image/png;base64,ZmFrZS1wbmc=');
@@ -396,8 +397,8 @@ describe('desktopMcp', () => {
       });
       notifyDesktopMcpRenderSettled(requestId);
     });
-    mockCaptureOffscreen.mockImplementation(async (previewUrl: string) =>
-      `data:image/png;base64,${previewUrl}`
+    mockCaptureOffscreen.mockImplementation(
+      async (previewUrl: string) => `data:image/png;base64,${previewUrl}`
     );
 
     const renderResponse = (await executeToolRequestForTests({

--- a/apps/ui/src/services/__tests__/desktopMcp.test.ts
+++ b/apps/ui/src/services/__tests__/desktopMcp.test.ts
@@ -1,0 +1,660 @@
+/** @jest-environment jsdom */
+
+import { jest } from '@jest/globals';
+
+const mockInvoke = jest.fn();
+const mockRequestRender = jest.fn();
+const mockCaptureOffscreen = jest.fn();
+const mockFileRead = jest.fn(async () => ({ content: 'cube(10);' }));
+const mockReadTextFile = jest.fn(async (absolutePath: string) => {
+  const projectRoot = mockProjectState.projectRoot;
+  if (!projectRoot) return null;
+  const prefix = `${projectRoot}/`;
+  const relativePath = absolutePath.startsWith(prefix) ? absolutePath.slice(prefix.length) : null;
+  if (!relativePath) return null;
+  const file = mockProjectState.files[relativePath];
+  return file ? file.content : null;
+});
+const mockGetRenderTargetContent = jest.fn();
+const mockListProjectFiles = jest.fn(() => ['main.scad']);
+const mockExportModel = jest.fn();
+const mockResolveWorkingDirDepsDetailed = jest.fn(async () => ({
+  files: {},
+  missingPaths: [],
+  stats: {
+    diskReads: 0,
+    dirtyProjectFileHits: 0,
+    projectFileFallbackHits: 0,
+  },
+}));
+
+type MockProjectFile = {
+  content: string;
+  savedContent: string;
+  isDirty: boolean;
+  isVirtual: boolean;
+  customizerBaseContent: string;
+};
+
+let mockProjectState: {
+  projectRoot: string | null;
+  renderTargetPath: string | null;
+  files: Record<string, MockProjectFile>;
+};
+
+const renderServiceModule = new URL('../renderService.ts', import.meta.url).pathname;
+const offscreenRendererModule = new URL('../offscreenRenderer.ts', import.meta.url).pathname;
+const studioToolingModule = new URL('../studioTooling.ts', import.meta.url).pathname;
+const projectStoreModule = new URL('../../stores/projectStore.ts', import.meta.url).pathname;
+const settingsStoreModule = new URL('../../stores/settingsStore.ts', import.meta.url).pathname;
+const workspaceStoreModule = new URL('../../stores/workspaceStore.ts', import.meta.url).pathname;
+const platformModule = new URL('../../platform/index.ts', import.meta.url).pathname;
+const renderRequestStoreModule = new URL(
+  '../../stores/renderRequestStore.ts',
+  import.meta.url
+).pathname;
+const projectFilePathsModule = new URL(
+  '../../utils/projectFilePaths.ts',
+  import.meta.url
+).pathname;
+const resolveWorkingDirDepsModule = new URL(
+  '../../utils/resolveWorkingDirDeps.ts',
+  import.meta.url
+).pathname;
+const desktopMcpModule = new URL('../desktopMcp.ts', import.meta.url).pathname;
+
+jest.unstable_mockModule('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+jest.unstable_mockModule('@tauri-apps/api/path', () => ({
+  join: async (...parts: string[]) => parts.join('/'),
+}));
+
+jest.unstable_mockModule(renderServiceModule, () => ({
+  getRenderService: () => ({
+    exportModel: (...args: unknown[]) => mockExportModel(...args),
+  }),
+}));
+
+jest.unstable_mockModule(offscreenRendererModule, () => ({
+  captureOffscreen: (...args: unknown[]) => mockCaptureOffscreen(...args),
+}));
+
+jest.unstable_mockModule(studioToolingModule, () => ({
+  buildProjectContextSummary: jest.fn(() => 'project summary'),
+}));
+
+jest.unstable_mockModule(projectStoreModule, () => ({
+  getAuxiliaryFilesForRender: jest.fn(() => ({})),
+  getProjectState: () => mockProjectState,
+  getProjectWorkingDirectory: jest.fn(() => mockProjectState.projectRoot),
+  getProjectStore: () => ({
+    getState: () => ({
+      addFile: jest.fn((relativePath: string, content: string) => {
+        mockProjectState.files[relativePath] = createMockProjectFile(content);
+      }),
+      markFileSaved: jest.fn((relativePath: string, savedContent?: string) => {
+        const file = mockProjectState.files[relativePath];
+        if (!file) return;
+        const nextContent = savedContent ?? file.content;
+        mockProjectState.files[relativePath] = {
+          ...file,
+          content: nextContent,
+          savedContent: nextContent,
+          customizerBaseContent: nextContent,
+          isDirty: false,
+        };
+      }),
+      setRenderTarget: jest.fn((relativePath: string) => {
+        mockProjectState.renderTargetPath = relativePath;
+      }),
+      updateFileContent: jest.fn((relativePath: string, content: string) => {
+        const file = mockProjectState.files[relativePath];
+        if (!file) return;
+        mockProjectState.files[relativePath] = {
+          ...file,
+          content,
+          isDirty: true,
+        };
+      }),
+    }),
+  }),
+  getRenderTargetContent: (...args: unknown[]) => mockGetRenderTargetContent(...args),
+  listProjectFiles: (...args: unknown[]) => mockListProjectFiles(...args),
+}));
+
+jest.unstable_mockModule(settingsStoreModule, () => ({
+  loadSettings: () => ({
+    library: {
+      autoDiscoverSystem: false,
+      customPaths: [],
+    },
+  }),
+}));
+
+jest.unstable_mockModule(workspaceStoreModule, () => ({
+  getWorkspaceState: () => ({
+    showWelcome: false,
+  }),
+}));
+
+jest.unstable_mockModule(platformModule, () => ({
+  getPlatform: () => ({
+    fileRead: (...args: unknown[]) => mockFileRead(...args),
+    getLibraryPaths: jest.fn(async () => []),
+    readDirectoryFiles: jest.fn(async () => ({})),
+    readTextFile: (...args: unknown[]) => mockReadTextFile(...args),
+    capabilities: {
+      hasFileSystem: true,
+    },
+  }),
+}));
+
+jest.unstable_mockModule(renderRequestStoreModule, () => ({
+  requestRender: (...args: unknown[]) => mockRequestRender(...args),
+}));
+
+jest.unstable_mockModule(projectFilePathsModule, () => ({
+  normalizeProjectRelativePath: (path: string) => path,
+}));
+
+jest.unstable_mockModule(resolveWorkingDirDepsModule, () => ({
+  resolveWorkingDirDeps: jest.fn(async () => ({})),
+  resolveWorkingDirDepsDetailed: (...args: unknown[]) => mockResolveWorkingDirDepsDetailed(...args),
+}));
+
+let executeToolRequestForTests: typeof import('../desktopMcp').__executeDesktopMcpToolRequestForTests;
+let notifyDesktopMcpRenderStarted: typeof import('../desktopMcp').notifyDesktopMcpRenderStarted;
+let notifyDesktopMcpRenderSettled: typeof import('../desktopMcp').notifyDesktopMcpRenderSettled;
+let resetDesktopMcpStateForTests: typeof import('../desktopMcp').__resetDesktopMcpStateForTests;
+let getRenderArtifactState: typeof import('../../stores/renderArtifactStore').getRenderArtifactState;
+let resetRenderArtifactStoreForTests: typeof import('../../stores/renderArtifactStore').__resetRenderArtifactStoreForTests;
+
+type ToolResponse = {
+  content: Array<{ type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }>;
+  isError?: boolean;
+};
+
+function getText(response: ToolResponse): string {
+  return response.content
+    .filter((entry): entry is Extract<ToolResponse['content'][number], { type: 'text' }> => entry.type === 'text')
+    .map((entry) => entry.text)
+    .join('\n');
+}
+
+function setProjectState(
+  overrides: Partial<{
+    projectRoot: string | null;
+    renderTargetPath: string | null;
+    files: Record<string, MockProjectFile>;
+  }> = {}
+) {
+  mockProjectState = {
+    projectRoot: '/workspace/poly555',
+    renderTargetPath: 'main.scad',
+    files: {
+      'main.scad': createMockProjectFile('cube(10);'),
+    },
+    ...overrides,
+  };
+}
+
+function createMockProjectFile(content: string, overrides: Partial<MockProjectFile> = {}): MockProjectFile {
+  return {
+    content,
+    savedContent: content,
+    isDirty: false,
+    isVirtual: false,
+    customizerBaseContent: content,
+    ...overrides,
+  };
+}
+
+const DEFAULT_SCENE_STYLE = {
+  background: 'system',
+  lighting: 'studio',
+  grid: true,
+} as const;
+
+let nextRequestId = 1;
+let lastStartedRequestId = 0;
+
+async function settleRender(snapshot: {
+  previewSrc: string;
+  previewKind: 'mesh' | 'svg';
+  diagnostics: Array<{ severity: 'error' | 'warning' | 'info'; line?: number; message: string }>;
+  error: string;
+}) {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  const renderTargetPath = mockProjectState.renderTargetPath ?? 'main.scad';
+  getRenderArtifactState().publishSettledArtifact({
+    requestId: lastStartedRequestId,
+    renderTargetPath,
+    workspaceRoot: mockProjectState.projectRoot,
+    sourceHash: 'test-hash',
+    previewKind: snapshot.previewKind,
+    previewSrc: snapshot.previewSrc,
+    diagnostics: snapshot.diagnostics,
+    error: snapshot.error,
+    dimensionMode: snapshot.previewKind === 'svg' ? '2d' : '3d',
+    sceneStyle: DEFAULT_SCENE_STYLE as never,
+    useModelColors: true,
+    createdAt: Date.now(),
+  });
+  notifyDesktopMcpRenderSettled(lastStartedRequestId);
+}
+
+describe('desktopMcp', () => {
+  beforeAll(async () => {
+    ({
+      __executeDesktopMcpToolRequestForTests: executeToolRequestForTests,
+      notifyDesktopMcpRenderStarted,
+      notifyDesktopMcpRenderSettled,
+      __resetDesktopMcpStateForTests: resetDesktopMcpStateForTests,
+    } = await import(desktopMcpModule));
+    ({
+      getRenderArtifactState,
+      __resetRenderArtifactStoreForTests: resetRenderArtifactStoreForTests,
+    } = await import('../../stores/renderArtifactStore'));
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setProjectState();
+    nextRequestId = 1;
+    lastStartedRequestId = 0;
+    mockRequestRender.mockReset();
+    mockRequestRender.mockImplementation(() => {
+      const requestId = nextRequestId++;
+      lastStartedRequestId = requestId;
+      notifyDesktopMcpRenderStarted({
+        renderTargetPath: mockProjectState.renderTargetPath ?? 'main.scad',
+        requestId,
+      });
+    });
+    mockGetRenderTargetContent.mockImplementation((state: typeof mockProjectState) => {
+      const renderTargetPath = state.renderTargetPath;
+      return renderTargetPath ? state.files[renderTargetPath]?.content ?? null : null;
+    });
+    mockCaptureOffscreen.mockReset();
+    mockCaptureOffscreen.mockResolvedValue('data:image/png;base64,ZmFrZS1wbmc=');
+    mockExportModel.mockReset();
+    mockReadTextFile.mockClear();
+    mockResolveWorkingDirDepsDetailed.mockClear();
+    mockResolveWorkingDirDepsDetailed.mockResolvedValue({
+      files: {},
+      missingPaths: [],
+      stats: {
+        diskReads: 0,
+        dirtyProjectFileHits: 0,
+        projectFileFallbackHits: 0,
+      },
+    });
+    resetDesktopMcpStateForTests();
+    resetRenderArtifactStoreForTests();
+    getRenderArtifactState().setActiveRenderTarget('main.scad', mockProjectState.projectRoot);
+    getRenderArtifactState().publishSettledArtifact({
+      requestId: 0,
+      renderTargetPath: 'main.scad',
+      workspaceRoot: mockProjectState.projectRoot,
+      sourceHash: 'initial-hash',
+      previewKind: 'mesh',
+      previewSrc: 'blob:preview',
+      diagnostics: [],
+      error: '',
+      dimensionMode: '3d',
+      sceneStyle: DEFAULT_SCENE_STYLE as never,
+      useModelColors: true,
+      createdAt: Date.now(),
+    });
+  });
+
+  it('returns success for a clean trigger_render', async () => {
+    const pending = executeToolRequestForTests({
+      requestId: 'req-1',
+      toolName: 'trigger_render',
+    });
+
+    await settleRender({
+      previewSrc: 'blob:preview',
+      previewKind: 'mesh',
+      diagnostics: [],
+      error: '',
+    });
+
+    const response = (await pending) as ToolResponse;
+
+    expect(mockRequestRender).toHaveBeenCalledWith('manual', {
+      immediate: true,
+      code: 'cube(10);',
+    });
+    expect(response.isError).not.toBe(true);
+    expect(getText(response)).toContain('✅ Render completed for main.scad.');
+  });
+
+  it('returns success for warnings-only trigger_render results', async () => {
+    const pending = executeToolRequestForTests({
+      requestId: 'req-2',
+      toolName: 'trigger_render',
+    });
+
+    await settleRender({
+      previewSrc: 'blob:preview',
+      previewKind: 'mesh',
+      diagnostics: [{ severity: 'warning', message: 'Object may be non-manifold' }],
+      error: '',
+    });
+
+    const response = (await pending) as ToolResponse;
+
+    expect(response.isError).not.toBe(true);
+    expect(getText(response)).toContain('[Warning]');
+  });
+
+  it('uses the newly settled preview for screenshots immediately after trigger_render', async () => {
+    setProjectState({
+      renderTargetPath: 'openscad/poly555.scad',
+      files: {
+        'openscad/poly555.scad': createMockProjectFile('cube(10);'),
+      },
+    });
+    getRenderArtifactState().publishSettledArtifact({
+      requestId: 99,
+      renderTargetPath: 'bos_test.scad',
+      workspaceRoot: mockProjectState.projectRoot,
+      sourceHash: 'bos-hash',
+      previewKind: 'mesh',
+      previewSrc: 'blob:bos-preview',
+      diagnostics: [],
+      error: '',
+      dimensionMode: '3d',
+      sceneStyle: DEFAULT_SCENE_STYLE as never,
+      useModelColors: true,
+      createdAt: Date.now(),
+    });
+    mockRequestRender.mockImplementation(() => {
+      const requestId = nextRequestId++;
+      lastStartedRequestId = requestId;
+      notifyDesktopMcpRenderStarted({
+        renderTargetPath: 'openscad/poly555.scad',
+        requestId,
+      });
+      getRenderArtifactState().publishSettledArtifact({
+        requestId,
+        renderTargetPath: 'openscad/poly555.scad',
+        workspaceRoot: mockProjectState.projectRoot,
+        sourceHash: 'poly555-hash',
+        previewSrc: 'blob:poly555-preview',
+        previewKind: 'mesh',
+        diagnostics: [],
+        error: '',
+        dimensionMode: '3d',
+        sceneStyle: DEFAULT_SCENE_STYLE as never,
+        useModelColors: true,
+        createdAt: Date.now(),
+      });
+      notifyDesktopMcpRenderSettled(requestId);
+    });
+    mockCaptureOffscreen.mockImplementation(async (previewUrl: string) =>
+      `data:image/png;base64,${previewUrl}`
+    );
+
+    const renderResponse = (await executeToolRequestForTests({
+      requestId: 'req-race-render',
+      toolName: 'trigger_render',
+    })) as ToolResponse;
+    expect(renderResponse.isError).not.toBe(true);
+
+    await executeToolRequestForTests({
+      requestId: 'req-race-screenshot',
+      toolName: 'get_preview_screenshot',
+      arguments: { view: 'isometric' },
+    });
+
+    expect(mockCaptureOffscreen).toHaveBeenLastCalledWith(
+      'blob:poly555-preview',
+      expect.objectContaining({ view: 'isometric' })
+    );
+  });
+
+  it('returns an MCP error when trigger_render reports a render error', async () => {
+    const pending = executeToolRequestForTests({
+      requestId: 'req-3',
+      toolName: 'trigger_render',
+    });
+
+    await settleRender({
+      previewSrc: '',
+      previewKind: 'mesh',
+      diagnostics: [],
+      error: 'Parser error: syntax error in file main.scad',
+    });
+
+    const response = (await pending) as ToolResponse;
+    const text = getText(response);
+
+    expect(response.isError).toBe(true);
+    expect(text).toContain('❌ Render failed for main.scad.');
+    expect(text).toContain('Parser error: syntax error in file main.scad');
+    expect(text).toContain('`get_diagnostics`');
+    expect(text).toContain('`set_render_target`');
+  });
+
+  it('returns an MCP error when trigger_render reports diagnostic errors', async () => {
+    const pending = executeToolRequestForTests({
+      requestId: 'req-4',
+      toolName: 'trigger_render',
+    });
+
+    await settleRender({
+      previewSrc: '',
+      previewKind: 'mesh',
+      diagnostics: [{ severity: 'error', line: 12, message: 'Undefined variable foo' }],
+      error: '',
+    });
+
+    const response = (await pending) as ToolResponse;
+
+    expect(response.isError).toBe(true);
+    expect(getText(response)).toContain('Undefined variable foo');
+  });
+
+  it('refreshes clean dependency files from disk before an MCP render', async () => {
+    setProjectState({
+      renderTargetPath: 'openscad/poly555.scad',
+      files: {
+        'openscad/poly555.scad': createMockProjectFile('include <config.scad>;'),
+        'openscad/config.scad': createMockProjectFile('SHOW_ENCLOSURE_BOTTOM = true;'),
+      },
+    });
+    mockResolveWorkingDirDepsDetailed.mockResolvedValue({
+      files: {
+        'openscad/config.scad': 'SHOW_ENCLOSURE_BOTTOM = false;',
+      },
+      missingPaths: [],
+      stats: {
+        diskReads: 2,
+        dirtyProjectFileHits: 0,
+        projectFileFallbackHits: 0,
+      },
+    });
+
+    const pending = executeToolRequestForTests({
+      requestId: 'req-refresh',
+      toolName: 'trigger_render',
+    });
+
+    await settleRender({
+      previewSrc: 'blob:preview',
+      previewKind: 'mesh',
+      diagnostics: [],
+      error: '',
+    });
+
+    const response = (await pending) as ToolResponse;
+
+    expect(mockRequestRender).toHaveBeenCalledWith('manual', {
+      immediate: true,
+      code: 'include <config.scad>;',
+    });
+    expect(mockProjectState.files['openscad/config.scad']?.content).toBe(
+      'SHOW_ENCLOSURE_BOTTOM = false;'
+    );
+    expect(response.isError).not.toBe(true);
+  });
+
+  it('uses the refreshed render-target source as the immediate render code override', async () => {
+    setProjectState({
+      renderTargetPath: 'openscad/poly555.scad',
+      files: {
+        'openscad/poly555.scad': createMockProjectFile('old_source();'),
+      },
+    });
+    mockReadTextFile.mockImplementation(async (absolutePath: string) => {
+      if (absolutePath.endsWith('/openscad/poly555.scad')) {
+        return 'updated_source();';
+      }
+      return null;
+    });
+
+    const pending = executeToolRequestForTests({
+      requestId: 'req-source-override',
+      toolName: 'trigger_render',
+    });
+
+    await settleRender({
+      previewSrc: 'blob:preview',
+      previewKind: 'mesh',
+      diagnostics: [],
+      error: '',
+    });
+
+    const response = (await pending) as ToolResponse;
+
+    expect(mockRequestRender).toHaveBeenCalledWith('manual', {
+      immediate: true,
+      code: 'updated_source();',
+    });
+    expect(response.isError).not.toBe(true);
+  });
+
+  it('fails before rendering when the MCP snapshot refresh cannot resolve a dependency', async () => {
+    setProjectState({
+      renderTargetPath: 'openscad/poly555.scad',
+      files: {
+        'openscad/poly555.scad': createMockProjectFile('include <config.scad>;'),
+      },
+    });
+    mockResolveWorkingDirDepsDetailed.mockResolvedValue({
+      files: {},
+      missingPaths: ['config.scad'],
+      stats: {
+        diskReads: 2,
+        dirtyProjectFileHits: 0,
+        projectFileFallbackHits: 0,
+      },
+    });
+
+    const response = (await executeToolRequestForTests({
+      requestId: 'req-missing',
+      toolName: 'trigger_render',
+    })) as ToolResponse;
+    const text = getText(response);
+
+    expect(response.isError).toBe(true);
+    expect(text).toContain('Could not refresh the MCP render snapshot for openscad/poly555.scad');
+    expect(text).toContain('Missing dependencies: config.scad');
+    expect(mockRequestRender).not.toHaveBeenCalled();
+  });
+
+  it('requires an explicit screenshot view', async () => {
+    setProjectState({ renderTargetPath: 'openscad/config.scad' });
+
+    const response = (await executeToolRequestForTests({
+      requestId: 'req-5',
+      toolName: 'get_preview_screenshot',
+      arguments: {},
+    })) as ToolResponse;
+
+    const text = getText(response);
+    expect(response.isError).toBe(true);
+    expect(text).toContain('requires an explicit `view` argument');
+  });
+
+  it('adds render-target guidance when explicit-view screenshots only have a 2D artifact', async () => {
+    setProjectState({ renderTargetPath: 'layout/top_plate.scad' });
+    getRenderArtifactState().publishSettledArtifact({
+      requestId: 101,
+      renderTargetPath: 'layout/top_plate.scad',
+      workspaceRoot: mockProjectState.projectRoot,
+      sourceHash: 'svg-hash',
+      previewKind: 'svg',
+      previewSrc: 'blob:svg-preview',
+      diagnostics: [],
+      error: '',
+      dimensionMode: '2d',
+      sceneStyle: DEFAULT_SCENE_STYLE as never,
+      useModelColors: true,
+      createdAt: Date.now(),
+    });
+
+    const response = (await executeToolRequestForTests({
+      requestId: 'req-6',
+      toolName: 'get_preview_screenshot',
+      arguments: { view: 'isometric' },
+    })) as ToolResponse;
+
+    const text = getText(response);
+    expect(response.isError).toBe(true);
+    expect(text).toContain('Render target: layout/top_plate.scad');
+    expect(text).toContain('A 3D preview is required');
+    expect(text).toContain('2D SVG preview');
+    expect(text).toContain('`get_diagnostics`');
+  });
+
+  it('adds the same corrective guidance when export_file is blocked by a failed render', async () => {
+    setProjectState({
+      renderTargetPath: 'parts/enclosure.scad',
+      files: {
+        'parts/enclosure.scad': createMockProjectFile('cube(20);'),
+      },
+    });
+    mockReadTextFile.mockImplementation(async (absolutePath: string) => {
+      if (absolutePath.endsWith('/parts/enclosure.scad')) {
+        return 'cube(20);';
+      }
+      return null;
+    });
+    getRenderArtifactState().publishSettledArtifact({
+      requestId: 202,
+      renderTargetPath: 'parts/enclosure.scad',
+      workspaceRoot: mockProjectState.projectRoot,
+      sourceHash: 'failed-hash',
+      previewKind: 'mesh',
+      previewSrc: '',
+      diagnostics: [{ severity: 'error', message: 'Parser error at line 9' }],
+      error: '',
+      dimensionMode: '3d',
+      sceneStyle: DEFAULT_SCENE_STYLE as never,
+      useModelColors: true,
+      createdAt: Date.now(),
+    });
+
+    const response = (await executeToolRequestForTests({
+      requestId: 'req-7',
+      toolName: 'export_file',
+      arguments: {
+        format: 'stl',
+        file_path: '/tmp/enclosure.stl',
+      },
+    })) as ToolResponse;
+
+    const text = getText(response);
+    expect(response.isError).toBe(true);
+    expect(text).toContain('Cannot export STL because the latest render failed.');
+    expect(text).toContain('Render target: parts/enclosure.scad');
+    expect(text).toContain('Parser error at line 9');
+    expect(text).toContain('`get_project_context`');
+  });
+});

--- a/apps/ui/src/services/__tests__/nativeRenderService.test.ts
+++ b/apps/ui/src/services/__tests__/nativeRenderService.test.ts
@@ -118,4 +118,55 @@ describe('NativeRenderService', () => {
       })
     ).resolves.toBeNull();
   });
+
+  it('forwards syntax-check render context to the native invoke call', async () => {
+    invoke.mockImplementation(async (command: string, payload?: Record<string, unknown>) => {
+      if (command === 'render_init') return 'OpenSCAD 2026.03.16';
+      if (command === 'render_native') {
+        return {
+          output: [],
+          stderr: 'WARNING: include note',
+          exit_code: 0,
+          duration_ms: 1,
+          payload,
+        };
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    const { NativeRenderService } = await import('../nativeRenderService');
+    const service = new NativeRenderService();
+
+    await expect(
+      service.checkSyntax('use <shared.scad>;\ncube(10);', {
+        auxiliaryFiles: { 'shared.scad': 'module helper() {}' },
+        libraryFiles: { 'libraries/util.scad': 'module util() {}' },
+        inputPath: 'models/main.scad',
+        workingDir: '/workspace',
+        libraryPaths: ['/lib/system'],
+      })
+    ).resolves.toEqual({
+      diagnostics: [
+        {
+          severity: 'warning',
+          line: undefined,
+          col: undefined,
+          message: 'WARNING: include note',
+        },
+      ],
+    });
+
+    expect(invoke).toHaveBeenCalledWith(
+      'render_native',
+      expect.objectContaining({
+        auxiliaryFiles: {
+          'shared.scad': 'module helper() {}',
+          'libraries/util.scad': 'module util() {}',
+        },
+        inputPath: 'models/main.scad',
+        workingDir: '/workspace',
+        libraryPaths: ['/lib/system'],
+      })
+    );
+  });
 });

--- a/apps/ui/src/services/__tests__/projectRenderInputs.test.ts
+++ b/apps/ui/src/services/__tests__/projectRenderInputs.test.ts
@@ -1,0 +1,127 @@
+import { jest } from '@jest/globals';
+import { buildProjectRenderInputs, loadConfiguredLibraryAssets } from '../projectRenderInputs';
+import type { ProjectStoreState } from '../../stores/projectTypes';
+
+function createState(overrides: Partial<ProjectStoreState> = {}): ProjectStoreState {
+  return {
+    projectRoot: null,
+    renderTargetPath: 'main.scad',
+    contentVersion: 0,
+    emptyFolders: [],
+    files: {
+      'main.scad': {
+        content: 'use <lib/utils.scad>\ncube(size);',
+        savedContent: 'use <lib/utils.scad>\ncube(size);',
+        isDirty: false,
+        isVirtual: true,
+        customizerBaseContent: 'use <lib/utils.scad>\ncube(size);',
+      },
+      'lib/utils.scad': {
+        content: 'size = 10;',
+        savedContent: 'size = 10;',
+        isDirty: false,
+        isVirtual: true,
+        customizerBaseContent: 'size = 10;',
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe('projectRenderInputs', () => {
+  it('builds web render inputs for multi-file projects from the render target snapshot', async () => {
+    const result = await buildProjectRenderInputs({
+      state: createState(),
+    });
+
+    expect(result.code).toBe('use <lib/utils.scad>\ncube(size);');
+    expect(result.workingDirDependencyFiles).toEqual({});
+    expect(result.renderOptions).toEqual({
+      auxiliaryFiles: {
+        'lib/utils.scad': 'size = 10;',
+      },
+      inputPath: 'main.scad',
+      libraryFiles: undefined,
+      libraryPaths: undefined,
+      workingDir: undefined,
+    });
+  });
+
+  it('merges working-directory dependencies through the shared builder', async () => {
+    const resolveWorkingDirDepsImpl = jest.fn(async () => ({
+      'deps/constants.scad': 'size = 24;',
+    }));
+
+    const result = await buildProjectRenderInputs({
+      state: createState({
+        projectRoot: '/project',
+        renderTargetPath: 'models/main.scad',
+        files: {
+          'models/main.scad': {
+            content: 'include <deps/constants.scad>\ncube(size);',
+            savedContent: 'include <deps/constants.scad>\ncube(size);',
+            isDirty: false,
+            isVirtual: false,
+            customizerBaseContent: 'include <deps/constants.scad>\ncube(size);',
+          },
+        },
+      }),
+      workingDir: '/project',
+      libraryFiles: {
+        'BOSL2/std.scad': 'module x() {}',
+      },
+      libraryPaths: ['/lib/system'],
+      platform: {
+        readTextFile: jest.fn(async () => null),
+      } as never,
+      resolveWorkingDirDepsImpl,
+    });
+
+    expect(resolveWorkingDirDepsImpl).toHaveBeenCalledWith(
+      'include <deps/constants.scad>\ncube(size);',
+      expect.objectContaining({
+        workingDir: '/project',
+        renderTargetDir: 'models',
+      })
+    );
+    expect(result.workingDirDependencyFiles).toEqual({
+      'deps/constants.scad': 'size = 24;',
+    });
+    expect(result.renderOptions).toEqual({
+      auxiliaryFiles: {
+        'BOSL2/std.scad': 'module x() {}',
+        'deps/constants.scad': 'size = 24;',
+      },
+      inputPath: 'models/main.scad',
+      libraryFiles: {
+        'BOSL2/std.scad': 'module x() {}',
+      },
+      libraryPaths: ['/lib/system'],
+      workingDir: '/project',
+    });
+  });
+
+  it('loads configured library files and paths in one place', async () => {
+    const result = await loadConfiguredLibraryAssets(
+      {
+        autoDiscoverSystem: true,
+        customPaths: ['/lib/custom'],
+      },
+      {
+        getLibraryPaths: jest.fn(async () => ['/lib/system']),
+        readDirectoryFiles: jest
+          .fn()
+          .mockResolvedValueOnce({ 'system.scad': 'module system() {}' })
+          .mockResolvedValueOnce({ 'custom.scad': 'module custom() {}' }),
+      }
+    );
+
+    expect(result).toEqual({
+      libraryFiles: {
+        'custom.scad': 'module custom() {}',
+        'system.scad': 'module system() {}',
+      },
+      libraryPaths: ['/lib/system', '/lib/custom'],
+    });
+  });
+});

--- a/apps/ui/src/services/__tests__/renderService.test.ts
+++ b/apps/ui/src/services/__tests__/renderService.test.ts
@@ -390,6 +390,45 @@ describe('RenderService', () => {
     await expect(exportPromise).resolves.toEqual(new Uint8Array([1, 2, 3]));
   });
 
+  it('forwards syntax-check auxiliary files and input path to the worker', async () => {
+    const service = new RenderService();
+    const initPromise = service.init();
+    mockWorkers[0].emitMessage({ type: 'ready' });
+    await initPromise;
+
+    const checkPromise = service.checkSyntax('use <shared.scad>;\ncube(10);', {
+      auxiliaryFiles: { 'shared.scad': 'module helper() {}' },
+      libraryFiles: { 'libraries/util.scad': 'module util() {}' },
+      inputPath: 'models/main.scad',
+    });
+    const { worker, request } = await takeLastPostedRenderRequest();
+
+    expect(request.args).toEqual(['/input.scad', '-o', '/output.stl', '--backend=manifold']);
+    expect((request as { inputPath?: string }).inputPath).toBe('models/main.scad');
+    expect((request as { auxiliaryFiles?: Record<string, string> }).auxiliaryFiles).toStrictEqual({
+      'shared.scad': 'module helper() {}',
+      'libraries/util.scad': 'module util() {}',
+    });
+
+    worker.emitMessage({
+      type: 'result',
+      id: request.id,
+      output: new Uint8Array(),
+      stderr: 'WARNING: include note',
+    });
+
+    await expect(checkPromise).resolves.toEqual({
+      diagnostics: [
+        {
+          severity: 'warning',
+          line: undefined,
+          col: undefined,
+          message: 'WARNING: include note',
+        },
+      ],
+    });
+  });
+
   it('rejects init when the worker reports an __init__ error', async () => {
     const service = new RenderService();
     const initPromise = service.init();

--- a/apps/ui/src/services/__tests__/renderService.test.ts
+++ b/apps/ui/src/services/__tests__/renderService.test.ts
@@ -360,6 +360,36 @@ describe('RenderService', () => {
     await expect(exportPromise).rejects.toThrow('Export produced no output');
   });
 
+  it('forwards export auxiliary files and input path to the worker', async () => {
+    const service = new RenderService();
+    const initPromise = service.init();
+    mockWorkers[0].emitMessage({ type: 'ready' });
+    await initPromise;
+
+    const exportPromise = service.exportModel('use <shared.scad>;\ncube(10);', 'obj', {
+      auxiliaryFiles: { 'shared.scad': 'module helper() {}' },
+      libraryFiles: { 'libraries/util.scad': 'module util() {}' },
+      inputPath: 'models/main.scad',
+    });
+    const { worker, request } = await takeLastPostedRenderRequest();
+
+    expect(request.args).toEqual(['/input.scad', '-o', '/output.obj', '--backend=manifold']);
+    expect((request as { inputPath?: string }).inputPath).toBe('models/main.scad');
+    expect((request as { auxiliaryFiles?: Record<string, string> }).auxiliaryFiles).toStrictEqual({
+      'shared.scad': 'module helper() {}',
+      'libraries/util.scad': 'module util() {}',
+    });
+
+    worker.emitMessage({
+      type: 'result',
+      id: request.id,
+      output: new Uint8Array([1, 2, 3]),
+      stderr: '',
+    });
+
+    await expect(exportPromise).resolves.toEqual(new Uint8Array([1, 2, 3]));
+  });
+
   it('rejects init when the worker reports an __init__ error', async () => {
     const service = new RenderService();
     const initPromise = service.init();

--- a/apps/ui/src/services/__tests__/windowOpenService.test.ts
+++ b/apps/ui/src/services/__tests__/windowOpenService.test.ts
@@ -1,0 +1,139 @@
+/** @jest-environment jsdom */
+
+import { jest } from '@jest/globals';
+import { openFileInWindow, openWorkspaceFolderInWindow } from '../windowOpenService';
+import { getProjectStore } from '../../stores/projectStore';
+import { getRenderRequestStore } from '../../stores/renderRequestStore';
+import { DEFAULT_TAB_NAME } from '../../stores/workspaceFactories';
+import {
+  getWorkspaceState,
+  resetWorkspaceStore,
+  workspaceStore,
+} from '../../stores/workspaceStore';
+
+function resetStores() {
+  getProjectStore().getState().resetProject();
+  resetWorkspaceStore();
+  getRenderRequestStore().setState({
+    pendingRequest: null,
+    nextId: 1,
+  });
+}
+
+describe('windowOpenService', () => {
+  beforeEach(() => {
+    resetStores();
+  });
+
+  it('opens a workspace folder and hydrates the window state before render', async () => {
+    const platform = {
+      capabilities: { hasFileSystem: true },
+      createDirectory: jest.fn(async () => {}),
+      readDirectoryFiles: jest.fn(async () => ({
+        'main.scad': 'cube(10);',
+        'parts/brace.scad': 'cube(2);',
+      })),
+      readSubdirectories: jest.fn(async () => ['parts', 'empty']),
+      writeTextFile: jest.fn(async () => {}),
+    };
+
+    const result = await openWorkspaceFolderInWindow('/tmp/pine-fiber', { platform });
+
+    expect(result).toMatchObject({
+      workspaceRoot: '/tmp/pine-fiber',
+      renderTargetPath: 'main.scad',
+      fileCount: 2,
+      createdDefaultFile: false,
+      emptyFolders: ['empty'],
+    });
+
+    const projectState = getProjectStore().getState();
+    expect(projectState.projectRoot).toBe('/tmp/pine-fiber');
+    expect(projectState.renderTargetPath).toBe('main.scad');
+    expect(projectState.emptyFolders).toEqual(['empty']);
+    expect(Object.keys(projectState.files)).toEqual(['main.scad', 'parts/brace.scad']);
+
+    const workspaceState = getWorkspaceState();
+    expect(workspaceState.showWelcome).toBe(false);
+    expect(workspaceState.tabs).toHaveLength(1);
+    expect(workspaceState.tabs[0]?.filePath).toBe('/tmp/pine-fiber/main.scad');
+    expect(workspaceState.tabs[0]?.projectPath).toBe('main.scad');
+    expect(workspaceState.activeTabId).toBe(result.activeTabId);
+
+    expect(getRenderRequestStore().getState().pendingRequest).toMatchObject({
+      trigger: 'file_open',
+      immediate: true,
+    });
+  });
+
+  it('reuses an already-open file tab instead of duplicating the workspace', async () => {
+    workspaceStore.getState().hydrateWorkspace({
+      tabs: [
+        {
+          ...getWorkspaceState().tabs[0],
+          filePath: '/tmp/pine-fiber/main.scad',
+          name: 'main.scad',
+          projectPath: 'main.scad',
+        },
+      ],
+      activeTabId: getWorkspaceState().tabs[0]?.id ?? null,
+      showWelcome: false,
+    });
+    getProjectStore()
+      .getState()
+      .openProject('/tmp/pine-fiber', { 'main.scad': 'cube(1);' }, 'main.scad');
+
+    const result = await openFileInWindow(
+      {
+        path: '/tmp/pine-fiber/main.scad',
+        name: 'main.scad',
+        content: 'flower();',
+      },
+      {
+        platform: {
+          capabilities: { hasFileSystem: true },
+          createDirectory: jest.fn(),
+          readDirectoryFiles: jest.fn(),
+          readSubdirectories: jest.fn(),
+          writeTextFile: jest.fn(),
+        },
+      }
+    );
+
+    expect(result.reusedExistingTab).toBe(true);
+    expect(getWorkspaceState().tabs).toHaveLength(1);
+    expect(getProjectStore().getState().files['main.scad']?.content).toBe('cube(1);');
+  });
+
+  it('opens a virtual single-file project when no disk path exists', async () => {
+    const result = await openFileInWindow(
+      {
+        path: null,
+        name: '',
+        content: 'sphere(5);',
+      },
+      {
+        platform: {
+          capabilities: { hasFileSystem: false },
+          createDirectory: jest.fn(),
+          readDirectoryFiles: jest.fn(),
+          readSubdirectories: jest.fn(),
+          writeTextFile: jest.fn(),
+        },
+      }
+    );
+
+    expect(result).toMatchObject({
+      projectRoot: null,
+      projectPath: DEFAULT_TAB_NAME,
+      reusedExistingTab: false,
+      fileCount: 1,
+    });
+    expect(getProjectStore().getState().files[DEFAULT_TAB_NAME]?.content).toBe('sphere(5);');
+    expect(getWorkspaceState().showWelcome).toBe(false);
+    expect(getRenderRequestStore().getState().pendingRequest).toMatchObject({
+      trigger: 'file_open',
+      immediate: true,
+    });
+  });
+});

--- a/apps/ui/src/services/aiService.ts
+++ b/apps/ui/src/services/aiService.ts
@@ -4,10 +4,14 @@ import { createOpenAI } from '@ai-sdk/openai';
 import { z } from 'zod';
 import { eventBus, historyService } from '../platform';
 import { getRenderService } from './renderService';
-import { captureOffscreen, type CaptureOptions } from './offscreenRenderer';
 import type { PreviewSceneStyle } from './previewSceneConfig';
 import type { AiProvider } from '../stores/apiKeyStore';
 import type { MeasurementUnit } from '../stores/settingsStore';
+import {
+  buildProjectContextSummary,
+  capturePreviewScreenshot,
+  listFolderEntries,
+} from './studioTooling';
 
 export interface AiToolCallbacks {
   captureCurrentView: () => Promise<string | null>;
@@ -31,9 +35,6 @@ export interface AiToolCallbacks {
   getMeasurementUnit: () => MeasurementUnit;
   setMeasurementUnit: (unit: MeasurementUnit) => void;
 }
-
-const MAX_CONTEXT_LINES = 200;
-const TRUNCATION_LINES = 150;
 
 export const SYSTEM_PROMPT = `## OpenSCAD AI Assistant
 
@@ -143,45 +144,6 @@ export function createModel(provider: AiProvider, apiKey: string, modelId: strin
   return openai(modelId);
 }
 
-/**
- * List files and subfolders at a specific directory level.
- * Returns a formatted string with entries like:
- *   📁 lib/
- *   main.scad (render target)
- *   utils.scad
- */
-function listFolderEntries(
-  allFiles: string[],
-  folder: string,
-  renderTarget?: string | null
-): string {
-  const prefix = folder ? folder + '/' : '';
-  const folders = new Set<string>();
-  const files: string[] = [];
-
-  for (const filePath of allFiles) {
-    if (!filePath.startsWith(prefix)) continue;
-    const remainder = filePath.slice(prefix.length);
-    const slashIdx = remainder.indexOf('/');
-    if (slashIdx >= 0) {
-      folders.add(remainder.slice(0, slashIdx));
-    } else {
-      files.push(remainder);
-    }
-  }
-
-  const lines: string[] = [];
-  for (const dir of [...folders].sort()) {
-    lines.push(`  📁 ${dir}/`);
-  }
-  for (const file of files.sort()) {
-    const fullPath = prefix + file;
-    lines.push(fullPath === renderTarget ? `  ${file} (render target)` : `  ${file}`);
-  }
-
-  return lines.join('\n');
-}
-
 export function buildTools(callbacks: AiToolCallbacks) {
   return {
     get_project_context: tool({
@@ -191,37 +153,12 @@ export function buildTools(callbacks: AiToolCallbacks) {
       execute: async () => {
         const renderTarget = callbacks.getRenderTargetPath();
         const allFiles = callbacks.listProjectFiles();
-
-        const parts: string[] = [];
-
-        // Render target info
-        if (renderTarget) {
-          parts.push(`Render target: ${renderTarget}`);
-          const content = callbacks.readProjectFile(renderTarget);
-          if (content) {
-            const lines = content.split('\n');
-            if (lines.length > MAX_CONTEXT_LINES) {
-              const truncated = lines.slice(0, TRUNCATION_LINES).join('\n');
-              parts.push(
-                `\n--- ${renderTarget} (showing ${TRUNCATION_LINES} of ${lines.length} lines) ---\n${truncated}\n\n[Truncated. Use read_file to see the full content.]`
-              );
-            } else {
-              parts.push(`\n--- ${renderTarget} ---\n${content}`);
-            }
-          }
-        } else {
-          parts.push('No render target set.');
-        }
-
-        // Top-level file/folder listing
-        if (allFiles.length > 0) {
-          const topLevel = listFolderEntries(allFiles, '', renderTarget);
-          parts.push(`\nProject files (${allFiles.length} total):\n${topLevel}`);
-        } else {
-          parts.push('\nNo project files.');
-        }
-
-        return parts.join('\n');
+        return buildProjectContextSummary({
+          renderTarget,
+          renderTargetContent: renderTarget ? callbacks.readProjectFile(renderTarget) : null,
+          allFiles,
+          includeTopLevelListing: true,
+        }).replace('[Truncated.]', '[Truncated. Use read_file to see the full content.]');
       },
     }),
 
@@ -293,44 +230,15 @@ export function buildTools(callbacks: AiToolCallbacks) {
           .describe('Custom elevation in degrees (0=level, 90=top-down). Overrides view if set.'),
       }),
       execute: async ({ view, azimuth, elevation }) => {
-        const useOffscreen = view !== 'current' || azimuth !== undefined || elevation !== undefined;
-
-        if (!useOffscreen) {
-          const dataUrl = await callbacks.captureCurrentView();
-          if (dataUrl) {
-            return { image_data_url: dataUrl };
-          }
-          return {
-            error:
-              'No preview available. The code may not have been rendered yet, or the preview panel is not visible.',
-          };
-        }
-
-        const preview3dUrl = callbacks.get3dPreviewUrl();
-        if (!preview3dUrl) {
-          return {
-            error:
-              'No 3D model available for angle-specific views. Render the code first, or use view="current" to capture the 2D SVG preview.',
-          };
-        }
-
-        try {
-          const opts: CaptureOptions = {};
-          if (azimuth !== undefined || elevation !== undefined) {
-            opts.azimuth = azimuth;
-            opts.elevation = elevation;
-          } else if (view !== 'current') {
-            opts.view = view;
-          }
-          opts.sceneStyle = callbacks.getPreviewSceneStyle();
-          opts.useModelColors = callbacks.getUseModelColors();
-          const dataUrl = await captureOffscreen(preview3dUrl, opts);
-          return { image_data_url: dataUrl };
-        } catch (err) {
-          return {
-            error: `Failed to capture screenshot: ${err instanceof Error ? err.message : String(err)}`,
-          };
-        }
+        return capturePreviewScreenshot({
+          captureCurrentView: callbacks.captureCurrentView,
+          get3dPreviewUrl: callbacks.get3dPreviewUrl,
+          getPreviewSceneStyle: callbacks.getPreviewSceneStyle,
+          getUseModelColors: callbacks.getUseModelColors,
+          view,
+          azimuth,
+          elevation,
+        });
       },
       toModelOutput({ output }) {
         if (typeof output === 'object' && output !== null && 'image_data_url' in output) {

--- a/apps/ui/src/services/aiService.ts
+++ b/apps/ui/src/services/aiService.ts
@@ -3,7 +3,7 @@ import { createAnthropic } from '@ai-sdk/anthropic';
 import { createOpenAI } from '@ai-sdk/openai';
 import { z } from 'zod';
 import { eventBus, historyService } from '../platform';
-import { getRenderService } from './renderService';
+import { getRenderService, type RenderOptions } from './renderService';
 import type { PreviewSceneStyle } from './previewSceneConfig';
 import type { AiProvider } from '../stores/apiKeyStore';
 import type { MeasurementUnit } from '../stores/settingsStore';
@@ -24,6 +24,12 @@ export interface AiToolCallbacks {
   readProjectFile: (path: string) => string | null;
   /** Returns the current render target path */
   getRenderTargetPath: () => string | null;
+  /** Build the current render validation inputs using the same project snapshot path as preview renders. */
+  getRenderValidationInputs: () => Promise<{
+    code: string;
+    renderTargetPath: string | null;
+    renderOptions: RenderOptions;
+  }>;
   /** Create a new file in the project */
   createProjectFile: (path: string, content: string) => boolean;
   /** Edit a file by exact string replacement. Returns null on success, error string on failure. */
@@ -321,9 +327,14 @@ export function buildTools(callbacks: AiToolCallbacks) {
       description: 'Get current OpenSCAD compilation errors and warnings',
       inputSchema: z.object({}),
       execute: async () => {
-        const renderTarget = callbacks.getRenderTargetPath();
-        const currentCode = renderTarget ? (callbacks.readProjectFile(renderTarget) ?? '') : '';
-        const result = await getRenderService().checkSyntax(currentCode);
+        const { code, renderTargetPath, renderOptions } =
+          await callbacks.getRenderValidationInputs();
+
+        if (!renderTargetPath) {
+          return '❌ No render target set.';
+        }
+
+        const result = await getRenderService().checkSyntax(code, renderOptions);
 
         if (result.diagnostics.length === 0) {
           return '✅ No errors or warnings. The code compiles successfully.';

--- a/apps/ui/src/services/desktopMcp.ts
+++ b/apps/ui/src/services/desktopMcp.ts
@@ -56,8 +56,6 @@ export type DesktopWindowLaunchIntent =
       request_id: string;
       folder_path: string;
       create_if_empty: boolean;
-      /** Pre-read .scad file contents from the Rust side (relative path → content). */
-      files?: Record<string, string> | null;
     }
   | { kind: 'open_file'; request_id: string; file_path: string };
 
@@ -80,15 +78,6 @@ interface InitializeDesktopMcpBridgeOptions {
 
 interface DesktopWindowBootstrapPayload {
   launchIntent?: DesktopWindowLaunchIntent | null;
-}
-
-function emitLocalStartupPhase(phase: string, detail?: string) {
-  if (typeof window === 'undefined') return;
-  window.dispatchEvent(
-    new CustomEvent('openscad:startup-phase', {
-      detail: { phase, detail: detail ?? null },
-    })
-  );
 }
 
 export type DesktopWindowStartupPhase =
@@ -143,6 +132,10 @@ const DEFAULT_STATUS: McpServerStatus = {
   message: null,
 };
 
+function isDesktopTauri(): boolean {
+  return typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
+}
+
 const previewState = {
   previewKind: 'mesh' as PreviewKind,
   previewSrc: '',
@@ -161,30 +154,6 @@ const renderWaiters = new Map<
 >();
 let nextRenderWaiterId = 1;
 let bridgeUnlistenPromise: Promise<() => void> | null = null;
-
-/**
- * Gate that resolves when <App /> mounts and the render service is ready.
- * MCP tool handlers that need the full UI (rendering, screenshots, etc.)
- * await this before executing.
- */
-let _appReadyResolve: (() => void) | null = null;
-const _appReadyPromise = new Promise<void>((resolve) => {
-  _appReadyResolve = resolve;
-});
-
-/** Called by <App /> on mount to signal that the render service is available. */
-export function signalAppReady(): void {
-  _appReadyResolve?.();
-}
-
-function waitForAppReady(): Promise<void> {
-  return _appReadyPromise;
-}
-
-function isDesktopTauri(): boolean {
-  return typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
-}
-
 
 function textResponse(text: string, isError = false): McpToolResponse {
   return {
@@ -260,7 +229,6 @@ function resolveNextRenderWaiter(snapshot: RenderSnapshotLike) {
 }
 
 async function runRenderAndWait(trigger: RenderTrigger): Promise<RenderSnapshotLike> {
-  await waitForAppReady();
   const pending = waitForNextRender();
   requestRender(trigger, { immediate: true });
   return pending;
@@ -340,7 +308,6 @@ async function handleTriggerRender(): Promise<McpToolResponse> {
 async function handlePreviewScreenshot(
   argumentsValue: Record<string, unknown>
 ): Promise<McpToolResponse> {
-  await waitForAppReady();
   const result = await capturePreviewScreenshot({
     ...buildScreenshotCallbacks(),
     view:
@@ -514,15 +481,11 @@ export async function initializeDesktopMcpBridge(
 
   if (!bridgeUnlistenPromise) {
     bridgeUnlistenPromise = (async () => {
-      emitLocalStartupPhase('desktop_mcp_bridge_begin');
       const { getCurrentWindow } = await import('@tauri-apps/api/window');
-      emitLocalStartupPhase('desktop_mcp_bridge_window_api_imported');
       const currentWindow = getCurrentWindow();
-      emitLocalStartupPhase('desktop_mcp_bridge_current_window_acquired');
       let unlistenOpenRequest: (() => void) | null = null;
       let unlistenFocus: (() => void) | null = null;
 
-      emitLocalStartupPhase('desktop_mcp_bridge_listen_tool_request_begin');
       const unlistenToolRequest = await currentWindow.listen<McpToolRequestPayload>(
         'mcp:tool-request',
         async (event) => {
@@ -543,18 +506,14 @@ export async function initializeDesktopMcpBridge(
           }
         }
       );
-      emitLocalStartupPhase('desktop_mcp_bridge_listen_tool_request_done');
 
-      emitLocalStartupPhase('desktop_mcp_bridge_listen_open_request_begin');
       unlistenOpenRequest = await currentWindow.listen<DesktopWindowOpenRequestPayload>(
         'desktop:open-request',
         async (event) => {
           await options.onOpenRequest?.(event.payload);
         }
       );
-      emitLocalStartupPhase('desktop_mcp_bridge_listen_open_request_done');
 
-      emitLocalStartupPhase('desktop_mcp_bridge_focus_hook_begin');
       unlistenFocus = await currentWindow.onFocusChanged(() => {
         void syncDesktopMcpWindowContext({
           title: document.title || 'OpenSCAD Studio',
@@ -564,30 +523,18 @@ export async function initializeDesktopMcpBridge(
           mode: getWorkspaceState().showWelcome ? 'welcome' : 'ready',
         });
       });
-      emitLocalStartupPhase('desktop_mcp_bridge_focus_hook_done');
 
-      emitLocalStartupPhase('desktop_mcp_bridge_mark_ready_begin');
       await invoke('mcp_mark_window_bridge_ready');
-      emitLocalStartupPhase('desktop_mcp_bridge_mark_ready_done');
 
-      emitLocalStartupPhase('desktop_mcp_bridge_sync_context_begin');
       void syncDesktopMcpWindowContext({
         title: document.title || 'OpenSCAD Studio',
         workspaceRoot: getProjectState().projectRoot,
         renderTargetPath: getProjectState().renderTargetPath,
         showWelcome: getWorkspaceState().showWelcome,
         mode: getWorkspaceState().showWelcome ? 'welcome' : 'ready',
-      })
-        .then(() => {
-          emitLocalStartupPhase('desktop_mcp_bridge_sync_context_done');
-        })
-        .catch((error) => {
-          emitLocalStartupPhase(
-            'desktop_mcp_bridge_sync_context_failed',
-            error instanceof Error ? error.message : String(error)
-          );
-          console.error('[desktopMcp] Initial syncDesktopMcpWindowContext failed:', error);
-        });
+      }).catch((error) => {
+        console.error('[desktopMcp] Initial syncDesktopMcpWindowContext failed:', error);
+      });
 
       return () => {
         unlistenToolRequest();

--- a/apps/ui/src/services/desktopMcp.ts
+++ b/apps/ui/src/services/desktopMcp.ts
@@ -1,6 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
-import { listen } from '@tauri-apps/api/event';
-import type { Diagnostic } from './renderService';
+import { getRenderService, type Diagnostic, type ExportFormat } from './renderService';
 import { FALLBACK_PREVIEW_SCENE_STYLE, type PreviewSceneStyle } from './previewSceneConfig';
 import { captureCurrentPreview } from '../utils/capturePreview';
 import {
@@ -9,13 +8,18 @@ import {
   type PreviewScreenshotOptions,
 } from './studioTooling';
 import {
+  getAuxiliaryFilesForRender,
   getProjectState,
+  getProjectWorkingDirectory,
   getProjectStore,
   getRenderTargetContent,
   listProjectFiles as listProjectFilesFromState,
 } from '../stores/projectStore';
+import { getPlatform } from '../platform';
+import { loadSettings } from '../stores/settingsStore';
 import { requestRender } from '../stores/renderRequestStore';
 import { normalizeProjectRelativePath } from '../utils/projectFilePaths';
+import { resolveWorkingDirDeps } from '../utils/resolveWorkingDirDeps';
 
 type PreviewKind = 'mesh' | 'svg';
 type RenderTrigger = Parameters<typeof requestRender>[0];
@@ -28,6 +32,14 @@ export interface McpServerStatus {
   status: McpServerState;
   endpoint: string | null;
   message: string | null;
+}
+
+export interface WorkspaceDescriptor {
+  windowId: string;
+  title: string;
+  workspaceRoot: string | null;
+  renderTargetPath: string | null;
+  isFocused: boolean;
 }
 
 interface McpToolRequestPayload {
@@ -276,6 +288,117 @@ async function handlePreviewScreenshot(
   };
 }
 
+function isAbsolutePath(path: string): boolean {
+  return path.startsWith('/') || /^[A-Za-z]:[\\/]/.test(path);
+}
+
+async function resolveExportDestination(filePath: string): Promise<string | null> {
+  if (isAbsolutePath(filePath)) {
+    return filePath;
+  }
+
+  const projectRoot = getProjectState().projectRoot;
+  if (!projectRoot) {
+    return null;
+  }
+
+  const { join } = await import('@tauri-apps/api/path');
+  return join(projectRoot, filePath);
+}
+
+async function loadLibraryExportContext() {
+  const platform = getPlatform();
+  const settings = loadSettings();
+  const systemPaths = settings.library.autoDiscoverSystem ? await platform.getLibraryPaths() : [];
+  const libraryPaths = [...systemPaths, ...settings.library.customPaths];
+  const libraryFiles: Record<string, string> = {};
+
+  for (const libPath of libraryPaths) {
+    try {
+      const files = await platform.readDirectoryFiles(libPath);
+      Object.assign(libraryFiles, files);
+    } catch (error) {
+      console.warn(`[desktopMcp] Failed to read library path ${libPath}:`, error);
+    }
+  }
+
+  return { libraryFiles, libraryPaths };
+}
+
+async function handleExportFile(argumentsValue: Record<string, unknown>): Promise<McpToolResponse> {
+  const format =
+    typeof argumentsValue.format === 'string' ? (argumentsValue.format as ExportFormat) : null;
+  const filePath =
+    typeof argumentsValue.file_path === 'string'
+      ? argumentsValue.file_path
+      : typeof argumentsValue.path === 'string'
+        ? argumentsValue.path
+        : null;
+
+  if (!format) {
+    return textResponse('`export_file` requires a `format` argument.', true);
+  }
+  if (!filePath) {
+    return textResponse('`export_file` requires a `file_path` argument.', true);
+  }
+
+  const state = getProjectState();
+  const source = getRenderTargetContent(state);
+  if (!source) {
+    return textResponse('❌ No active render target is available to export.', true);
+  }
+
+  const resolvedPath = await resolveExportDestination(filePath);
+  if (!resolvedPath) {
+    return textResponse(
+      '❌ Relative export paths require an open desktop workspace with a project root.',
+      true
+    );
+  }
+
+  const projectFiles = getAuxiliaryFilesForRender(state);
+  const workingDir = getProjectWorkingDirectory(state);
+  const renderTargetPath = state.renderTargetPath ?? undefined;
+  const renderTargetDir =
+    renderTargetPath && renderTargetPath.includes('/')
+      ? renderTargetPath.slice(0, renderTargetPath.lastIndexOf('/'))
+      : undefined;
+
+  const { libraryFiles, libraryPaths } = await loadLibraryExportContext();
+  let projectAuxFiles: Record<string, string> = { ...projectFiles };
+
+  if (workingDir) {
+    const workingDirFiles = await resolveWorkingDirDeps(source, {
+      workingDir,
+      libraryFiles,
+      platform: getPlatform(),
+      projectFiles,
+      renderTargetDir,
+    });
+
+    if (Object.keys(workingDirFiles).length > 0) {
+      projectAuxFiles = { ...projectAuxFiles, ...workingDirFiles };
+    }
+  }
+
+  const exportBytes = await getRenderService().exportModel(source, format, {
+    backend: 'manifold',
+    auxiliaryFiles: Object.keys(projectAuxFiles).length > 0 ? projectAuxFiles : undefined,
+    libraryFiles: Object.keys(libraryFiles).length > 0 ? libraryFiles : undefined,
+    libraryPaths: libraryPaths.length > 0 ? libraryPaths : undefined,
+    inputPath: renderTargetPath,
+    workingDir: workingDir || undefined,
+  });
+
+  const { dirname } = await import('@tauri-apps/api/path');
+  const { mkdir, writeFile } = await import('@tauri-apps/plugin-fs');
+  const parentDir = await dirname(resolvedPath);
+  await mkdir(parentDir, { recursive: true });
+  await writeFile(resolvedPath, exportBytes);
+
+  return textResponse(`✅ Exported ${format.toUpperCase()} to ${resolvedPath}`);
+}
+
 async function executeToolRequest(payload: McpToolRequestPayload): Promise<McpToolResponse> {
   const args = payload.arguments ?? {};
 
@@ -290,6 +413,8 @@ async function executeToolRequest(payload: McpToolRequestPayload): Promise<McpTo
       return handleTriggerRender();
     case 'get_preview_screenshot':
       return handlePreviewScreenshot(args);
+    case 'export_file':
+      return handleExportFile(args);
     default:
       return textResponse(`Unsupported MCP tool: ${payload.toolName}`, true);
   }
@@ -305,21 +430,44 @@ export async function initializeDesktopMcpBridge(): Promise<() => void> {
   }
 
   if (!bridgeUnlistenPromise) {
-    bridgeUnlistenPromise = listen<McpToolRequestPayload>('mcp:tool-request', async (event) => {
-      const payload = event.payload;
-      const response = await executeToolRequest(payload).catch((error: unknown) =>
-        textResponse(
-          error instanceof Error ? error.message : `Unexpected MCP tool error: ${String(error)}`,
-          true
-        )
+    bridgeUnlistenPromise = (async () => {
+      const { getCurrentWindow } = await import('@tauri-apps/api/window');
+      const currentWindow = getCurrentWindow();
+
+      const unlistenToolRequest = await currentWindow.listen<McpToolRequestPayload>(
+        'mcp:tool-request',
+        async (event) => {
+          const payload = event.payload;
+          const response = await executeToolRequest(payload).catch((error: unknown) =>
+            textResponse(
+              error instanceof Error
+                ? error.message
+                : `Unexpected MCP tool error: ${String(error)}`,
+              true
+            )
+          );
+
+          try {
+            await submitToolResponse(payload.requestId, response);
+          } catch (error) {
+            console.error('[desktopMcp] Failed to submit tool response:', error);
+          }
+        }
       );
 
-      try {
-        await submitToolResponse(payload.requestId, response);
-      } catch (error) {
-        console.error('[desktopMcp] Failed to submit tool response:', error);
-      }
-    });
+      const unlistenFocus = await currentWindow.onFocusChanged(() => {
+        void syncDesktopMcpWindowContext({
+          title: document.title || 'OpenSCAD Studio',
+          workspaceRoot: getProjectState().projectRoot,
+          renderTargetPath: getProjectState().renderTargetPath,
+        });
+      });
+
+      return () => {
+        unlistenToolRequest();
+        unlistenFocus();
+      };
+    })();
   }
 
   const unlisten = await bridgeUnlistenPromise;
@@ -358,6 +506,22 @@ export async function syncDesktopMcpConfig(config: {
   return invoke<McpServerStatus>('configure_mcp_server', config);
 }
 
+export async function syncDesktopMcpWindowContext(context: {
+  title: string;
+  workspaceRoot: string | null;
+  renderTargetPath: string | null;
+}): Promise<void> {
+  if (!isDesktopTauri()) return;
+  await invoke('mcp_update_window_context', {
+    payload: {
+      title: context.title,
+      workspaceRoot: context.workspaceRoot,
+      renderTargetPath: context.renderTargetPath,
+      ready: true,
+    },
+  });
+}
+
 export async function getDesktopMcpStatus(): Promise<McpServerStatus> {
   if (!isDesktopTauri()) return DEFAULT_STATUS;
   return invoke<McpServerStatus>('get_mcp_server_status');
@@ -371,6 +535,29 @@ export function buildCodexMcpCommand(port: number): string {
   return `codex mcp add openscad-studio --url http://127.0.0.1:${port}/mcp`;
 }
 
+export function buildCursorMcpConfig(port: number): string {
+  return `{
+  "mcpServers": {
+    "openscad-studio": {
+      "url": "http://127.0.0.1:${port}/mcp"
+    }
+  }
+}`;
+}
+
+export function buildOpenCodeMcpConfig(port: number): string {
+  return `{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "openscad-studio": {
+      "type": "remote",
+      "url": "http://127.0.0.1:${port}/mcp",
+      "enabled": true
+    }
+  }
+}`;
+}
+
 export function buildAgentSnippet(port: number): string {
-  return `Use the OpenSCAD Studio MCP server at http://127.0.0.1:${port}/mcp for project context, render-target switching, diagnostics, render refresh, and preview screenshots. Read and edit files directly in the repo; do not use Studio MCP for file reads or writes.`;
+  return `Use the OpenSCAD Studio MCP server at http://127.0.0.1:${port}/mcp for render-target switching, diagnostics, render refresh, preview screenshots, and exports. Read and edit files directly in the repo, then call select_workspace with the repo root before using Studio tools.`;
 }

--- a/apps/ui/src/services/desktopMcp.ts
+++ b/apps/ui/src/services/desktopMcp.ts
@@ -18,6 +18,7 @@ import {
 import { getPlatform } from '../platform';
 import { loadSettings } from '../stores/settingsStore';
 import { requestRender } from '../stores/renderRequestStore';
+import { getWorkspaceState } from '../stores/workspaceStore';
 import { normalizeProjectRelativePath } from '../utils/projectFilePaths';
 import { resolveWorkingDirDeps } from '../utils/resolveWorkingDirDeps';
 
@@ -46,6 +47,37 @@ interface McpToolRequestPayload {
   requestId: string;
   toolName: string;
   arguments?: Record<string, unknown>;
+}
+
+export type DesktopWindowLaunchIntent =
+  | { kind: 'welcome' }
+  | {
+      kind: 'open_folder';
+      request_id: string;
+      folder_path: string;
+      create_if_empty: boolean;
+    }
+  | { kind: 'open_file'; request_id: string; file_path: string };
+
+export type DesktopWindowOpenRequest =
+  | {
+      kind: 'open_folder';
+      folder_path: string;
+      create_if_empty: boolean;
+    }
+  | { kind: 'open_file'; file_path: string };
+
+interface DesktopWindowOpenRequestPayload {
+  requestId: string;
+  request: DesktopWindowOpenRequest;
+}
+
+interface InitializeDesktopMcpBridgeOptions {
+  onOpenRequest?: (payload: DesktopWindowOpenRequestPayload) => void | Promise<void>;
+}
+
+interface DesktopWindowBootstrapPayload {
+  launchIntent?: DesktopWindowLaunchIntent | null;
 }
 
 interface McpTextContent {
@@ -84,6 +116,7 @@ const DEFAULT_STATUS: McpServerStatus = {
 const previewState = {
   previewKind: 'mesh' as PreviewKind,
   previewSrc: '',
+  previewViewerId: null as string | null,
   previewSceneStyle: FALLBACK_PREVIEW_SCENE_STYLE as PreviewSceneStyle,
   useModelColors: true,
 };
@@ -117,6 +150,7 @@ function buildScreenshotCallbacks(): Omit<
   return {
     captureCurrentView: async () =>
       captureCurrentPreview({
+        viewerId: previewState.previewViewerId,
         svgSourceUrl: previewState.previewKind === 'svg' ? previewState.previewSrc : null,
         targetWidth: 1200,
         targetHeight: 630,
@@ -424,7 +458,9 @@ async function submitToolResponse(requestId: string, response: McpToolResponse) 
   await invoke('mcp_submit_tool_response', { requestId, response });
 }
 
-export async function initializeDesktopMcpBridge(): Promise<() => void> {
+export async function initializeDesktopMcpBridge(
+  options: InitializeDesktopMcpBridgeOptions = {}
+): Promise<() => void> {
   if (!isDesktopTauri()) {
     return () => {};
   }
@@ -455,16 +491,35 @@ export async function initializeDesktopMcpBridge(): Promise<() => void> {
         }
       );
 
+      const unlistenOpenRequest = await currentWindow.listen<DesktopWindowOpenRequestPayload>(
+        'desktop:open-request',
+        async (event) => {
+          await options.onOpenRequest?.(event.payload);
+        }
+      );
+
       const unlistenFocus = await currentWindow.onFocusChanged(() => {
         void syncDesktopMcpWindowContext({
           title: document.title || 'OpenSCAD Studio',
           workspaceRoot: getProjectState().projectRoot,
           renderTargetPath: getProjectState().renderTargetPath,
+          showWelcome: getWorkspaceState().showWelcome,
+          mode: getWorkspaceState().showWelcome ? 'welcome' : 'ready',
         });
+      });
+
+      await invoke('mcp_mark_window_bridge_ready');
+      await syncDesktopMcpWindowContext({
+        title: document.title || 'OpenSCAD Studio',
+        workspaceRoot: getProjectState().projectRoot,
+        renderTargetPath: getProjectState().renderTargetPath,
+        showWelcome: getWorkspaceState().showWelcome,
+        mode: getWorkspaceState().showWelcome ? 'welcome' : 'ready',
       });
 
       return () => {
         unlistenToolRequest();
+        unlistenOpenRequest();
         unlistenFocus();
       };
     })();
@@ -480,16 +535,19 @@ export async function initializeDesktopMcpBridge(): Promise<() => void> {
 export function updateDesktopMcpPreviewState({
   previewKind,
   previewSrc,
+  previewViewerId,
   previewSceneStyle,
   useModelColors,
 }: {
   previewKind: PreviewKind;
   previewSrc: string;
+  previewViewerId: string | null;
   previewSceneStyle: PreviewSceneStyle;
   useModelColors: boolean;
 }) {
   previewState.previewKind = previewKind;
   previewState.previewSrc = previewSrc;
+  previewState.previewViewerId = previewViewerId;
   previewState.previewSceneStyle = previewSceneStyle;
   previewState.useModelColors = useModelColors;
 }
@@ -510,6 +568,9 @@ export async function syncDesktopMcpWindowContext(context: {
   title: string;
   workspaceRoot: string | null;
   renderTargetPath: string | null;
+  showWelcome: boolean;
+  mode?: 'welcome' | 'opening' | 'ready' | 'open_failed';
+  pendingRequestId?: string | null;
 }): Promise<void> {
   if (!isDesktopTauri()) return;
   await invoke('mcp_update_window_context', {
@@ -517,7 +578,39 @@ export async function syncDesktopMcpWindowContext(context: {
       title: context.title,
       workspaceRoot: context.workspaceRoot,
       renderTargetPath: context.renderTargetPath,
+      showWelcome: context.showWelcome,
+      mode: context.mode ?? (context.showWelcome ? 'welcome' : 'ready'),
+      pendingRequestId: context.pendingRequestId ?? null,
       ready: true,
+    },
+  });
+}
+
+export function consumeDesktopBootstrapLaunchIntent(): DesktopWindowLaunchIntent | null {
+  if (typeof window === 'undefined') return null;
+  const payload = window.__OPENSCAD_STUDIO_BOOTSTRAP__ as DesktopWindowBootstrapPayload | undefined;
+  const intent = payload?.launchIntent ?? null;
+  if (payload) {
+    payload.launchIntent = null;
+  }
+  return intent;
+}
+
+export async function reportDesktopWindowOpenResult(payload: {
+  requestId: string;
+  success: boolean;
+  message?: string;
+  openedWorkspaceRoot?: string | null;
+  openedFilePath?: string | null;
+}): Promise<void> {
+  if (!isDesktopTauri()) return;
+  await invoke('report_window_open_result', {
+    payload: {
+      requestId: payload.requestId,
+      success: payload.success,
+      message: payload.message ?? null,
+      openedWorkspaceRoot: payload.openedWorkspaceRoot ?? null,
+      openedFilePath: payload.openedFilePath ?? null,
     },
   });
 }
@@ -559,5 +652,5 @@ export function buildOpenCodeMcpConfig(port: number): string {
 }
 
 export function buildAgentSnippet(port: number): string {
-  return `Use the OpenSCAD Studio MCP server at http://127.0.0.1:${port}/mcp for render-target switching, diagnostics, render refresh, preview screenshots, and exports. Read and edit files directly in the repo, then call select_workspace with the repo root before using Studio tools.`;
+  return `Use the OpenSCAD Studio MCP server at http://127.0.0.1:${port}/mcp for render-target switching, diagnostics, render refresh, preview screenshots, and exports. Read and edit files directly in the repo, then call get_or_create_workspace with the repo root before using Studio tools.`;
 }

--- a/apps/ui/src/services/desktopMcp.ts
+++ b/apps/ui/src/services/desktopMcp.ts
@@ -188,8 +188,7 @@ function textResponse(text: string, isError = false): McpToolResponse {
 }
 
 function debugLog(message: string, payload?: Record<string, unknown>) {
-  const isDev =
-    (import.meta as ImportMeta & { env?: { DEV?: boolean } }).env?.DEV ?? false;
+  const isDev = (import.meta as ImportMeta & { env?: { DEV?: boolean } }).env?.DEV ?? false;
   if (isDev) {
     console.debug(message, payload);
   }
@@ -270,7 +269,9 @@ function buildRenderRecoveryGuidance(options: { includeTriggerRender?: boolean }
   }
 
   guidance.push('Call `get_diagnostics` to inspect the current render errors and warnings.');
-  guidance.push('Call `get_project_context` to verify which file is currently set as the render target.');
+  guidance.push(
+    'Call `get_project_context` to verify which file is currently set as the render target.'
+  );
   guidance.push(
     'If the wrong file is selected, call `set_render_target` with the correct workspace-relative path.'
   );
@@ -296,10 +297,16 @@ function buildContextualRenderFailureMessage(options: {
   ].join('\n\n');
 }
 
-function buildPreviewTroubleshootingMessage(rawError: string, options: { requestedView: string }): string {
+function buildPreviewTroubleshootingMessage(
+  rawError: string,
+  options: { requestedView: string }
+): string {
   const currentRenderTargetPath = getCurrentRenderTargetPath();
   const artifact = getCurrentRenderArtifact();
-  const sections = [rawError, `Render target: ${currentRenderTargetPath ?? '(no active render target)'}`];
+  const sections = [
+    rawError,
+    `Render target: ${currentRenderTargetPath ?? '(no active render target)'}`,
+  ];
   const renderState = classifyCurrentRenderState();
 
   if (renderState === 'missing_artifact') {
@@ -359,9 +366,7 @@ function resolveRenderWaiter(requestId: number) {
   const [id, waiter] = entry;
   const artifact = getArtifactByRequestId(requestId);
   if (!artifact) {
-    waiter.reject(
-      new Error(`Render ${requestId} settled without a published render artifact.`)
-    );
+    waiter.reject(new Error(`Render ${requestId} settled without a published render artifact.`));
     clearTimeout(waiter.timeoutId);
     renderWaiters.delete(id);
     return;
@@ -443,8 +448,7 @@ async function refreshMcpRenderSnapshot(
   libraryContext: LibraryContext,
   toolName: 'trigger_render' | 'get_diagnostics' | 'export_file'
 ): Promise<
-  | { ok: true; source: string; summary: McpRenderSnapshotSummary }
-  | { ok: false; message: string }
+  { ok: true; source: string; summary: McpRenderSnapshotSummary } | { ok: false; message: string }
 > {
   const state = getProjectState();
   const renderTargetPath = normalizeProjectRelativePath(state.renderTargetPath ?? '');
@@ -844,10 +848,9 @@ async function handleExportFile(argumentsValue: Record<string, unknown>): Promis
   const source = getRenderTargetContent(state);
   if (!source) {
     return textResponse(
-      [
-        '❌ No active render target is available to export.',
-        buildRenderRecoveryGuidance(),
-      ].join('\n\n'),
+      ['❌ No active render target is available to export.', buildRenderRecoveryGuidance()].join(
+        '\n\n'
+      ),
       true
     );
   }

--- a/apps/ui/src/services/desktopMcp.ts
+++ b/apps/ui/src/services/desktopMcp.ts
@@ -243,7 +243,10 @@ async function readRenderTargetFromDisk(): Promise<string | null> {
   return result?.content ?? null;
 }
 
-async function runRenderAndWait(trigger: RenderTrigger, code?: string): Promise<RenderSnapshotLike> {
+async function runRenderAndWait(
+  trigger: RenderTrigger,
+  code?: string
+): Promise<RenderSnapshotLike> {
   const pending = waitForNextRender();
   requestRender(trigger, { immediate: true, code });
   return pending;

--- a/apps/ui/src/services/desktopMcp.ts
+++ b/apps/ui/src/services/desktopMcp.ts
@@ -228,9 +228,24 @@ function resolveNextRenderWaiter(snapshot: RenderSnapshotLike) {
   waiter.resolve(snapshot);
 }
 
-async function runRenderAndWait(trigger: RenderTrigger): Promise<RenderSnapshotLike> {
+/**
+ * Read the render target file fresh from disk, bypassing the file-watcher
+ * debounce. Used before MCP-triggered renders so that external edits (e.g.
+ * from Claude Code) are reflected immediately rather than after the 300ms
+ * debounce window.
+ */
+async function readRenderTargetFromDisk(): Promise<string | null> {
+  const state = getProjectState();
+  if (!state.renderTargetPath || !state.projectRoot) return null;
+  const { join } = await import('@tauri-apps/api/path');
+  const absolutePath = await join(state.projectRoot, state.renderTargetPath);
+  const result = await getPlatform().fileRead(absolutePath);
+  return result?.content ?? null;
+}
+
+async function runRenderAndWait(trigger: RenderTrigger, code?: string): Promise<RenderSnapshotLike> {
   const pending = waitForNextRender();
-  requestRender(trigger, { immediate: true });
+  requestRender(trigger, { immediate: true, code });
   return pending;
 }
 
@@ -291,12 +306,14 @@ async function handleSetRenderTarget(
 }
 
 async function handleDiagnostics(): Promise<McpToolResponse> {
-  const snapshot = await runRenderAndWait('manual');
+  const freshCode = await readRenderTargetFromDisk().catch(() => null);
+  const snapshot = await runRenderAndWait('manual', freshCode ?? undefined);
   return textResponse(formatDiagnostics(snapshot.diagnostics, snapshot.error));
 }
 
 async function handleTriggerRender(): Promise<McpToolResponse> {
-  const snapshot = await runRenderAndWait('manual');
+  const freshCode = await readRenderTargetFromDisk().catch(() => null);
+  const snapshot = await runRenderAndWait('manual', freshCode ?? undefined);
   return textResponse(
     `✅ Render completed for ${getProjectState().renderTargetPath ?? 'the current render target'}.\n\n${formatDiagnostics(
       snapshot.diagnostics,

--- a/apps/ui/src/services/desktopMcp.ts
+++ b/apps/ui/src/services/desktopMcp.ts
@@ -56,6 +56,8 @@ export type DesktopWindowLaunchIntent =
       request_id: string;
       folder_path: string;
       create_if_empty: boolean;
+      /** Pre-read .scad file contents from the Rust side (relative path → content). */
+      files?: Record<string, string> | null;
     }
   | { kind: 'open_file'; request_id: string; file_path: string };
 
@@ -79,6 +81,34 @@ interface InitializeDesktopMcpBridgeOptions {
 interface DesktopWindowBootstrapPayload {
   launchIntent?: DesktopWindowLaunchIntent | null;
 }
+
+function emitLocalStartupPhase(phase: string, detail?: string) {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(
+    new CustomEvent('openscad:startup-phase', {
+      detail: { phase, detail: detail ?? null },
+    })
+  );
+}
+
+export type DesktopWindowStartupPhase =
+  | 'module_loaded'
+  | 'window_error'
+  | 'unhandled_rejection'
+  | 'bootstrap_started'
+  | 'platform_initializing'
+  | 'platform_ready'
+  | 'page_load_started'
+  | 'page_load_finished'
+  | 'bridge_initializing'
+  | 'bridge_ready'
+  | 'launch_intent_consumed'
+  | 'launch_intent_none'
+  | 'open_request_started'
+  | 'open_request_succeeded'
+  | 'open_request_failed'
+  | 'welcome_ready'
+  | 'startup_error';
 
 interface McpTextContent {
   type: 'text';
@@ -132,9 +162,29 @@ const renderWaiters = new Map<
 let nextRenderWaiterId = 1;
 let bridgeUnlistenPromise: Promise<() => void> | null = null;
 
+/**
+ * Gate that resolves when <App /> mounts and the render service is ready.
+ * MCP tool handlers that need the full UI (rendering, screenshots, etc.)
+ * await this before executing.
+ */
+let _appReadyResolve: (() => void) | null = null;
+const _appReadyPromise = new Promise<void>((resolve) => {
+  _appReadyResolve = resolve;
+});
+
+/** Called by <App /> on mount to signal that the render service is available. */
+export function signalAppReady(): void {
+  _appReadyResolve?.();
+}
+
+function waitForAppReady(): Promise<void> {
+  return _appReadyPromise;
+}
+
 function isDesktopTauri(): boolean {
   return typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
 }
+
 
 function textResponse(text: string, isError = false): McpToolResponse {
   return {
@@ -210,6 +260,7 @@ function resolveNextRenderWaiter(snapshot: RenderSnapshotLike) {
 }
 
 async function runRenderAndWait(trigger: RenderTrigger): Promise<RenderSnapshotLike> {
+  await waitForAppReady();
   const pending = waitForNextRender();
   requestRender(trigger, { immediate: true });
   return pending;
@@ -259,20 +310,15 @@ async function handleSetRenderTarget(
     return textResponse(`❌ Render target not found: ${filePath}`, true);
   }
 
-  let snapshot: RenderSnapshotLike;
-  if (state.renderTargetPath === normalizedPath) {
-    snapshot = await runRenderAndWait('manual');
-  } else {
-    const pending = waitForNextRender();
+  if (state.renderTargetPath !== normalizedPath) {
     getProjectStore().getState().setRenderTarget(normalizedPath);
-    snapshot = await pending;
   }
+  requestRender('manual', { immediate: true });
 
   return textResponse(
-    `✅ Render target changed to ${normalizedPath}.\n\n${formatDiagnostics(
-      snapshot.diagnostics,
-      snapshot.error
-    )}`
+    state.renderTargetPath === normalizedPath
+      ? `✅ Render target remains ${normalizedPath}. A fresh render has been requested.`
+      : `✅ Render target changed to ${normalizedPath}. A render has been requested for the new target.`
   );
 }
 
@@ -294,6 +340,7 @@ async function handleTriggerRender(): Promise<McpToolResponse> {
 async function handlePreviewScreenshot(
   argumentsValue: Record<string, unknown>
 ): Promise<McpToolResponse> {
+  await waitForAppReady();
   const result = await capturePreviewScreenshot({
     ...buildScreenshotCallbacks(),
     view:
@@ -467,9 +514,15 @@ export async function initializeDesktopMcpBridge(
 
   if (!bridgeUnlistenPromise) {
     bridgeUnlistenPromise = (async () => {
+      emitLocalStartupPhase('desktop_mcp_bridge_begin');
       const { getCurrentWindow } = await import('@tauri-apps/api/window');
+      emitLocalStartupPhase('desktop_mcp_bridge_window_api_imported');
       const currentWindow = getCurrentWindow();
+      emitLocalStartupPhase('desktop_mcp_bridge_current_window_acquired');
+      let unlistenOpenRequest: (() => void) | null = null;
+      let unlistenFocus: (() => void) | null = null;
 
+      emitLocalStartupPhase('desktop_mcp_bridge_listen_tool_request_begin');
       const unlistenToolRequest = await currentWindow.listen<McpToolRequestPayload>(
         'mcp:tool-request',
         async (event) => {
@@ -490,15 +543,19 @@ export async function initializeDesktopMcpBridge(
           }
         }
       );
+      emitLocalStartupPhase('desktop_mcp_bridge_listen_tool_request_done');
 
-      const unlistenOpenRequest = await currentWindow.listen<DesktopWindowOpenRequestPayload>(
+      emitLocalStartupPhase('desktop_mcp_bridge_listen_open_request_begin');
+      unlistenOpenRequest = await currentWindow.listen<DesktopWindowOpenRequestPayload>(
         'desktop:open-request',
         async (event) => {
           await options.onOpenRequest?.(event.payload);
         }
       );
+      emitLocalStartupPhase('desktop_mcp_bridge_listen_open_request_done');
 
-      const unlistenFocus = await currentWindow.onFocusChanged(() => {
+      emitLocalStartupPhase('desktop_mcp_bridge_focus_hook_begin');
+      unlistenFocus = await currentWindow.onFocusChanged(() => {
         void syncDesktopMcpWindowContext({
           title: document.title || 'OpenSCAD Studio',
           workspaceRoot: getProjectState().projectRoot,
@@ -507,20 +564,35 @@ export async function initializeDesktopMcpBridge(
           mode: getWorkspaceState().showWelcome ? 'welcome' : 'ready',
         });
       });
+      emitLocalStartupPhase('desktop_mcp_bridge_focus_hook_done');
 
+      emitLocalStartupPhase('desktop_mcp_bridge_mark_ready_begin');
       await invoke('mcp_mark_window_bridge_ready');
-      await syncDesktopMcpWindowContext({
+      emitLocalStartupPhase('desktop_mcp_bridge_mark_ready_done');
+
+      emitLocalStartupPhase('desktop_mcp_bridge_sync_context_begin');
+      void syncDesktopMcpWindowContext({
         title: document.title || 'OpenSCAD Studio',
         workspaceRoot: getProjectState().projectRoot,
         renderTargetPath: getProjectState().renderTargetPath,
         showWelcome: getWorkspaceState().showWelcome,
         mode: getWorkspaceState().showWelcome ? 'welcome' : 'ready',
-      });
+      })
+        .then(() => {
+          emitLocalStartupPhase('desktop_mcp_bridge_sync_context_done');
+        })
+        .catch((error) => {
+          emitLocalStartupPhase(
+            'desktop_mcp_bridge_sync_context_failed',
+            error instanceof Error ? error.message : String(error)
+          );
+          console.error('[desktopMcp] Initial syncDesktopMcpWindowContext failed:', error);
+        });
 
       return () => {
         unlistenToolRequest();
-        unlistenOpenRequest();
-        unlistenFocus();
+        unlistenOpenRequest?.();
+        unlistenFocus?.();
       };
     })();
   }
@@ -611,6 +683,19 @@ export async function reportDesktopWindowOpenResult(payload: {
       message: payload.message ?? null,
       openedWorkspaceRoot: payload.openedWorkspaceRoot ?? null,
       openedFilePath: payload.openedFilePath ?? null,
+    },
+  });
+}
+
+export async function reportDesktopWindowStartupPhase(payload: {
+  phase: DesktopWindowStartupPhase;
+  detail?: string | null;
+}): Promise<void> {
+  if (!isDesktopTauri()) return;
+  await invoke('mcp_report_window_startup_phase', {
+    payload: {
+      phase: payload.phase,
+      detail: payload.detail ?? null,
     },
   });
 }

--- a/apps/ui/src/services/desktopMcp.ts
+++ b/apps/ui/src/services/desktopMcp.ts
@@ -1,12 +1,7 @@
 import { invoke } from '@tauri-apps/api/core';
 import { getRenderService, type Diagnostic, type ExportFormat } from './renderService';
-import { FALLBACK_PREVIEW_SCENE_STYLE, type PreviewSceneStyle } from './previewSceneConfig';
-import { captureCurrentPreview } from '../utils/capturePreview';
-import {
-  buildProjectContextSummary,
-  capturePreviewScreenshot,
-  type PreviewScreenshotOptions,
-} from './studioTooling';
+import { captureOffscreen, type PresetView } from './offscreenRenderer';
+import { buildProjectContextSummary } from './studioTooling';
 import {
   getAuxiliaryFilesForRender,
   getProjectState,
@@ -20,10 +15,19 @@ import { loadSettings } from '../stores/settingsStore';
 import { requestRender } from '../stores/renderRequestStore';
 import { getWorkspaceState } from '../stores/workspaceStore';
 import { normalizeProjectRelativePath } from '../utils/projectFilePaths';
-import { resolveWorkingDirDeps } from '../utils/resolveWorkingDirDeps';
-
-type PreviewKind = 'mesh' | 'svg';
+import {
+  resolveWorkingDirDeps,
+  resolveWorkingDirDepsDetailed,
+} from '../utils/resolveWorkingDirDeps';
+import {
+  getArtifactByRequestId,
+  getLatestArtifactForTarget,
+  getRenderArtifactDebugState,
+  getRenderArtifactState,
+  type RenderArtifact,
+} from '../stores/renderArtifactStore';
 type RenderTrigger = Parameters<typeof requestRender>[0];
+type McpScreenshotView = Exclude<PresetView, 'current'>;
 
 export type McpServerState = 'starting' | 'running' | 'disabled' | 'port_conflict' | 'error';
 
@@ -117,11 +121,25 @@ interface McpToolResponse {
   isError?: boolean;
 }
 
-interface RenderSnapshotLike {
-  previewSrc: string;
-  previewKind: PreviewKind;
-  diagnostics: Diagnostic[];
-  error: string;
+type RenderStateClassification =
+  | 'missing_render_target'
+  | 'missing_artifact'
+  | 'render_error'
+  | 'diagnostic_error'
+  | 'unavailable_preview'
+  | 'success';
+
+interface LibraryContext {
+  libraryFiles: Record<string, string>;
+  libraryPaths: string[];
+}
+
+interface McpRenderSnapshotSummary {
+  renderTargetPath: string;
+  dirtyPaths: string[];
+  refreshedPaths: string[];
+  dependencyCount: number;
+  diskReadCount: number;
 }
 
 const DEFAULT_STATUS: McpServerStatus = {
@@ -136,18 +154,25 @@ function isDesktopTauri(): boolean {
   return typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
 }
 
-const previewState = {
-  previewKind: 'mesh' as PreviewKind,
-  previewSrc: '',
-  previewViewerId: null as string | null,
-  previewSceneStyle: FALLBACK_PREVIEW_SCENE_STYLE as PreviewSceneStyle,
-  useModelColors: true,
+const libraryContextCache = {
+  key: '',
+  value: null as LibraryContext | null,
 };
+const MCP_SCREENSHOT_VIEWS = new Set<McpScreenshotView>([
+  'front',
+  'back',
+  'top',
+  'bottom',
+  'left',
+  'right',
+  'isometric',
+]);
 
 const renderWaiters = new Map<
   number,
   {
-    resolve: (snapshot: RenderSnapshotLike) => void;
+    requestId: number | null;
+    resolve: (artifact: RenderArtifact) => void;
     reject: (error: Error) => void;
     timeoutId: ReturnType<typeof setTimeout>;
   }
@@ -162,25 +187,12 @@ function textResponse(text: string, isError = false): McpToolResponse {
   };
 }
 
-function buildScreenshotCallbacks(): Omit<
-  PreviewScreenshotOptions,
-  'view' | 'azimuth' | 'elevation'
-> {
-  return {
-    captureCurrentView: async () =>
-      captureCurrentPreview({
-        viewerId: previewState.previewViewerId,
-        svgSourceUrl: previewState.previewKind === 'svg' ? previewState.previewSrc : null,
-        targetWidth: 1200,
-        targetHeight: 630,
-      }),
-    get3dPreviewUrl: () =>
-      previewState.previewKind === 'mesh' && previewState.previewSrc
-        ? previewState.previewSrc
-        : null,
-    getPreviewSceneStyle: () => previewState.previewSceneStyle,
-    getUseModelColors: () => previewState.useModelColors,
-  };
+function debugLog(message: string, payload?: Record<string, unknown>) {
+  const isDev =
+    (import.meta as ImportMeta & { env?: { DEV?: boolean } }).env?.DEV ?? false;
+  if (isDev) {
+    console.debug(message, payload);
+  }
 }
 
 function formatDiagnostics(diagnostics: Diagnostic[], renderError = ''): string {
@@ -206,50 +218,351 @@ function formatDiagnostics(diagnostics: Diagnostic[], renderError = ''): string 
   return `Render state: ${renderError}`;
 }
 
-function waitForNextRender(timeoutMs = 20000): Promise<RenderSnapshotLike> {
-  return new Promise<RenderSnapshotLike>((resolve, reject) => {
+function hasErrorDiagnostics(diagnostics: Diagnostic[]): boolean {
+  return diagnostics.some((diagnostic) => diagnostic.severity === 'error');
+}
+
+function getCurrentRenderTargetPath(): string | null {
+  return normalizeProjectRelativePath(getProjectState().renderTargetPath ?? '');
+}
+
+function getCurrentRenderTargetLabel(): string {
+  return getCurrentRenderTargetPath() ?? '(no active render target)';
+}
+
+function getCurrentRenderArtifact(): RenderArtifact | null {
+  return getLatestArtifactForTarget(getCurrentRenderTargetPath());
+}
+
+function classifyCurrentRenderState(): RenderStateClassification {
+  const artifact = getCurrentRenderArtifact();
+
+  if (!getCurrentRenderTargetPath()) {
+    return 'missing_render_target';
+  }
+
+  if (!artifact) {
+    return 'missing_artifact';
+  }
+
+  if (artifact.error) {
+    return 'render_error';
+  }
+
+  if (hasErrorDiagnostics(artifact.diagnostics)) {
+    return 'diagnostic_error';
+  }
+
+  if (!artifact.previewSrc) {
+    return 'unavailable_preview';
+  }
+
+  return 'success';
+}
+
+function buildRenderRecoveryGuidance(options: { includeTriggerRender?: boolean } = {}): string {
+  const guidance: string[] = [];
+
+  if (!getProjectState().projectRoot) {
+    guidance.push(
+      'If no workspace is attached, call `get_or_create_workspace(folder_path)` for the correct repo root first.'
+    );
+  }
+
+  guidance.push('Call `get_diagnostics` to inspect the current render errors and warnings.');
+  guidance.push('Call `get_project_context` to verify which file is currently set as the render target.');
+  guidance.push(
+    'If the wrong file is selected, call `set_render_target` with the correct workspace-relative path.'
+  );
+
+  if (options.includeTriggerRender) {
+    guidance.push('After correcting the issue, rerun `trigger_render`.');
+  }
+
+  return `Next steps:\n- ${guidance.join('\n- ')}`;
+}
+
+function buildContextualRenderFailureMessage(options: {
+  title: string;
+  includeTriggerRender?: boolean;
+}): string {
+  const artifact = getCurrentRenderArtifact();
+  const detail = formatDiagnostics(artifact?.diagnostics ?? [], artifact?.error ?? '');
+  return [
+    `❌ ${options.title}`,
+    `Render target: ${getCurrentRenderTargetLabel()}`,
+    detail,
+    buildRenderRecoveryGuidance({ includeTriggerRender: options.includeTriggerRender }),
+  ].join('\n\n');
+}
+
+function buildPreviewTroubleshootingMessage(rawError: string, options: { requestedView: string }): string {
+  const currentRenderTargetPath = getCurrentRenderTargetPath();
+  const artifact = getCurrentRenderArtifact();
+  const sections = [rawError, `Render target: ${currentRenderTargetPath ?? '(no active render target)'}`];
+  const renderState = classifyCurrentRenderState();
+
+  if (renderState === 'missing_artifact') {
+    sections.push('No settled render artifact is available yet for the current render target.');
+  }
+
+  if (renderState === 'render_error' || renderState === 'diagnostic_error') {
+    sections.push(formatDiagnostics(artifact?.diagnostics ?? [], artifact?.error ?? ''));
+  } else if (artifact?.previewKind === 'svg') {
+    sections.push(
+      `The latest settled render produced a 2D SVG preview, so the explicit ${options.requestedView} view is unavailable.`
+    );
+  }
+
+  sections.push(buildRenderRecoveryGuidance({ includeTriggerRender: true }));
+
+  return sections.join('\n\n');
+}
+
+function buildMissingRenderTargetMessage(toolName: string): string {
+  return [
+    `❌ ${toolName} requires an active render target, but none is currently selected.`,
+    buildRenderRecoveryGuidance({ includeTriggerRender: toolName === 'trigger_render' }),
+  ].join('\n\n');
+}
+
+function waitForNextRender(timeoutMs = 20000): Promise<RenderArtifact> {
+  return new Promise<RenderArtifact>((resolve, reject) => {
     const id = nextRenderWaiterId++;
     const timeoutId = setTimeout(() => {
       renderWaiters.delete(id);
       reject(new Error('Timed out waiting for Studio to finish rendering.'));
     }, timeoutMs);
 
-    renderWaiters.set(id, { resolve, reject, timeoutId });
+    renderWaiters.set(id, { requestId: null, resolve, reject, timeoutId });
   });
 }
 
-function resolveNextRenderWaiter(snapshot: RenderSnapshotLike) {
-  const firstEntry = renderWaiters.entries().next();
-  if (firstEntry.done) return;
+function attachRequestIdToNextRenderWaiter(requestId: number) {
+  const firstEntry = [...renderWaiters.entries()].find(([, waiter]) => waiter.requestId === null);
+  if (!firstEntry) {
+    return;
+  }
+  const [id, waiter] = firstEntry;
+  renderWaiters.set(id, {
+    ...waiter,
+    requestId,
+  });
+}
 
-  const [id, waiter] = firstEntry.value;
+function resolveRenderWaiter(requestId: number) {
+  const entry = [...renderWaiters.entries()].find(([, waiter]) => waiter.requestId === requestId);
+  if (!entry) {
+    return;
+  }
+
+  const [id, waiter] = entry;
+  const artifact = getArtifactByRequestId(requestId);
+  if (!artifact) {
+    waiter.reject(
+      new Error(`Render ${requestId} settled without a published render artifact.`)
+    );
+    clearTimeout(waiter.timeoutId);
+    renderWaiters.delete(id);
+    return;
+  }
+
   clearTimeout(waiter.timeoutId);
   renderWaiters.delete(id);
-  waiter.resolve(snapshot);
+  waiter.resolve(artifact);
 }
 
-/**
- * Read the render target file fresh from disk, bypassing the file-watcher
- * debounce. Used before MCP-triggered renders so that external edits (e.g.
- * from Claude Code) are reflected immediately rather than after the 300ms
- * debounce window.
- */
-async function readRenderTargetFromDisk(): Promise<string | null> {
-  const state = getProjectState();
-  if (!state.renderTargetPath || !state.projectRoot) return null;
-  const { join } = await import('@tauri-apps/api/path');
-  const absolutePath = await join(state.projectRoot, state.renderTargetPath);
-  const result = await getPlatform().fileRead(absolutePath);
-  return result?.content ?? null;
-}
-
-async function runRenderAndWait(
-  trigger: RenderTrigger,
-  code?: string
-): Promise<RenderSnapshotLike> {
+async function runRenderAndWait(trigger: RenderTrigger, code?: string): Promise<RenderArtifact> {
   const pending = waitForNextRender();
   requestRender(trigger, { immediate: true, code });
   return pending;
+}
+
+function buildAllProjectFiles(state = getProjectState()): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(state.files).map(([path, file]) => [path, file.content])
+  );
+}
+
+function buildDirtyProjectFiles(state = getProjectState()): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(state.files)
+      .filter(([, file]) => file.isDirty)
+      .map(([path, file]) => [path, file.content])
+  );
+}
+
+function buildSnapshotUsageNote(summary: McpRenderSnapshotSummary): string | null {
+  if (summary.dirtyPaths.length === 0) {
+    return null;
+  }
+
+  const listedPaths = summary.dirtyPaths.slice(0, 3).join(', ');
+  const extraCount = summary.dirtyPaths.length - Math.min(summary.dirtyPaths.length, 3);
+  const suffix = extraCount > 0 ? `, plus ${extraCount} more` : '';
+
+  return `Snapshot note: used unsaved Studio edits for ${listedPaths}${suffix}.`;
+}
+
+async function refreshFileInStore(relativePath: string, content: string) {
+  const store = getProjectStore().getState();
+  const file = getProjectState().files[relativePath];
+
+  if (file) {
+    if (file.isDirty) {
+      return false;
+    }
+    if (file.content !== content) {
+      store.updateFileContent(relativePath, content);
+      store.markFileSaved(relativePath, content);
+      return true;
+    }
+    return false;
+  }
+
+  store.addFile(relativePath, content, { isVirtual: false });
+  store.markFileSaved(relativePath, content);
+  return true;
+}
+
+function buildSnapshotRefreshFailureMessage(
+  toolName: 'trigger_render' | 'get_diagnostics' | 'export_file',
+  renderTargetPath: string,
+  reason: string,
+  extraDetails: string[] = []
+): string {
+  return [
+    `❌ Could not refresh the MCP render snapshot for ${renderTargetPath}.`,
+    reason,
+    ...extraDetails,
+    buildRenderRecoveryGuidance({ includeTriggerRender: toolName === 'trigger_render' }),
+  ].join('\n\n');
+}
+
+async function refreshMcpRenderSnapshot(
+  libraryContext: LibraryContext,
+  toolName: 'trigger_render' | 'get_diagnostics' | 'export_file'
+): Promise<
+  | { ok: true; source: string; summary: McpRenderSnapshotSummary }
+  | { ok: false; message: string }
+> {
+  const state = getProjectState();
+  const renderTargetPath = normalizeProjectRelativePath(state.renderTargetPath ?? '');
+  const workingDir = getProjectWorkingDirectory(state);
+
+  if (!renderTargetPath) {
+    return {
+      ok: false,
+      message: buildMissingRenderTargetMessage(toolName),
+    };
+  }
+
+  if (!workingDir) {
+    const source = getRenderTargetContent(state);
+    if (!source) {
+      return {
+        ok: false,
+        message: buildMissingRenderTargetMessage(toolName),
+      };
+    }
+
+    return {
+      ok: true,
+      source,
+      summary: {
+        renderTargetPath,
+        dirtyPaths: [],
+        refreshedPaths: [],
+        dependencyCount: 0,
+        diskReadCount: 0,
+      },
+    };
+  }
+
+  const targetFile = state.files[renderTargetPath];
+  if (!targetFile) {
+    return {
+      ok: false,
+      message: buildMissingRenderTargetMessage(toolName),
+    };
+  }
+
+  const { join } = await import('@tauri-apps/api/path');
+  const platform = getPlatform();
+  const dirtyProjectFiles = buildDirtyProjectFiles(state);
+  const dirtyPaths = Object.keys(dirtyProjectFiles).sort((a, b) => a.localeCompare(b));
+  const refreshedPaths: string[] = [];
+
+  let source = targetFile.content;
+  if (!targetFile.isDirty) {
+    const absolutePath = await join(workingDir, renderTargetPath);
+    const diskContent = await platform.readTextFile(absolutePath);
+    if (diskContent === null) {
+      return {
+        ok: false,
+        message: buildSnapshotRefreshFailureMessage(
+          toolName,
+          renderTargetPath,
+          `Studio could not read the render target from disk at ${absolutePath}.`
+        ),
+      };
+    }
+
+    source = diskContent;
+    if (await refreshFileInStore(renderTargetPath, diskContent)) {
+      refreshedPaths.push(renderTargetPath);
+    }
+  }
+
+  const renderTargetDir = renderTargetPath.includes('/')
+    ? renderTargetPath.slice(0, renderTargetPath.lastIndexOf('/'))
+    : undefined;
+  const resolved = await resolveWorkingDirDepsDetailed(source, {
+    workingDir,
+    libraryFiles: libraryContext.libraryFiles,
+    platform,
+    projectFiles: buildAllProjectFiles(state),
+    dirtyProjectFiles,
+    renderTargetDir,
+    preferDiskForProjectFiles: true,
+    includeProjectFilesAsFallback: false,
+  });
+
+  if (resolved.missingPaths.length > 0) {
+    return {
+      ok: false,
+      message: buildSnapshotRefreshFailureMessage(
+        toolName,
+        renderTargetPath,
+        'Studio could not refresh one or more included files from disk.',
+        [`Missing dependencies: ${resolved.missingPaths.join(', ')}`]
+      ),
+    };
+  }
+
+  for (const [path, content] of Object.entries(resolved.files)) {
+    if (await refreshFileInStore(path, content)) {
+      refreshedPaths.push(path);
+    }
+  }
+
+  const summary: McpRenderSnapshotSummary = {
+    renderTargetPath,
+    dirtyPaths,
+    refreshedPaths: [...new Set(refreshedPaths)].sort((a, b) => a.localeCompare(b)),
+    dependencyCount: Object.keys(resolved.files).length,
+    diskReadCount: resolved.stats.diskReads,
+  };
+
+  debugLog('[desktopMcp] Refreshed MCP render snapshot', {
+    renderTargetPath,
+    dependencyCount: summary.dependencyCount,
+    diskReadCount: summary.diskReadCount,
+    dirtyOverrideCount: summary.dirtyPaths.length,
+    refreshedFileCount: summary.refreshedPaths.length,
+  });
+
+  return { ok: true, source, summary };
 }
 
 async function handleProjectContext(): Promise<McpToolResponse> {
@@ -299,6 +612,7 @@ async function handleSetRenderTarget(
   if (state.renderTargetPath !== normalizedPath) {
     getProjectStore().getState().setRenderTarget(normalizedPath);
   }
+  getRenderArtifactState().setActiveRenderTarget(normalizedPath, state.projectRoot);
   requestRender('manual', { immediate: true });
 
   return textResponse(
@@ -309,44 +623,141 @@ async function handleSetRenderTarget(
 }
 
 async function handleDiagnostics(): Promise<McpToolResponse> {
-  const freshCode = await readRenderTargetFromDisk().catch(() => null);
-  const snapshot = await runRenderAndWait('manual', freshCode ?? undefined);
-  return textResponse(formatDiagnostics(snapshot.diagnostics, snapshot.error));
+  if (!getCurrentRenderTargetPath()) {
+    return textResponse(buildMissingRenderTargetMessage('get_diagnostics'), true);
+  }
+
+  const libraryContext = await loadLibraryExportContext();
+  const refresh = await refreshMcpRenderSnapshot(libraryContext, 'get_diagnostics');
+  if (!refresh.ok) {
+    return textResponse(refresh.message, true);
+  }
+
+  const artifact = await runRenderAndWait('manual', refresh.source);
+  const snapshotNote = buildSnapshotUsageNote(refresh.summary);
+  return textResponse(
+    [
+      `Diagnostics for render target: ${getCurrentRenderTargetLabel()}`,
+      snapshotNote,
+      formatDiagnostics(artifact.diagnostics, artifact.error),
+    ]
+      .filter(Boolean)
+      .join('\n\n')
+  );
 }
 
 async function handleTriggerRender(): Promise<McpToolResponse> {
-  const freshCode = await readRenderTargetFromDisk().catch(() => null);
-  const snapshot = await runRenderAndWait('manual', freshCode ?? undefined);
+  if (!getCurrentRenderTargetPath()) {
+    return textResponse(buildMissingRenderTargetMessage('trigger_render'), true);
+  }
+
+  const libraryContext = await loadLibraryExportContext();
+  const refresh = await refreshMcpRenderSnapshot(libraryContext, 'trigger_render');
+  if (!refresh.ok) {
+    return textResponse(refresh.message, true);
+  }
+
+  const artifact = await runRenderAndWait('manual', refresh.source);
+  const targetLabel = getCurrentRenderTargetLabel();
+  const diagnosticsText = formatDiagnostics(artifact.diagnostics, artifact.error);
+  const hasFailure = Boolean(artifact.error) || hasErrorDiagnostics(artifact.diagnostics);
+  const snapshotNote = buildSnapshotUsageNote(refresh.summary);
+
+  if (hasFailure) {
+    return textResponse(
+      [
+        `❌ Render failed for ${targetLabel}.`,
+        diagnosticsText,
+        snapshotNote,
+        buildRenderRecoveryGuidance({ includeTriggerRender: true }),
+      ]
+        .filter(Boolean)
+        .join('\n\n'),
+      true
+    );
+  }
+
   return textResponse(
-    `✅ Render completed for ${getProjectState().renderTargetPath ?? 'the current render target'}.\n\n${formatDiagnostics(
-      snapshot.diagnostics,
-      snapshot.error
-    )}`
+    [`✅ Render completed for ${targetLabel}.`, diagnosticsText, snapshotNote]
+      .filter(Boolean)
+      .join('\n\n')
   );
 }
 
 async function handlePreviewScreenshot(
   argumentsValue: Record<string, unknown>
 ): Promise<McpToolResponse> {
-  const result = await capturePreviewScreenshot({
-    ...buildScreenshotCallbacks(),
-    view:
-      typeof argumentsValue.view === 'string'
-        ? (argumentsValue.view as PreviewScreenshotOptions['view'])
-        : 'current',
-    azimuth:
-      typeof argumentsValue.azimuth === 'number' ? (argumentsValue.azimuth as number) : undefined,
-    elevation:
-      typeof argumentsValue.elevation === 'number'
-        ? (argumentsValue.elevation as number)
-        : undefined,
-  });
+  const viewValue = typeof argumentsValue.view === 'string' ? argumentsValue.view : null;
+  if (!viewValue) {
+    return textResponse(
+      '`get_preview_screenshot` requires an explicit `view` argument: front, back, top, bottom, left, right, or isometric.',
+      true
+    );
+  }
+  if (!MCP_SCREENSHOT_VIEWS.has(viewValue as McpScreenshotView)) {
+    return textResponse(
+      `Unsupported screenshot view: ${viewValue}. Use one of: front, back, top, bottom, left, right, or isometric.`,
+      true
+    );
+  }
+  const requestedView = viewValue as McpScreenshotView;
 
-  if (result.error) {
-    return textResponse(result.error, true);
+  const artifact = getCurrentRenderArtifact();
+  if (!artifact) {
+    return textResponse(
+      buildPreviewTroubleshootingMessage(
+        'No settled render artifact is available for the current render target.',
+        { requestedView }
+      ),
+      true
+    );
   }
 
-  const dataUrl = result.image_data_url ?? '';
+  if (artifact.previewKind !== 'mesh' || !artifact.previewSrc) {
+    return textResponse(
+      buildPreviewTroubleshootingMessage(
+        'A 3D preview is required for MCP screenshots with explicit views.',
+        { requestedView }
+      ),
+      true
+    );
+  }
+
+  debugLog('[desktopMcp] Capturing screenshot from render artifact', {
+    requestedView,
+    artifact: {
+      artifactId: artifact.artifactId,
+      renderTargetPath: artifact.renderTargetPath,
+      requestId: artifact.requestId,
+      previewKind: artifact.previewKind,
+      createdAt: artifact.createdAt,
+    },
+    store: getRenderArtifactDebugState(),
+  });
+
+  let dataUrl = '';
+  try {
+    dataUrl = await captureOffscreen(artifact.previewSrc, {
+      view: requestedView,
+      azimuth:
+        typeof argumentsValue.azimuth === 'number' ? (argumentsValue.azimuth as number) : undefined,
+      elevation:
+        typeof argumentsValue.elevation === 'number'
+          ? (argumentsValue.elevation as number)
+          : undefined,
+      sceneStyle: artifact.sceneStyle,
+      useModelColors: artifact.useModelColors,
+    });
+  } catch (error) {
+    return textResponse(
+      buildPreviewTroubleshootingMessage(
+        `Failed to capture screenshot: ${error instanceof Error ? error.message : String(error)}`,
+        { requestedView }
+      ),
+      true
+    );
+  }
+
   const base64 = dataUrl.replace(/^data:image\/png;base64,/, '');
   return {
     content: [
@@ -374,11 +785,21 @@ async function resolveExportDestination(filePath: string): Promise<string | null
   return join(projectRoot, filePath);
 }
 
-async function loadLibraryExportContext() {
+async function loadLibraryExportContext(): Promise<LibraryContext> {
   const platform = getPlatform();
   const settings = loadSettings();
   const systemPaths = settings.library.autoDiscoverSystem ? await platform.getLibraryPaths() : [];
   const libraryPaths = [...systemPaths, ...settings.library.customPaths];
+  const cacheKey = JSON.stringify({
+    autoDiscoverSystem: settings.library.autoDiscoverSystem,
+    customPaths: [...settings.library.customPaths].sort((a, b) => a.localeCompare(b)),
+    systemPaths: [...systemPaths].sort((a, b) => a.localeCompare(b)),
+  });
+
+  if (libraryContextCache.value && libraryContextCache.key === cacheKey) {
+    return libraryContextCache.value;
+  }
+
   const libraryFiles: Record<string, string> = {};
 
   for (const libPath of libraryPaths) {
@@ -390,7 +811,10 @@ async function loadLibraryExportContext() {
     }
   }
 
-  return { libraryFiles, libraryPaths };
+  const context = { libraryFiles, libraryPaths };
+  libraryContextCache.key = cacheKey;
+  libraryContextCache.value = context;
+  return context;
 }
 
 async function handleExportFile(argumentsValue: Record<string, unknown>): Promise<McpToolResponse> {
@@ -410,10 +834,34 @@ async function handleExportFile(argumentsValue: Record<string, unknown>): Promis
     return textResponse('`export_file` requires a `file_path` argument.', true);
   }
 
+  const libraryContext = await loadLibraryExportContext();
+  const refresh = await refreshMcpRenderSnapshot(libraryContext, 'export_file');
+  if (!refresh.ok) {
+    return textResponse(refresh.message, true);
+  }
+
   const state = getProjectState();
   const source = getRenderTargetContent(state);
   if (!source) {
-    return textResponse('❌ No active render target is available to export.', true);
+    return textResponse(
+      [
+        '❌ No active render target is available to export.',
+        buildRenderRecoveryGuidance(),
+      ].join('\n\n'),
+      true
+    );
+  }
+
+  const renderState = classifyCurrentRenderState();
+  const snapshotChanged =
+    refresh.summary.refreshedPaths.length > 0 || refresh.summary.dirtyPaths.length > 0;
+  if (!snapshotChanged && (renderState === 'render_error' || renderState === 'diagnostic_error')) {
+    return textResponse(
+      buildContextualRenderFailureMessage({
+        title: `Cannot export ${format?.toUpperCase() ?? 'the current render target'} because the latest render failed.`,
+      }),
+      true
+    );
   }
 
   const resolvedPath = await resolveExportDestination(filePath);
@@ -426,13 +874,13 @@ async function handleExportFile(argumentsValue: Record<string, unknown>): Promis
 
   const projectFiles = getAuxiliaryFilesForRender(state);
   const workingDir = getProjectWorkingDirectory(state);
-  const renderTargetPath = state.renderTargetPath ?? undefined;
+  const renderTargetPath = getCurrentRenderTargetPath() ?? undefined;
   const renderTargetDir =
     renderTargetPath && renderTargetPath.includes('/')
       ? renderTargetPath.slice(0, renderTargetPath.lastIndexOf('/'))
       : undefined;
 
-  const { libraryFiles, libraryPaths } = await loadLibraryExportContext();
+  const { libraryFiles, libraryPaths } = libraryContext;
   let projectAuxFiles: Record<string, string> = { ...projectFiles };
 
   if (workingDir) {
@@ -464,7 +912,12 @@ async function handleExportFile(argumentsValue: Record<string, unknown>): Promis
   await mkdir(parentDir, { recursive: true });
   await writeFile(resolvedPath, exportBytes);
 
-  return textResponse(`✅ Exported ${format.toUpperCase()} to ${resolvedPath}`);
+  const snapshotNote = buildSnapshotUsageNote(refresh.summary);
+  return textResponse(
+    [`✅ Exported ${format.toUpperCase()} to ${resolvedPath}`, snapshotNote]
+      .filter(Boolean)
+      .join('\n\n')
+  );
 }
 
 async function executeToolRequest(payload: McpToolRequestPayload): Promise<McpToolResponse> {
@@ -571,28 +1024,34 @@ export async function initializeDesktopMcpBridge(
   };
 }
 
-export function updateDesktopMcpPreviewState({
-  previewKind,
-  previewSrc,
-  previewViewerId,
-  previewSceneStyle,
-  useModelColors,
-}: {
-  previewKind: PreviewKind;
-  previewSrc: string;
-  previewViewerId: string | null;
-  previewSceneStyle: PreviewSceneStyle;
-  useModelColors: boolean;
+export function notifyDesktopMcpRenderStarted(payload: {
+  renderTargetPath: string;
+  requestId: number;
 }) {
-  previewState.previewKind = previewKind;
-  previewState.previewSrc = previewSrc;
-  previewState.previewViewerId = previewViewerId;
-  previewState.previewSceneStyle = previewSceneStyle;
-  previewState.useModelColors = useModelColors;
+  getRenderArtifactState().markRenderStarted(payload.renderTargetPath, payload.requestId);
+  attachRequestIdToNextRenderWaiter(payload.requestId);
 }
 
-export function notifyDesktopMcpRenderSettled(snapshot: RenderSnapshotLike) {
-  resolveNextRenderWaiter(snapshot);
+export function notifyDesktopMcpRenderSettled(requestId: number | null) {
+  if (requestId === null) {
+    return;
+  }
+  resolveRenderWaiter(requestId);
+}
+
+export async function __executeDesktopMcpToolRequestForTests(
+  payload: McpToolRequestPayload
+): Promise<McpToolResponse> {
+  return executeToolRequest(payload);
+}
+
+export function __resetDesktopMcpStateForTests() {
+  getRenderArtifactState().reset();
+  for (const [id, waiter] of renderWaiters.entries()) {
+    clearTimeout(waiter.timeoutId);
+    waiter.reject(new Error('Desktop MCP test state reset before render settled.'));
+    renderWaiters.delete(id);
+  }
 }
 
 export async function syncDesktopMcpConfig(config: {

--- a/apps/ui/src/services/desktopMcp.ts
+++ b/apps/ui/src/services/desktopMcp.ts
@@ -1,0 +1,376 @@
+import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
+import type { Diagnostic } from './renderService';
+import { FALLBACK_PREVIEW_SCENE_STYLE, type PreviewSceneStyle } from './previewSceneConfig';
+import { captureCurrentPreview } from '../utils/capturePreview';
+import {
+  buildProjectContextSummary,
+  capturePreviewScreenshot,
+  type PreviewScreenshotOptions,
+} from './studioTooling';
+import {
+  getProjectState,
+  getProjectStore,
+  getRenderTargetContent,
+  listProjectFiles as listProjectFilesFromState,
+} from '../stores/projectStore';
+import { requestRender } from '../stores/renderRequestStore';
+import { normalizeProjectRelativePath } from '../utils/projectFilePaths';
+
+type PreviewKind = 'mesh' | 'svg';
+type RenderTrigger = Parameters<typeof requestRender>[0];
+
+export type McpServerState = 'starting' | 'running' | 'disabled' | 'port_conflict' | 'error';
+
+export interface McpServerStatus {
+  enabled: boolean;
+  port: number;
+  status: McpServerState;
+  endpoint: string | null;
+  message: string | null;
+}
+
+interface McpToolRequestPayload {
+  requestId: string;
+  toolName: string;
+  arguments?: Record<string, unknown>;
+}
+
+interface McpTextContent {
+  type: 'text';
+  text: string;
+}
+
+interface McpImageContent {
+  type: 'image';
+  data: string;
+  mimeType: 'image/png';
+}
+
+type McpContent = McpTextContent | McpImageContent;
+
+interface McpToolResponse {
+  content: McpContent[];
+  isError?: boolean;
+}
+
+interface RenderSnapshotLike {
+  previewSrc: string;
+  previewKind: PreviewKind;
+  diagnostics: Diagnostic[];
+  error: string;
+}
+
+const DEFAULT_STATUS: McpServerStatus = {
+  enabled: true,
+  port: 32123,
+  status: 'disabled',
+  endpoint: null,
+  message: null,
+};
+
+const previewState = {
+  previewKind: 'mesh' as PreviewKind,
+  previewSrc: '',
+  previewSceneStyle: FALLBACK_PREVIEW_SCENE_STYLE as PreviewSceneStyle,
+  useModelColors: true,
+};
+
+const renderWaiters = new Map<
+  number,
+  {
+    resolve: (snapshot: RenderSnapshotLike) => void;
+    reject: (error: Error) => void;
+    timeoutId: ReturnType<typeof setTimeout>;
+  }
+>();
+let nextRenderWaiterId = 1;
+let bridgeUnlistenPromise: Promise<() => void> | null = null;
+
+function isDesktopTauri(): boolean {
+  return typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
+}
+
+function textResponse(text: string, isError = false): McpToolResponse {
+  return {
+    content: [{ type: 'text', text }],
+    isError,
+  };
+}
+
+function buildScreenshotCallbacks(): Omit<
+  PreviewScreenshotOptions,
+  'view' | 'azimuth' | 'elevation'
+> {
+  return {
+    captureCurrentView: async () =>
+      captureCurrentPreview({
+        svgSourceUrl: previewState.previewKind === 'svg' ? previewState.previewSrc : null,
+        targetWidth: 1200,
+        targetHeight: 630,
+      }),
+    get3dPreviewUrl: () =>
+      previewState.previewKind === 'mesh' && previewState.previewSrc
+        ? previewState.previewSrc
+        : null,
+    getPreviewSceneStyle: () => previewState.previewSceneStyle,
+    getUseModelColors: () => previewState.useModelColors,
+  };
+}
+
+function formatDiagnostics(diagnostics: Diagnostic[], renderError = ''): string {
+  if (diagnostics.length === 0 && !renderError) {
+    return '✅ No errors or warnings. The current render target compiled successfully.';
+  }
+
+  const formatted = diagnostics
+    .map((d) => {
+      const severity =
+        d.severity === 'error' ? 'Error' : d.severity === 'warning' ? 'Warning' : 'Info';
+      const location = d.line ? ` (line ${d.line}${d.col ? `, col ${d.col}` : ''})` : '';
+      return `[${severity}]${location}: ${d.message}`;
+    })
+    .join('\n');
+
+  if (formatted && renderError) {
+    return `Render diagnostics:\n\n${formatted}\n\nRender state: ${renderError}`;
+  }
+  if (formatted) {
+    return `Render diagnostics:\n\n${formatted}`;
+  }
+  return `Render state: ${renderError}`;
+}
+
+function waitForNextRender(timeoutMs = 20000): Promise<RenderSnapshotLike> {
+  return new Promise<RenderSnapshotLike>((resolve, reject) => {
+    const id = nextRenderWaiterId++;
+    const timeoutId = setTimeout(() => {
+      renderWaiters.delete(id);
+      reject(new Error('Timed out waiting for Studio to finish rendering.'));
+    }, timeoutMs);
+
+    renderWaiters.set(id, { resolve, reject, timeoutId });
+  });
+}
+
+function resolveNextRenderWaiter(snapshot: RenderSnapshotLike) {
+  const firstEntry = renderWaiters.entries().next();
+  if (firstEntry.done) return;
+
+  const [id, waiter] = firstEntry.value;
+  clearTimeout(waiter.timeoutId);
+  renderWaiters.delete(id);
+  waiter.resolve(snapshot);
+}
+
+async function runRenderAndWait(trigger: RenderTrigger): Promise<RenderSnapshotLike> {
+  const pending = waitForNextRender();
+  requestRender(trigger, { immediate: true });
+  return pending;
+}
+
+async function handleProjectContext(): Promise<McpToolResponse> {
+  const state = getProjectState();
+  const renderTarget = state.renderTargetPath;
+  const summary = buildProjectContextSummary({
+    renderTarget,
+    renderTargetContent: getRenderTargetContent(state),
+    allFiles: listProjectFilesFromState(state),
+    includeTopLevelListing: false,
+  });
+
+  const parts = [summary];
+  if (state.projectRoot) {
+    parts.push(`Workspace root: ${state.projectRoot}`);
+  }
+  if (renderTarget) {
+    const file = state.files[renderTarget];
+    if (file?.isDirty) {
+      parts.push('Render target has unsaved changes inside OpenSCAD Studio.');
+    }
+  }
+
+  return textResponse(parts.join('\n\n'));
+}
+
+async function handleSetRenderTarget(
+  argumentsValue: Record<string, unknown>
+): Promise<McpToolResponse> {
+  const filePath =
+    typeof argumentsValue.file_path === 'string'
+      ? argumentsValue.file_path
+      : typeof argumentsValue.path === 'string'
+        ? argumentsValue.path
+        : null;
+
+  if (!filePath) {
+    return textResponse('`set_render_target` requires a `file_path` argument.', true);
+  }
+
+  const normalizedPath = normalizeProjectRelativePath(filePath);
+  const state = getProjectState();
+  if (!normalizedPath || !(normalizedPath in state.files)) {
+    return textResponse(`❌ Render target not found: ${filePath}`, true);
+  }
+
+  let snapshot: RenderSnapshotLike;
+  if (state.renderTargetPath === normalizedPath) {
+    snapshot = await runRenderAndWait('manual');
+  } else {
+    const pending = waitForNextRender();
+    getProjectStore().getState().setRenderTarget(normalizedPath);
+    snapshot = await pending;
+  }
+
+  return textResponse(
+    `✅ Render target changed to ${normalizedPath}.\n\n${formatDiagnostics(
+      snapshot.diagnostics,
+      snapshot.error
+    )}`
+  );
+}
+
+async function handleDiagnostics(): Promise<McpToolResponse> {
+  const snapshot = await runRenderAndWait('manual');
+  return textResponse(formatDiagnostics(snapshot.diagnostics, snapshot.error));
+}
+
+async function handleTriggerRender(): Promise<McpToolResponse> {
+  const snapshot = await runRenderAndWait('manual');
+  return textResponse(
+    `✅ Render completed for ${getProjectState().renderTargetPath ?? 'the current render target'}.\n\n${formatDiagnostics(
+      snapshot.diagnostics,
+      snapshot.error
+    )}`
+  );
+}
+
+async function handlePreviewScreenshot(
+  argumentsValue: Record<string, unknown>
+): Promise<McpToolResponse> {
+  const result = await capturePreviewScreenshot({
+    ...buildScreenshotCallbacks(),
+    view:
+      typeof argumentsValue.view === 'string'
+        ? (argumentsValue.view as PreviewScreenshotOptions['view'])
+        : 'current',
+    azimuth:
+      typeof argumentsValue.azimuth === 'number' ? (argumentsValue.azimuth as number) : undefined,
+    elevation:
+      typeof argumentsValue.elevation === 'number'
+        ? (argumentsValue.elevation as number)
+        : undefined,
+  });
+
+  if (result.error) {
+    return textResponse(result.error, true);
+  }
+
+  const dataUrl = result.image_data_url ?? '';
+  const base64 = dataUrl.replace(/^data:image\/png;base64,/, '');
+  return {
+    content: [
+      { type: 'image', data: base64, mimeType: 'image/png' },
+      { type: 'text', text: 'Screenshot captured successfully.' },
+    ],
+  };
+}
+
+async function executeToolRequest(payload: McpToolRequestPayload): Promise<McpToolResponse> {
+  const args = payload.arguments ?? {};
+
+  switch (payload.toolName) {
+    case 'get_project_context':
+      return handleProjectContext();
+    case 'set_render_target':
+      return handleSetRenderTarget(args);
+    case 'get_diagnostics':
+      return handleDiagnostics();
+    case 'trigger_render':
+      return handleTriggerRender();
+    case 'get_preview_screenshot':
+      return handlePreviewScreenshot(args);
+    default:
+      return textResponse(`Unsupported MCP tool: ${payload.toolName}`, true);
+  }
+}
+
+async function submitToolResponse(requestId: string, response: McpToolResponse) {
+  await invoke('mcp_submit_tool_response', { requestId, response });
+}
+
+export async function initializeDesktopMcpBridge(): Promise<() => void> {
+  if (!isDesktopTauri()) {
+    return () => {};
+  }
+
+  if (!bridgeUnlistenPromise) {
+    bridgeUnlistenPromise = listen<McpToolRequestPayload>('mcp:tool-request', async (event) => {
+      const payload = event.payload;
+      const response = await executeToolRequest(payload).catch((error: unknown) =>
+        textResponse(
+          error instanceof Error ? error.message : `Unexpected MCP tool error: ${String(error)}`,
+          true
+        )
+      );
+
+      try {
+        await submitToolResponse(payload.requestId, response);
+      } catch (error) {
+        console.error('[desktopMcp] Failed to submit tool response:', error);
+      }
+    });
+  }
+
+  const unlisten = await bridgeUnlistenPromise;
+  return () => {
+    unlisten();
+    bridgeUnlistenPromise = null;
+  };
+}
+
+export function updateDesktopMcpPreviewState({
+  previewKind,
+  previewSrc,
+  previewSceneStyle,
+  useModelColors,
+}: {
+  previewKind: PreviewKind;
+  previewSrc: string;
+  previewSceneStyle: PreviewSceneStyle;
+  useModelColors: boolean;
+}) {
+  previewState.previewKind = previewKind;
+  previewState.previewSrc = previewSrc;
+  previewState.previewSceneStyle = previewSceneStyle;
+  previewState.useModelColors = useModelColors;
+}
+
+export function notifyDesktopMcpRenderSettled(snapshot: RenderSnapshotLike) {
+  resolveNextRenderWaiter(snapshot);
+}
+
+export async function syncDesktopMcpConfig(config: {
+  enabled: boolean;
+  port: number;
+}): Promise<McpServerStatus> {
+  if (!isDesktopTauri()) return DEFAULT_STATUS;
+  return invoke<McpServerStatus>('configure_mcp_server', config);
+}
+
+export async function getDesktopMcpStatus(): Promise<McpServerStatus> {
+  if (!isDesktopTauri()) return DEFAULT_STATUS;
+  return invoke<McpServerStatus>('get_mcp_server_status');
+}
+
+export function buildClaudeMcpCommand(port: number): string {
+  return `claude mcp add --transport http --scope user openscad-studio http://127.0.0.1:${port}/mcp`;
+}
+
+export function buildCodexMcpCommand(port: number): string {
+  return `codex mcp add openscad-studio --url http://127.0.0.1:${port}/mcp`;
+}
+
+export function buildAgentSnippet(port: number): string {
+  return `Use the OpenSCAD Studio MCP server at http://127.0.0.1:${port}/mcp for project context, render-target switching, diagnostics, render refresh, and preview screenshots. Read and edit files directly in the repo; do not use Studio MCP for file reads or writes.`;
+}

--- a/apps/ui/src/services/nativeRenderService.ts
+++ b/apps/ui/src/services/nativeRenderService.ts
@@ -152,7 +152,14 @@ export class NativeRenderService implements IRenderService {
   async exportModel(
     code: string,
     format: ExportFormat,
-    options: { backend?: 'manifold' | 'cgal' | 'auto' } = {}
+    options: {
+      backend?: 'manifold' | 'cgal' | 'auto';
+      auxiliaryFiles?: Record<string, string>;
+      inputPath?: string;
+      workingDir?: string;
+      libraryFiles?: Record<string, string>;
+      libraryPaths?: string[];
+    } = {}
   ): Promise<Uint8Array> {
     const { backend = 'manifold' } = options;
 
@@ -168,7 +175,19 @@ export class NativeRenderService implements IRenderService {
       args.push('--export-format=binstl');
     }
 
-    const result = await this.invokeRender(code, args);
+    const allFiles =
+      options.libraryFiles || options.auxiliaryFiles
+        ? { ...(options.libraryFiles || {}), ...(options.auxiliaryFiles || {}) }
+        : undefined;
+
+    const result = await this.invokeRender(
+      code,
+      args,
+      allFiles,
+      options.inputPath,
+      options.workingDir,
+      options.libraryPaths
+    );
     const output = new Uint8Array(result.output);
 
     if (output.length === 0) {

--- a/apps/ui/src/services/nativeRenderService.ts
+++ b/apps/ui/src/services/nativeRenderService.ts
@@ -205,11 +205,22 @@ export class NativeRenderService implements IRenderService {
   /**
    * Check syntax by rendering (same as WASM approach).
    */
-  async checkSyntax(code: string): Promise<SyntaxCheckResult> {
+  async checkSyntax(code: string, options: RenderOptions = {}): Promise<SyntaxCheckResult> {
     await this.init();
 
     const args = ['/input.scad', '-o', '/output.stl', '--backend=manifold'];
-    const result = await this.invokeRender(code, args);
+    const allFiles =
+      options.libraryFiles || options.auxiliaryFiles
+        ? { ...(options.libraryFiles || {}), ...(options.auxiliaryFiles || {}) }
+        : undefined;
+    const result = await this.invokeRender(
+      code,
+      args,
+      allFiles,
+      options.inputPath,
+      options.workingDir,
+      options.libraryPaths
+    );
     const diagnostics = parseOpenScadStderr(result.stderr);
 
     return { diagnostics };

--- a/apps/ui/src/services/projectRenderInputs.ts
+++ b/apps/ui/src/services/projectRenderInputs.ts
@@ -1,0 +1,121 @@
+import type { PlatformBridge } from '../platform/types';
+import {
+  getAuxiliaryFilesForRender,
+  getProjectWorkingDirectory,
+  getRenderTargetContent,
+} from '../stores/projectStore';
+import type { ProjectStoreState } from '../stores/projectTypes';
+import type { LibrarySettings } from '../stores/settingsStore';
+import { normalizeProjectRelativePath } from '../utils/projectFilePaths';
+import { resolveWorkingDirDeps } from '../utils/resolveWorkingDirDeps';
+import type { RenderOptions } from './renderService';
+
+export interface LoadedLibraryAssets {
+  libraryFiles: Record<string, string>;
+  libraryPaths: string[];
+}
+
+export async function loadConfiguredLibraryAssets(
+  library: LibrarySettings | undefined,
+  platform: Pick<PlatformBridge, 'getLibraryPaths' | 'readDirectoryFiles'>
+): Promise<LoadedLibraryAssets> {
+  if (!library) {
+    return { libraryFiles: {}, libraryPaths: [] };
+  }
+
+  const systemPaths = library.autoDiscoverSystem ? await platform.getLibraryPaths() : [];
+  const libraryPaths = [...systemPaths, ...library.customPaths];
+  const libraryFiles: Record<string, string> = {};
+
+  for (const libPath of libraryPaths) {
+    try {
+      const files = await platform.readDirectoryFiles(libPath);
+      Object.assign(libraryFiles, files);
+    } catch (err) {
+      console.warn(`[projectRenderInputs] Failed to read library path ${libPath}:`, err);
+    }
+  }
+
+  return { libraryFiles, libraryPaths };
+}
+
+export interface BuildProjectRenderInputsOptions {
+  state: ProjectStoreState;
+  code?: string | null;
+  workingDir?: string | null;
+  libraryFiles?: Record<string, string>;
+  libraryPaths?: string[];
+  platform?: PlatformBridge;
+  resolveWorkingDirDepsImpl?: typeof resolveWorkingDirDeps;
+}
+
+export interface ProjectRenderInputs {
+  code: string;
+  renderTargetPath: string | null;
+  renderTargetDir?: string;
+  projectAuxiliaryFiles: Record<string, string>;
+  workingDirDependencyFiles: Record<string, string>;
+  renderOptions: RenderOptions;
+}
+
+export async function buildProjectRenderInputs(
+  options: BuildProjectRenderInputsOptions
+): Promise<ProjectRenderInputs> {
+  const {
+    state,
+    workingDir = getProjectWorkingDirectory(state),
+    libraryFiles = {},
+    libraryPaths = [],
+    platform,
+    resolveWorkingDirDepsImpl = resolveWorkingDirDeps,
+  } = options;
+
+  const code = options.code ?? getRenderTargetContent(state) ?? '';
+  const renderTargetPath = normalizeProjectRelativePath(state.renderTargetPath ?? '') ?? null;
+  const renderTargetDir = renderTargetPath?.includes('/')
+    ? renderTargetPath.slice(0, renderTargetPath.lastIndexOf('/'))
+    : undefined;
+
+  const projectFiles = getAuxiliaryFilesForRender(state);
+  let projectAuxiliaryFiles: Record<string, string> = { ...projectFiles };
+  let workingDirDependencyFiles: Record<string, string> = {};
+
+  if (workingDir) {
+    if (!platform) {
+      throw new Error('A platform bridge is required to resolve working-directory dependencies.');
+    }
+
+    workingDirDependencyFiles = await resolveWorkingDirDepsImpl(code, {
+      workingDir,
+      libraryFiles,
+      platform,
+      projectFiles,
+      renderTargetDir,
+    });
+
+    if (Object.keys(workingDirDependencyFiles).length > 0) {
+      projectAuxiliaryFiles = {
+        ...projectAuxiliaryFiles,
+        ...workingDirDependencyFiles,
+      };
+    }
+  }
+
+  const mergedAuxiliaryFiles = { ...libraryFiles, ...projectAuxiliaryFiles };
+
+  return {
+    code,
+    renderTargetPath,
+    renderTargetDir,
+    projectAuxiliaryFiles,
+    workingDirDependencyFiles,
+    renderOptions: {
+      auxiliaryFiles:
+        Object.keys(mergedAuxiliaryFiles).length > 0 ? mergedAuxiliaryFiles : undefined,
+      libraryFiles: Object.keys(libraryFiles).length > 0 ? libraryFiles : undefined,
+      libraryPaths: libraryPaths.length > 0 ? libraryPaths : undefined,
+      inputPath: renderTargetPath ?? undefined,
+      workingDir: workingDir ?? undefined,
+    },
+  };
+}

--- a/apps/ui/src/services/renderService.ts
+++ b/apps/ui/src/services/renderService.ts
@@ -201,7 +201,7 @@ export interface IRenderService {
   render(code: string, options?: RenderOptions): Promise<RenderResult>;
   getCached(code: string, options?: RenderOptions): Promise<RenderResult | null>;
   exportModel(code: string, format: ExportFormat, options?: ExportOptions): Promise<Uint8Array>;
-  checkSyntax(code: string): Promise<SyntaxCheckResult>;
+  checkSyntax(code: string, options?: RenderOptions): Promise<SyntaxCheckResult>;
   cancel(): void;
   clearCache(): void;
   dispose(): void;
@@ -446,9 +446,13 @@ export class WasmRenderService implements IRenderService {
   /**
    * Check syntax by attempting to render. Returns diagnostics only.
    */
-  async checkSyntax(code: string): Promise<SyntaxCheckResult> {
+  async checkSyntax(code: string, options: RenderOptions = {}): Promise<SyntaxCheckResult> {
     const args = this.buildArgs('/output.stl', { backend: 'manifold' });
-    const result = await this.sendRequest(code, args);
+    const allFiles =
+      options.libraryFiles || options.auxiliaryFiles
+        ? { ...(options.libraryFiles || {}), ...(options.auxiliaryFiles || {}) }
+        : undefined;
+    const result = await this.sendRequest(code, args, allFiles, options.inputPath);
     const diagnostics = parseOpenScadStderr(result.stderr);
 
     return { diagnostics };

--- a/apps/ui/src/services/renderService.ts
+++ b/apps/ui/src/services/renderService.ts
@@ -20,6 +20,13 @@ export interface Diagnostic {
 
 export type ExportFormat = 'stl' | 'obj' | 'amf' | '3mf' | 'svg' | 'dxf';
 
+export interface ExportOptions extends Pick<
+  RenderOptions,
+  'auxiliaryFiles' | 'inputPath' | 'workingDir' | 'libraryFiles' | 'libraryPaths'
+> {
+  backend?: 'manifold' | 'cgal' | 'auto';
+}
+
 export interface RenderOptions {
   view?: '2d' | '3d';
   backend?: 'manifold' | 'cgal' | 'auto';
@@ -193,11 +200,7 @@ export interface IRenderService {
   init(): Promise<void>;
   render(code: string, options?: RenderOptions): Promise<RenderResult>;
   getCached(code: string, options?: RenderOptions): Promise<RenderResult | null>;
-  exportModel(
-    code: string,
-    format: ExportFormat,
-    options?: { backend?: 'manifold' | 'cgal' | 'auto' }
-  ): Promise<Uint8Array>;
+  exportModel(code: string, format: ExportFormat, options?: ExportOptions): Promise<Uint8Array>;
   checkSyntax(code: string): Promise<SyntaxCheckResult>;
   cancel(): void;
   clearCache(): void;
@@ -457,18 +460,22 @@ export class WasmRenderService implements IRenderService {
   async exportModel(
     code: string,
     format: ExportFormat,
-    options: { backend?: 'manifold' | 'cgal' | 'auto' } = {}
+    options: ExportOptions = {}
   ): Promise<Uint8Array> {
     const { backend = 'manifold' } = options;
     const outputPath = `/output.${format}`;
     const args = this.buildArgs(outputPath, { backend });
+    const allFiles =
+      options.libraryFiles || options.auxiliaryFiles
+        ? { ...(options.libraryFiles || {}), ...(options.auxiliaryFiles || {}) }
+        : undefined;
 
     // For binary STL (more compact)
     if (format === 'stl') {
       args.push('--export-format=binstl');
     }
 
-    const result = await this.sendRequest(code, args);
+    const result = await this.sendRequest(code, args, allFiles, options.inputPath);
 
     if (result.output.length === 0) {
       const diagnostics = parseOpenScadStderr(result.stderr);

--- a/apps/ui/src/services/studioTooling.ts
+++ b/apps/ui/src/services/studioTooling.ts
@@ -1,0 +1,150 @@
+import { captureOffscreen, type CaptureOptions } from './offscreenRenderer';
+import type { PreviewSceneStyle } from './previewSceneConfig';
+
+const MAX_CONTEXT_LINES = 200;
+const TRUNCATION_LINES = 150;
+
+export interface ProjectContextOptions {
+  renderTarget: string | null;
+  renderTargetContent: string | null;
+  allFiles: string[];
+  includeTopLevelListing?: boolean;
+}
+
+export interface PreviewScreenshotOptions {
+  captureCurrentView: () => Promise<string | null>;
+  get3dPreviewUrl: () => string | null;
+  getPreviewSceneStyle: () => PreviewSceneStyle;
+  getUseModelColors: () => boolean;
+  view?: 'current' | 'front' | 'back' | 'top' | 'bottom' | 'left' | 'right' | 'isometric';
+  azimuth?: number;
+  elevation?: number;
+}
+
+/**
+ * List files and subfolders at a specific directory level.
+ * Returns a formatted string with entries like:
+ *   📁 lib/
+ *   main.scad (render target)
+ *   utils.scad
+ */
+export function listFolderEntries(
+  allFiles: string[],
+  folder: string,
+  renderTarget?: string | null
+): string {
+  const prefix = folder ? `${folder}/` : '';
+  const folders = new Set<string>();
+  const files: string[] = [];
+
+  for (const filePath of allFiles) {
+    if (!filePath.startsWith(prefix)) continue;
+    const remainder = filePath.slice(prefix.length);
+    const slashIdx = remainder.indexOf('/');
+    if (slashIdx >= 0) {
+      folders.add(remainder.slice(0, slashIdx));
+    } else {
+      files.push(remainder);
+    }
+  }
+
+  const lines: string[] = [];
+  for (const dir of [...folders].sort()) {
+    lines.push(`  📁 ${dir}/`);
+  }
+  for (const file of files.sort()) {
+    const fullPath = prefix + file;
+    lines.push(fullPath === renderTarget ? `  ${file} (render target)` : `  ${file}`);
+  }
+
+  return lines.join('\n');
+}
+
+export function buildProjectContextSummary({
+  renderTarget,
+  renderTargetContent,
+  allFiles,
+  includeTopLevelListing = true,
+}: ProjectContextOptions): string {
+  const parts: string[] = [];
+
+  if (renderTarget) {
+    parts.push(`Render target: ${renderTarget}`);
+    if (renderTargetContent) {
+      const lines = renderTargetContent.split('\n');
+      if (lines.length > MAX_CONTEXT_LINES) {
+        const truncated = lines.slice(0, TRUNCATION_LINES).join('\n');
+        parts.push(
+          `\n--- ${renderTarget} (showing ${TRUNCATION_LINES} of ${lines.length} lines) ---\n${truncated}\n\n[Truncated.]`
+        );
+      } else {
+        parts.push(`\n--- ${renderTarget} ---\n${renderTargetContent}`);
+      }
+    }
+  } else {
+    parts.push('No render target set.');
+  }
+
+  if (allFiles.length === 0) {
+    parts.push('\nNo project files.');
+    return parts.join('\n');
+  }
+
+  if (includeTopLevelListing) {
+    const topLevel = listFolderEntries(allFiles, '', renderTarget);
+    parts.push(`\nProject files (${allFiles.length} total):\n${topLevel}`);
+  } else {
+    parts.push(`\nProject files: ${allFiles.length} total`);
+  }
+
+  return parts.join('\n');
+}
+
+export async function capturePreviewScreenshot({
+  captureCurrentView,
+  get3dPreviewUrl,
+  getPreviewSceneStyle,
+  getUseModelColors,
+  view = 'current',
+  azimuth,
+  elevation,
+}: PreviewScreenshotOptions): Promise<{ image_data_url?: string; error?: string }> {
+  const useOffscreen = view !== 'current' || azimuth !== undefined || elevation !== undefined;
+
+  if (!useOffscreen) {
+    const dataUrl = await captureCurrentView();
+    if (dataUrl) {
+      return { image_data_url: dataUrl };
+    }
+    return {
+      error:
+        'No preview available. The code may not have been rendered yet, or the preview panel is not visible.',
+    };
+  }
+
+  const preview3dUrl = get3dPreviewUrl();
+  if (!preview3dUrl) {
+    return {
+      error:
+        'No 3D model available for angle-specific views. Render the code first, or use view="current" to capture the 2D SVG preview.',
+    };
+  }
+
+  try {
+    const opts: CaptureOptions = {};
+    if (azimuth !== undefined || elevation !== undefined) {
+      opts.azimuth = azimuth;
+      opts.elevation = elevation;
+    } else if (view !== 'current') {
+      opts.view = view;
+    }
+    opts.sceneStyle = getPreviewSceneStyle();
+    opts.useModelColors = getUseModelColors();
+    const dataUrl = await captureOffscreen(preview3dUrl, opts);
+    return { image_data_url: dataUrl };
+  } catch (err) {
+    return {
+      error: `Failed to capture screenshot: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}

--- a/apps/ui/src/services/windowOpenService.ts
+++ b/apps/ui/src/services/windowOpenService.ts
@@ -18,8 +18,6 @@ export interface OpenWorkspaceFolderOptions {
   requestRender?: boolean;
   trackRecent?: boolean;
   platform?: FileOpenPlatform;
-  /** Pre-read file contents — bypasses FS calls when provided (used by secondary windows). */
-  preReadFiles?: Record<string, string>;
 }
 
 export interface OpenWorkspaceFolderResult {
@@ -43,18 +41,6 @@ export interface OpenFileInWindowResult {
   activeTabId: string;
   fileCount: number;
   reusedExistingTab: boolean;
-}
-
-function emitStartupDetail(phase: string, detail?: string) {
-  if (typeof window === 'undefined') return;
-  window.dispatchEvent(
-    new CustomEvent('openscad:startup-phase', {
-      detail: {
-        phase,
-        detail: detail ?? null,
-      },
-    })
-  );
 }
 
 function revokeBlobUrl(url: string | null | undefined) {
@@ -158,31 +144,10 @@ export async function openWorkspaceFolderInWindow(
   options: OpenWorkspaceFolderOptions = {}
 ): Promise<OpenWorkspaceFolderResult> {
   const platform = options.platform ?? getPlatform();
-  emitStartupDetail('workspace_open_begin', dirPath);
 
-  let workspace;
-  if (options.preReadFiles && Object.keys(options.preReadFiles).length > 0) {
-    // Use pre-read files from the Rust side (avoids FS plugin IPC in secondary windows).
-    const files = options.preReadFiles;
-    const filePaths = Object.keys(files);
-    const renderTargetPath =
-      filePaths.find((p) => p === DEFAULT_TAB_NAME) ??
-      [...filePaths].sort((a, b) => a.localeCompare(b))[0];
-    workspace = {
-      files,
-      renderTargetPath,
-      emptyFolders: [] as string[],
-      createdDefaultFile: false,
-    };
-  } else {
-    workspace = await loadWorkspaceFolder(platform, dirPath, {
-      createIfEmpty: options.createIfEmpty,
-    });
-  }
-  emitStartupDetail(
-    'workspace_open_loaded',
-    `${Object.keys(workspace.files).length} file(s), target ${workspace.renderTargetPath}`
-  );
+  const workspace = await loadWorkspaceFolder(platform, dirPath, {
+    createIfEmpty: options.createIfEmpty,
+  });
 
   const activeTabId = hydrateWindowWorkspace({
     projectRoot: dirPath,
@@ -191,21 +156,17 @@ export async function openWorkspaceFolderInWindow(
     activeProjectPath: workspace.renderTargetPath,
     activeFilePath: `${dirPath}/${workspace.renderTargetPath}`,
   });
-  emitStartupDetail('workspace_open_hydrated', workspace.renderTargetPath);
 
   const projectStore = getProjectStore().getState();
   for (const dir of workspace.emptyFolders) {
     projectStore.addFolder(dir);
   }
-  emitStartupDetail('workspace_open_folders_added', `${workspace.emptyFolders.length} empty folder(s)`);
 
   if (options.trackRecent ?? true) {
     addRecentFolder(dirPath);
-    emitStartupDetail('workspace_open_recent_added', dirPath);
   }
   if (options.requestRender ?? true) {
     requestRender('file_open', { immediate: true });
-    emitStartupDetail('workspace_open_render_requested', workspace.renderTargetPath);
   }
 
   return {

--- a/apps/ui/src/services/windowOpenService.ts
+++ b/apps/ui/src/services/windowOpenService.ts
@@ -18,6 +18,8 @@ export interface OpenWorkspaceFolderOptions {
   requestRender?: boolean;
   trackRecent?: boolean;
   platform?: FileOpenPlatform;
+  /** Pre-read file contents — bypasses FS calls when provided (used by secondary windows). */
+  preReadFiles?: Record<string, string>;
 }
 
 export interface OpenWorkspaceFolderResult {
@@ -41,6 +43,18 @@ export interface OpenFileInWindowResult {
   activeTabId: string;
   fileCount: number;
   reusedExistingTab: boolean;
+}
+
+function emitStartupDetail(phase: string, detail?: string) {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(
+    new CustomEvent('openscad:startup-phase', {
+      detail: {
+        phase,
+        detail: detail ?? null,
+      },
+    })
+  );
 }
 
 function revokeBlobUrl(url: string | null | undefined) {
@@ -144,9 +158,31 @@ export async function openWorkspaceFolderInWindow(
   options: OpenWorkspaceFolderOptions = {}
 ): Promise<OpenWorkspaceFolderResult> {
   const platform = options.platform ?? getPlatform();
-  const workspace = await loadWorkspaceFolder(platform, dirPath, {
-    createIfEmpty: options.createIfEmpty,
-  });
+  emitStartupDetail('workspace_open_begin', dirPath);
+
+  let workspace;
+  if (options.preReadFiles && Object.keys(options.preReadFiles).length > 0) {
+    // Use pre-read files from the Rust side (avoids FS plugin IPC in secondary windows).
+    const files = options.preReadFiles;
+    const filePaths = Object.keys(files);
+    const renderTargetPath =
+      filePaths.find((p) => p === DEFAULT_TAB_NAME) ??
+      [...filePaths].sort((a, b) => a.localeCompare(b))[0];
+    workspace = {
+      files,
+      renderTargetPath,
+      emptyFolders: [] as string[],
+      createdDefaultFile: false,
+    };
+  } else {
+    workspace = await loadWorkspaceFolder(platform, dirPath, {
+      createIfEmpty: options.createIfEmpty,
+    });
+  }
+  emitStartupDetail(
+    'workspace_open_loaded',
+    `${Object.keys(workspace.files).length} file(s), target ${workspace.renderTargetPath}`
+  );
 
   const activeTabId = hydrateWindowWorkspace({
     projectRoot: dirPath,
@@ -155,17 +191,21 @@ export async function openWorkspaceFolderInWindow(
     activeProjectPath: workspace.renderTargetPath,
     activeFilePath: `${dirPath}/${workspace.renderTargetPath}`,
   });
+  emitStartupDetail('workspace_open_hydrated', workspace.renderTargetPath);
 
   const projectStore = getProjectStore().getState();
   for (const dir of workspace.emptyFolders) {
     projectStore.addFolder(dir);
   }
+  emitStartupDetail('workspace_open_folders_added', `${workspace.emptyFolders.length} empty folder(s)`);
 
   if (options.trackRecent ?? true) {
     addRecentFolder(dirPath);
+    emitStartupDetail('workspace_open_recent_added', dirPath);
   }
   if (options.requestRender ?? true) {
     requestRender('file_open', { immediate: true });
+    emitStartupDetail('workspace_open_render_requested', workspace.renderTargetPath);
   }
 
   return {

--- a/apps/ui/src/services/windowOpenService.ts
+++ b/apps/ui/src/services/windowOpenService.ts
@@ -1,0 +1,235 @@
+import { type FileOpenResult, getPlatform, type PlatformBridge } from '../platform';
+import { eventBus } from '../platform/eventBus';
+import { getProjectStore } from '../stores/projectStore';
+import { requestRender } from '../stores/renderRequestStore';
+import { DEFAULT_TAB_NAME, createWorkspaceTab } from '../stores/workspaceFactories';
+import { getWorkspaceState, workspaceStore } from '../stores/workspaceStore';
+import type { WorkspaceStoreState } from '../stores/workspaceTypes';
+import { addRecentFile, addRecentFolder } from '../utils/recentFiles';
+import { findEmptyFolders, loadWorkspaceFolder } from '../utils/workspaceFolder';
+
+type FileOpenPlatform = Pick<
+  PlatformBridge,
+  'capabilities' | 'readDirectoryFiles' | 'readSubdirectories' | 'createDirectory' | 'writeTextFile'
+>;
+
+export interface OpenWorkspaceFolderOptions {
+  createIfEmpty?: boolean;
+  requestRender?: boolean;
+  trackRecent?: boolean;
+  platform?: FileOpenPlatform;
+}
+
+export interface OpenWorkspaceFolderResult {
+  workspaceRoot: string;
+  renderTargetPath: string;
+  emptyFolders: string[];
+  createdDefaultFile: boolean;
+  fileCount: number;
+  activeTabId: string;
+}
+
+export interface OpenFileInWindowOptions {
+  requestRender?: boolean;
+  trackRecent?: boolean;
+  platform?: FileOpenPlatform;
+}
+
+export interface OpenFileInWindowResult {
+  projectRoot: string | null;
+  projectPath: string;
+  activeTabId: string;
+  fileCount: number;
+  reusedExistingTab: boolean;
+}
+
+function revokeBlobUrl(url: string | null | undefined) {
+  if (!url || !url.startsWith('blob:')) {
+    return;
+  }
+
+  URL.revokeObjectURL(url);
+}
+
+function clearExistingWorkspaceUi() {
+  for (const tab of getWorkspaceState().tabs) {
+    revokeBlobUrl(tab.render.previewSrc);
+  }
+}
+
+function hydrateWindowWorkspace(args: {
+  projectRoot: string | null;
+  files: Record<string, string>;
+  renderTargetPath: string;
+  activeProjectPath?: string;
+  activeFilePath?: string | null;
+}) {
+  const activeProjectPath = args.activeProjectPath ?? args.renderTargetPath;
+  const activeTab = createWorkspaceTab({
+    filePath: args.activeFilePath ?? null,
+    name: activeProjectPath,
+    projectPath: activeProjectPath,
+  });
+  const workspaceState: WorkspaceStoreState = {
+    tabs: [activeTab],
+    activeTabId: activeTab.id,
+    showWelcome: false,
+  };
+
+  clearExistingWorkspaceUi();
+  getProjectStore().getState().openProject(args.projectRoot, args.files, args.renderTargetPath);
+  workspaceStore.getState().hydrateWorkspace(workspaceState);
+
+  const activeContent = args.files[activeProjectPath];
+  if (activeContent) {
+    eventBus.emit('code-updated', { code: activeContent, source: 'file-open' });
+  }
+
+  return activeTab.id;
+}
+
+async function loadProjectFromFile(
+  platform: FileOpenPlatform,
+  result: Pick<FileOpenResult, 'path' | 'name' | 'content'>
+) {
+  if (!result.path) {
+    return {
+      projectRoot: null,
+      files: { [result.name || DEFAULT_TAB_NAME]: result.content },
+      renderTargetPath: result.name || DEFAULT_TAB_NAME,
+      activeProjectPath: result.name || DEFAULT_TAB_NAME,
+      emptyFolders: [] as string[],
+    };
+  }
+
+  const separatorIndex = result.path.lastIndexOf('/');
+  const projectRoot = separatorIndex > 0 ? result.path.substring(0, separatorIndex) : null;
+  const relativeName = result.path.substring(separatorIndex + 1);
+  const files: Record<string, string> = { [relativeName]: result.content };
+
+  if (projectRoot && platform.capabilities.hasFileSystem) {
+    try {
+      const siblings = await platform.readDirectoryFiles(projectRoot, ['scad'], true);
+      for (const [relPath, siblingContent] of Object.entries(siblings)) {
+        if (relPath !== relativeName) {
+          files[relPath] = siblingContent;
+        }
+      }
+    } catch (error) {
+      console.warn('[windowOpenService] Failed to load sibling files:', error);
+    }
+  }
+
+  let emptyFolders: string[] = [];
+  if (projectRoot && platform.capabilities.hasFileSystem) {
+    try {
+      const allDirs = await platform.readSubdirectories(projectRoot);
+      emptyFolders = findEmptyFolders(allDirs, Object.keys(files));
+    } catch {
+      emptyFolders = [];
+    }
+  }
+
+  return {
+    projectRoot,
+    files,
+    renderTargetPath: relativeName,
+    activeProjectPath: relativeName,
+    emptyFolders,
+  };
+}
+
+export async function openWorkspaceFolderInWindow(
+  dirPath: string,
+  options: OpenWorkspaceFolderOptions = {}
+): Promise<OpenWorkspaceFolderResult> {
+  const platform = options.platform ?? getPlatform();
+  const workspace = await loadWorkspaceFolder(platform, dirPath, {
+    createIfEmpty: options.createIfEmpty,
+  });
+
+  const activeTabId = hydrateWindowWorkspace({
+    projectRoot: dirPath,
+    files: workspace.files,
+    renderTargetPath: workspace.renderTargetPath,
+    activeProjectPath: workspace.renderTargetPath,
+    activeFilePath: `${dirPath}/${workspace.renderTargetPath}`,
+  });
+
+  const projectStore = getProjectStore().getState();
+  for (const dir of workspace.emptyFolders) {
+    projectStore.addFolder(dir);
+  }
+
+  if (options.trackRecent ?? true) {
+    addRecentFolder(dirPath);
+  }
+  if (options.requestRender ?? true) {
+    requestRender('file_open', { immediate: true });
+  }
+
+  return {
+    workspaceRoot: dirPath,
+    renderTargetPath: workspace.renderTargetPath,
+    emptyFolders: workspace.emptyFolders,
+    createdDefaultFile: workspace.createdDefaultFile,
+    fileCount: Object.keys(workspace.files).length,
+    activeTabId,
+  };
+}
+
+export async function openFileInWindow(
+  result: Pick<FileOpenResult, 'path' | 'name' | 'content'>,
+  options: OpenFileInWindowOptions = {}
+): Promise<OpenFileInWindowResult> {
+  if (result.path) {
+    const existingTab = getWorkspaceState().tabs.find((tab) => tab.filePath === result.path);
+    if (existingTab) {
+      workspaceStore.getState().setActiveTab(existingTab.id);
+      workspaceStore.getState().hideWelcomeScreen();
+      return {
+        projectRoot: getProjectStore().getState().projectRoot,
+        projectPath: existingTab.projectPath,
+        activeTabId: existingTab.id,
+        fileCount: Object.keys(getProjectStore().getState().files).length,
+        reusedExistingTab: true,
+      };
+    }
+  }
+
+  const platform = options.platform ?? getPlatform();
+  const project = await loadProjectFromFile(platform, result);
+  const activeFilePath =
+    project.projectRoot && result.path
+      ? result.path
+      : project.projectRoot
+        ? `${project.projectRoot}/${project.activeProjectPath}`
+        : null;
+  const activeTabId = hydrateWindowWorkspace({
+    projectRoot: project.projectRoot,
+    files: project.files,
+    renderTargetPath: project.renderTargetPath,
+    activeProjectPath: project.activeProjectPath,
+    activeFilePath,
+  });
+
+  const projectStore = getProjectStore().getState();
+  for (const dir of project.emptyFolders) {
+    projectStore.addFolder(dir);
+  }
+
+  if ((options.trackRecent ?? true) && result.path) {
+    addRecentFile(result.path);
+  }
+  if (options.requestRender ?? true) {
+    requestRender('file_open', { immediate: true });
+  }
+
+  return {
+    projectRoot: project.projectRoot,
+    projectPath: project.activeProjectPath,
+    activeTabId,
+    fileCount: Object.keys(project.files).length,
+    reusedExistingTab: false,
+  };
+}

--- a/apps/ui/src/stores/__tests__/renderArtifactStore.test.ts
+++ b/apps/ui/src/stores/__tests__/renderArtifactStore.test.ts
@@ -1,0 +1,105 @@
+import {
+  __resetRenderArtifactStoreForTests,
+  getArtifactByRequestId,
+  getLatestArtifactForTarget,
+  getLatestSuccessfulArtifactForTarget,
+  getRenderArtifactState,
+} from '../renderArtifactStore';
+
+const sceneStyle = {
+  background: 'system',
+  lighting: 'studio',
+  grid: true,
+} as const;
+
+describe('renderArtifactStore', () => {
+  beforeEach(() => {
+    __resetRenderArtifactStoreForTests();
+  });
+
+  it('publishes settled artifacts by target and request id', () => {
+    const store = getRenderArtifactState();
+    store.setActiveRenderTarget('openscad/poly555.scad', '/workspace/poly555');
+    store.markRenderStarted('openscad/poly555.scad', 7);
+    store.publishSettledArtifact({
+      requestId: 7,
+      renderTargetPath: 'openscad/poly555.scad',
+      workspaceRoot: '/workspace/poly555',
+      sourceHash: 'abc12345',
+      previewKind: 'mesh',
+      previewSrc: 'blob:poly555',
+      diagnostics: [],
+      error: '',
+      dimensionMode: '3d',
+      sceneStyle: sceneStyle as never,
+      useModelColors: true,
+      createdAt: 1,
+    });
+
+    expect(getLatestArtifactForTarget('openscad/poly555.scad')?.previewSrc).toBe('blob:poly555');
+    expect(getLatestSuccessfulArtifactForTarget('openscad/poly555.scad')?.requestId).toBe(7);
+    expect(getArtifactByRequestId(7)?.renderTargetPath).toBe('openscad/poly555.scad');
+    expect(getRenderArtifactState().inFlightRequestIdByTarget['openscad/poly555.scad']).toBeUndefined();
+  });
+
+  it('keeps the last successful artifact when a later render fails', () => {
+    const store = getRenderArtifactState();
+    store.setActiveRenderTarget('main.scad', '/workspace/project');
+    store.publishSettledArtifact({
+      requestId: 1,
+      renderTargetPath: 'main.scad',
+      workspaceRoot: '/workspace/project',
+      sourceHash: 'clean123',
+      previewKind: 'mesh',
+      previewSrc: 'blob:clean',
+      diagnostics: [],
+      error: '',
+      dimensionMode: '3d',
+      sceneStyle: sceneStyle as never,
+      useModelColors: true,
+      createdAt: 1,
+    });
+    store.publishSettledArtifact({
+      requestId: 2,
+      renderTargetPath: 'main.scad',
+      workspaceRoot: '/workspace/project',
+      sourceHash: 'broken123',
+      previewKind: 'mesh',
+      previewSrc: '',
+      diagnostics: [{ severity: 'error', message: 'Parser error' }],
+      error: '',
+      dimensionMode: '3d',
+      sceneStyle: sceneStyle as never,
+      useModelColors: true,
+      createdAt: 2,
+    });
+
+    expect(getLatestArtifactForTarget('main.scad')?.requestId).toBe(2);
+    expect(getLatestSuccessfulArtifactForTarget('main.scad')?.requestId).toBe(1);
+  });
+
+  it('clears prior artifacts when the workspace root changes', () => {
+    const store = getRenderArtifactState();
+    store.setActiveRenderTarget('main.scad', '/workspace/first');
+    store.publishSettledArtifact({
+      requestId: 1,
+      renderTargetPath: 'main.scad',
+      workspaceRoot: '/workspace/first',
+      sourceHash: 'first123',
+      previewKind: 'mesh',
+      previewSrc: 'blob:first',
+      diagnostics: [],
+      error: '',
+      dimensionMode: '3d',
+      sceneStyle: sceneStyle as never,
+      useModelColors: true,
+      createdAt: 1,
+    });
+
+    store.setActiveRenderTarget('openscad/poly555.scad', '/workspace/second');
+
+    expect(getLatestArtifactForTarget('main.scad')).toBeNull();
+    expect(getRenderArtifactState().workspaceRoot).toBe('/workspace/second');
+    expect(getRenderArtifactState().activeRenderTargetPath).toBe('openscad/poly555.scad');
+  });
+});

--- a/apps/ui/src/stores/__tests__/renderArtifactStore.test.ts
+++ b/apps/ui/src/stores/__tests__/renderArtifactStore.test.ts
@@ -39,7 +39,9 @@ describe('renderArtifactStore', () => {
     expect(getLatestArtifactForTarget('openscad/poly555.scad')?.previewSrc).toBe('blob:poly555');
     expect(getLatestSuccessfulArtifactForTarget('openscad/poly555.scad')?.requestId).toBe(7);
     expect(getArtifactByRequestId(7)?.renderTargetPath).toBe('openscad/poly555.scad');
-    expect(getRenderArtifactState().inFlightRequestIdByTarget['openscad/poly555.scad']).toBeUndefined();
+    expect(
+      getRenderArtifactState().inFlightRequestIdByTarget['openscad/poly555.scad']
+    ).toBeUndefined();
   });
 
   it('keeps the last successful artifact when a later render fails', () => {

--- a/apps/ui/src/stores/__tests__/settingsStore.test.ts
+++ b/apps/ui/src/stores/__tests__/settingsStore.test.ts
@@ -34,5 +34,7 @@ describe('settingsStore', () => {
     expect(settings.viewer.enable2DGridSnap).toBe(true);
     expect(settings.privacy.analyticsEnabled).toBe(false);
     expect(settings.ui.hasCompletedNux).toBe(true);
+    expect(settings.mcp.enabled).toBe(true);
+    expect(settings.mcp.port).toBe(32123);
   });
 });

--- a/apps/ui/src/stores/renderArtifactStore.ts
+++ b/apps/ui/src/stores/renderArtifactStore.ts
@@ -1,0 +1,230 @@
+import { useStore } from 'zustand';
+import { createStore } from 'zustand/vanilla';
+import type { Diagnostic } from '../services/renderService';
+import type { PreviewSceneStyle } from '../services/previewSceneConfig';
+
+export type RenderArtifactKind = 'mesh' | 'svg';
+
+export interface RenderArtifact {
+  artifactId: string;
+  requestId: number;
+  renderTargetPath: string;
+  workspaceRoot: string | null;
+  sourceHash: string;
+  previewKind: RenderArtifactKind;
+  previewSrc: string;
+  diagnostics: Diagnostic[];
+  error: string;
+  dimensionMode: '2d' | '3d';
+  sceneStyle: PreviewSceneStyle;
+  useModelColors: boolean;
+  createdAt: number;
+}
+
+export interface RenderArtifactStoreState {
+  activeRenderTargetPath: string | null;
+  workspaceRoot: string | null;
+  artifactsByTarget: Record<string, RenderArtifact>;
+  latestSuccessfulByTarget: Record<string, RenderArtifact>;
+  latestByRequestId: Record<number, RenderArtifact>;
+  inFlightRequestIdByTarget: Record<string, number>;
+}
+
+interface RenderArtifactStoreActions {
+  setActiveRenderTarget: (path: string | null, workspaceRoot: string | null) => void;
+  markRenderStarted: (renderTargetPath: string, requestId: number) => void;
+  publishSettledArtifact: (artifact: Omit<RenderArtifact, 'artifactId'>) => void;
+  clearArtifactsForWorkspace: (workspaceRoot: string | null) => void;
+  clearArtifactsForTarget: (renderTargetPath: string) => void;
+  reset: () => void;
+}
+
+export type RenderArtifactStore = RenderArtifactStoreState & RenderArtifactStoreActions;
+
+function createInitialRenderArtifactState(): RenderArtifactStoreState {
+  return {
+    activeRenderTargetPath: null,
+    workspaceRoot: null,
+    artifactsByTarget: {},
+    latestSuccessfulByTarget: {},
+    latestByRequestId: {},
+    inFlightRequestIdByTarget: {},
+  };
+}
+
+function isArtifactSuccessful(artifact: RenderArtifact): boolean {
+  return !artifact.error && artifact.diagnostics.every((entry) => entry.severity !== 'error');
+}
+
+export function createSourceHash(source: string): string {
+  let hash = 2166136261;
+  for (let index = 0; index < source.length; index += 1) {
+    hash ^= source.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0');
+}
+
+function createArtifactId(artifact: Omit<RenderArtifact, 'artifactId'>): string {
+  return [
+    artifact.renderTargetPath,
+    artifact.requestId,
+    artifact.sourceHash,
+    artifact.createdAt,
+  ].join(':');
+}
+
+function buildEmptyRequestMap(
+  requestIdMap: Record<string, number>,
+  renderTargetPath: string
+): Record<string, number> {
+  const next = { ...requestIdMap };
+  delete next[renderTargetPath];
+  return next;
+}
+
+export function createRenderArtifactStore(
+  initialState: RenderArtifactStoreState = createInitialRenderArtifactState()
+) {
+  return createStore<RenderArtifactStore>()((set, get) => ({
+    ...initialState,
+
+    setActiveRenderTarget: (path, workspaceRoot) => {
+      set((state) => {
+        const workspaceChanged = state.workspaceRoot !== workspaceRoot;
+        if (!workspaceChanged) {
+          return {
+            ...state,
+            activeRenderTargetPath: path,
+            workspaceRoot,
+          };
+        }
+
+        return {
+          ...createInitialRenderArtifactState(),
+          activeRenderTargetPath: path,
+          workspaceRoot,
+        };
+      });
+    },
+
+    markRenderStarted: (renderTargetPath, requestId) => {
+      set((state) => ({
+        ...state,
+        activeRenderTargetPath: renderTargetPath,
+        inFlightRequestIdByTarget: {
+          ...state.inFlightRequestIdByTarget,
+          [renderTargetPath]: requestId,
+        },
+      }));
+    },
+
+    publishSettledArtifact: (artifactInput) => {
+      const artifact = {
+        ...artifactInput,
+        artifactId: createArtifactId(artifactInput),
+      };
+
+      set((state) => ({
+        ...state,
+        activeRenderTargetPath: artifact.renderTargetPath,
+        workspaceRoot: artifact.workspaceRoot,
+        artifactsByTarget: {
+          ...state.artifactsByTarget,
+          [artifact.renderTargetPath]: artifact,
+        },
+        latestSuccessfulByTarget: isArtifactSuccessful(artifact)
+          ? {
+              ...state.latestSuccessfulByTarget,
+              [artifact.renderTargetPath]: artifact,
+            }
+          : state.latestSuccessfulByTarget,
+        latestByRequestId: {
+          ...state.latestByRequestId,
+          [artifact.requestId]: artifact,
+        },
+        inFlightRequestIdByTarget: buildEmptyRequestMap(
+          state.inFlightRequestIdByTarget,
+          artifact.renderTargetPath
+        ),
+      }));
+    },
+
+    clearArtifactsForWorkspace: (workspaceRoot) => {
+      if (get().workspaceRoot !== workspaceRoot) {
+        return;
+      }
+      set({
+        ...createInitialRenderArtifactState(),
+        workspaceRoot,
+      });
+    },
+
+    clearArtifactsForTarget: (renderTargetPath) => {
+      set((state) => {
+        const artifactsByTarget = { ...state.artifactsByTarget };
+        const latestSuccessfulByTarget = { ...state.latestSuccessfulByTarget };
+        const inFlightRequestIdByTarget = { ...state.inFlightRequestIdByTarget };
+        delete artifactsByTarget[renderTargetPath];
+        delete latestSuccessfulByTarget[renderTargetPath];
+        delete inFlightRequestIdByTarget[renderTargetPath];
+
+        const latestByRequestId = Object.fromEntries(
+          Object.entries(state.latestByRequestId).filter(
+            ([, artifact]) => artifact.renderTargetPath !== renderTargetPath
+          )
+        ) as Record<number, RenderArtifact>;
+
+        return {
+          ...state,
+          artifactsByTarget,
+          latestSuccessfulByTarget,
+          latestByRequestId,
+          inFlightRequestIdByTarget,
+        };
+      });
+    },
+
+    reset: () => {
+      set(createInitialRenderArtifactState());
+    },
+  }));
+}
+
+const renderArtifactStore = createRenderArtifactStore();
+
+export function useRenderArtifactStore<T>(selector: (state: RenderArtifactStore) => T): T {
+  return useStore(renderArtifactStore, selector);
+}
+
+export function getRenderArtifactState(): RenderArtifactStore {
+  return renderArtifactStore.getState();
+}
+
+export function getLatestArtifactForTarget(renderTargetPath: string | null): RenderArtifact | null {
+  if (!renderTargetPath) {
+    return null;
+  }
+  return getRenderArtifactState().artifactsByTarget[renderTargetPath] ?? null;
+}
+
+export function getLatestSuccessfulArtifactForTarget(
+  renderTargetPath: string | null
+): RenderArtifact | null {
+  if (!renderTargetPath) {
+    return null;
+  }
+  return getRenderArtifactState().latestSuccessfulByTarget[renderTargetPath] ?? null;
+}
+
+export function getArtifactByRequestId(requestId: number): RenderArtifact | null {
+  return getRenderArtifactState().latestByRequestId[requestId] ?? null;
+}
+
+export function getRenderArtifactDebugState() {
+  return renderArtifactStore.getState();
+}
+
+export function __resetRenderArtifactStoreForTests() {
+  renderArtifactStore.getState().reset();
+}

--- a/apps/ui/src/stores/settingsStore.ts
+++ b/apps/ui/src/stores/settingsStore.ts
@@ -57,6 +57,11 @@ export interface ProjectSettings {
   defaultProjectDirectory: string;
 }
 
+export interface McpSettings {
+  enabled: boolean;
+  port: number;
+}
+
 export interface Settings {
   editor: EditorSettings;
   appearance: AppearanceSettings;
@@ -65,6 +70,7 @@ export interface Settings {
   library: LibrarySettings;
   privacy: PrivacySettings;
   project: ProjectSettings;
+  mcp: McpSettings;
 }
 
 const DEFAULT_VIM_CONFIG = `# Vim Configuration
@@ -140,6 +146,10 @@ const DEFAULT_SETTINGS: Settings = {
   project: {
     defaultProjectDirectory: '',
   },
+  mcp: {
+    enabled: true,
+    port: 32123,
+  },
 };
 
 const SETTINGS_KEY = 'openscad-studio-settings';
@@ -183,6 +193,10 @@ export function loadSettings(): Settings {
         project: {
           ...DEFAULT_SETTINGS.project,
           ...(parsed.project || {}),
+        },
+        mcp: {
+          ...DEFAULT_SETTINGS.mcp,
+          ...(parsed.mcp || {}),
         },
       };
     }

--- a/apps/ui/src/utils/__tests__/capturePreview.test.ts
+++ b/apps/ui/src/utils/__tests__/capturePreview.test.ts
@@ -1,0 +1,97 @@
+/** @jest-environment jsdom */
+
+import { jest } from '@jest/globals';
+import { captureCurrentPreview } from '../capturePreview';
+
+describe('captureCurrentPreview', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    jest.restoreAllMocks();
+  });
+
+  it('prefers the scoped 3D preview canvas for the active viewer', async () => {
+    const staleCanvas = document.createElement('canvas');
+    staleCanvas.dataset.engine = 'stale';
+    jest.spyOn(staleCanvas, 'toDataURL').mockReturnValue('data:image/png;base64,stale');
+    document.body.appendChild(staleCanvas);
+
+    const scopedRoot = document.createElement('div');
+    scopedRoot.setAttribute('data-preview-root', 'viewer-2');
+    const activeCanvas = document.createElement('canvas');
+    activeCanvas.dataset.engine = 'active';
+    jest.spyOn(activeCanvas, 'toDataURL').mockReturnValue('data:image/png;base64,active');
+    scopedRoot.appendChild(activeCanvas);
+    document.body.appendChild(scopedRoot);
+
+    const result = await captureCurrentPreview({ viewerId: 'viewer-2' });
+
+    expect(result).toBe('data:image/png;base64,active');
+  });
+
+  it('prefers the scoped SVG preview for the active viewer', async () => {
+    document.body.innerHTML = `
+      <div data-preview-root="viewer-1">
+        <svg width="10" height="10" xmlns="http://www.w3.org/2000/svg">
+          <g data-preview-svg><circle cx="5" cy="5" r="4" /></g>
+        </svg>
+      </div>
+      <div data-preview-root="viewer-2">
+        <svg width="10" height="10" xmlns="http://www.w3.org/2000/svg">
+          <g data-preview-svg><rect width="10" height="10" /></g>
+        </svg>
+      </div>
+    `;
+
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: jest.fn(() => 'blob:scoped-preview'),
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: jest.fn(),
+    });
+
+    class MockImage {
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      naturalWidth = 200;
+      naturalHeight = 100;
+
+      set src(_value: string) {
+        this.onload?.();
+      }
+    }
+
+    Object.defineProperty(globalThis, 'Image', {
+      configurable: true,
+      value: MockImage,
+    });
+
+    const drawImage = jest.fn();
+    const fillRect = jest.fn();
+    const toDataURL = jest.fn(() => 'data:image/png;base64,scoped-svg');
+    const originalCreateElement = document.createElement.bind(document);
+    jest.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+      if (tagName === 'canvas') {
+        return {
+          width: 0,
+          height: 0,
+          getContext: jest.fn(() => ({
+            fillStyle: '',
+            fillRect,
+            drawImage,
+          })),
+          toDataURL,
+        } as unknown as HTMLCanvasElement;
+      }
+
+      return originalCreateElement(tagName);
+    });
+
+    const result = await captureCurrentPreview({ viewerId: 'viewer-2' });
+
+    expect(result).toBe('data:image/png;base64,scoped-svg');
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:scoped-preview');
+  });
+});

--- a/apps/ui/src/utils/__tests__/openscadProjectFiles.test.ts
+++ b/apps/ui/src/utils/__tests__/openscadProjectFiles.test.ts
@@ -22,6 +22,36 @@ describe('openscadProjectFiles helpers', () => {
     );
   });
 
+  it('prefers a renderable file whose basename matches the workspace name', () => {
+    expect(
+      pickOpenScadRenderTarget(
+        ['openscad/config.scad', 'openscad/poly555.scad', 'z.scad'],
+        null,
+        'poly555'
+      )
+    ).toBe('openscad/poly555.scad');
+  });
+
+  it('breaks workspace-name matches by shallower path and then alphabetical order', () => {
+    expect(
+      pickOpenScadRenderTarget(
+        ['nested/deeper/poly555.scad', 'alpha/poly555.scad', 'beta/poly555.scad'],
+        null,
+        'poly555'
+      )
+    ).toBe('alpha/poly555.scad');
+  });
+
+  it('preserves the preferred render target when provided', () => {
+    expect(
+      pickOpenScadRenderTarget(
+        ['openscad/config.scad', 'openscad/poly555.scad'],
+        'openscad/config.scad',
+        'poly555'
+      )
+    ).toBe('openscad/config.scad');
+  });
+
   it('returns null when no renderable files exist', () => {
     expect(pickOpenScadRenderTarget(['lib/constants.h', 'params.h'])).toBeNull();
   });

--- a/apps/ui/src/utils/__tests__/resolveWorkingDirDeps.test.ts
+++ b/apps/ui/src/utils/__tests__/resolveWorkingDirDeps.test.ts
@@ -1,5 +1,9 @@
 import { jest } from '@jest/globals';
-import { normalizePath, resolveWorkingDirDeps } from '../resolveWorkingDirDeps';
+import {
+  normalizePath,
+  resolveWorkingDirDeps,
+  resolveWorkingDirDepsDetailed,
+} from '../resolveWorkingDirDeps';
 import type { PlatformBridge } from '../../platform/types';
 
 describe('normalizePath', () => {
@@ -114,6 +118,29 @@ describe('resolveWorkingDirDeps', () => {
     expect(result).toEqual({
       'a.scad': 'include <b.scad>\nmodule a() { b(); }',
       'b.scad': 'module b() { cube(1); }',
+    });
+  });
+
+  it('resolves transitive includes relative to the included file directory', async () => {
+    const platform = createMockPlatform({
+      '/project/openscad/lib/enclosure.scad':
+        'include <values.scad>\ninclude <basic_shapes.scad>\nmodule enclosure() {}',
+      '/project/openscad/lib/values.scad': 'keys_x = 10;',
+      '/project/openscad/lib/basic_shapes.scad': 'module rounded_cube() {}',
+    });
+
+    const result = await resolveWorkingDirDeps('include <lib/enclosure.scad>', {
+      workingDir: '/project',
+      libraryFiles: {},
+      platform: platform as unknown as PlatformBridge,
+      renderTargetDir: 'openscad',
+    });
+
+    expect(result).toEqual({
+      'openscad/lib/enclosure.scad':
+        'include <values.scad>\ninclude <basic_shapes.scad>\nmodule enclosure() {}',
+      'openscad/lib/values.scad': 'keys_x = 10;',
+      'openscad/lib/basic_shapes.scad': 'module rounded_cube() {}',
     });
   });
 
@@ -339,5 +366,45 @@ describe('resolveWorkingDirDeps', () => {
     });
 
     expect(result).toEqual({});
+  });
+
+  it('prefers disk over clean project files when requested, while preserving dirty overrides', async () => {
+    const platform = createMockPlatform({
+      '/project/dep.scad': 'size = 20;',
+    });
+
+    const result = await resolveWorkingDirDepsDetailed('include <dep.scad>\ncube(size);', {
+      workingDir: '/project',
+      libraryFiles: {},
+      platform: platform as unknown as PlatformBridge,
+      projectFiles: {
+        'dep.scad': 'size = 10;',
+      },
+      dirtyProjectFiles: {
+        'dirty.scad': 'unused = true;',
+      },
+      preferDiskForProjectFiles: true,
+      includeProjectFilesAsFallback: false,
+    });
+
+    expect(result.files).toEqual({
+      'dep.scad': 'size = 20;',
+    });
+    expect(result.missingPaths).toEqual([]);
+  });
+
+  it('reports missing dependencies in the detailed resolver result', async () => {
+    const platform = createMockPlatform({});
+
+    const result = await resolveWorkingDirDepsDetailed('include <missing.scad>', {
+      workingDir: '/project',
+      libraryFiles: {},
+      platform: platform as unknown as PlatformBridge,
+      preferDiskForProjectFiles: true,
+      includeProjectFilesAsFallback: false,
+    });
+
+    expect(result.files).toEqual({});
+    expect(result.missingPaths).toEqual(['missing.scad']);
   });
 });

--- a/apps/ui/src/utils/__tests__/workspaceFolder.test.ts
+++ b/apps/ui/src/utils/__tests__/workspaceFolder.test.ts
@@ -36,6 +36,22 @@ describe('workspaceFolder', () => {
     expect(platform.writeTextFile).not.toHaveBeenCalled();
   });
 
+  it('prefers a nested entrypoint whose basename matches the workspace folder name', async () => {
+    const platform = {
+      createDirectory: jest.fn(),
+      readDirectoryFiles: jest.fn(async () => ({
+        'openscad/config.scad': '// config',
+        'openscad/poly555.scad': 'include <config.scad>;',
+      })),
+      readSubdirectories: jest.fn(async () => ['openscad']),
+      writeTextFile: jest.fn(),
+    };
+
+    const result = await loadWorkspaceFolder(platform, '/tmp/poly555');
+
+    expect(result.renderTargetPath).toBe('openscad/poly555.scad');
+  });
+
   it('creates a default main.scad file when opening an empty folder in create mode', async () => {
     const platform = {
       createDirectory: jest.fn(async () => {}),

--- a/apps/ui/src/utils/__tests__/workspaceFolder.test.ts
+++ b/apps/ui/src/utils/__tests__/workspaceFolder.test.ts
@@ -1,0 +1,65 @@
+/** @jest-environment jsdom */
+
+import { jest } from '@jest/globals';
+import { findEmptyFolders, loadWorkspaceFolder } from '../workspaceFolder';
+import { DEFAULT_OPENSCAD_CODE, DEFAULT_TAB_NAME } from '../../stores/workspaceFactories';
+
+describe('workspaceFolder', () => {
+  it('finds directories that have no file descendants', () => {
+    expect(
+      findEmptyFolders(['lib', 'lib/generated', 'parts', 'parts/full'], ['parts/full/main.scad'])
+    ).toEqual(['lib', 'lib/generated']);
+  });
+
+  it('loads a workspace folder and prefers main.scad as the render target', async () => {
+    const platform = {
+      createDirectory: jest.fn(),
+      readDirectoryFiles: jest.fn(async () => ({
+        'lib/helper.scad': '// helper',
+        'main.scad': 'cube(1);',
+      })),
+      readSubdirectories: jest.fn(async () => ['lib', 'empty']),
+      writeTextFile: jest.fn(),
+    };
+
+    const result = await loadWorkspaceFolder(platform, '/tmp/project');
+
+    expect(result).toEqual({
+      files: {
+        'lib/helper.scad': '// helper',
+        'main.scad': 'cube(1);',
+      },
+      renderTargetPath: 'main.scad',
+      emptyFolders: ['empty'],
+      createdDefaultFile: false,
+    });
+    expect(platform.writeTextFile).not.toHaveBeenCalled();
+  });
+
+  it('creates a default main.scad file when opening an empty folder in create mode', async () => {
+    const platform = {
+      createDirectory: jest.fn(async () => {}),
+      readDirectoryFiles: jest.fn(async () => ({})),
+      readSubdirectories: jest.fn(async () => []),
+      writeTextFile: jest.fn(async () => {}),
+    };
+
+    const result = await loadWorkspaceFolder(platform, '/tmp/empty', {
+      createIfEmpty: true,
+    });
+
+    expect(platform.createDirectory).toHaveBeenCalledWith('/tmp/empty');
+    expect(platform.writeTextFile).toHaveBeenCalledWith(
+      '/tmp/empty/main.scad',
+      DEFAULT_OPENSCAD_CODE
+    );
+    expect(result).toEqual({
+      files: {
+        [DEFAULT_TAB_NAME]: DEFAULT_OPENSCAD_CODE,
+      },
+      renderTargetPath: DEFAULT_TAB_NAME,
+      emptyFolders: [],
+      createdDefaultFile: true,
+    });
+  });
+});

--- a/apps/ui/src/utils/capturePreview.ts
+++ b/apps/ui/src/utils/capturePreview.ts
@@ -1,5 +1,7 @@
 import { captureSvgPreviewImage, type SvgPreviewImageOptions } from './captureSvgPreviewImage';
 
+export const MAIN_PREVIEW_VIEWER_ID = 'workspace-preview';
+
 export type CaptureCurrentPreviewOptions = Pick<
   SvgPreviewImageOptions,
   'svgSourceUrl' | 'targetWidth' | 'targetHeight'

--- a/apps/ui/src/utils/capturePreview.ts
+++ b/apps/ui/src/utils/capturePreview.ts
@@ -3,12 +3,28 @@ import { captureSvgPreviewImage, type SvgPreviewImageOptions } from './captureSv
 export type CaptureCurrentPreviewOptions = Pick<
   SvgPreviewImageOptions,
   'svgSourceUrl' | 'targetWidth' | 'targetHeight'
->;
+> & {
+  viewerId?: string | null;
+};
+
+function getPreviewRoot(viewerId?: string | null): ParentNode | null {
+  if (typeof document === 'undefined' || !viewerId) {
+    return null;
+  }
+
+  if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
+    return document.querySelector(`[data-preview-root="${CSS.escape(viewerId)}"]`);
+  }
+
+  return document.querySelector(`[data-preview-root="${viewerId.replace(/"/g, '\\"')}"]`);
+}
 
 export async function captureCurrentPreview(
   options: CaptureCurrentPreviewOptions = {}
 ): Promise<string | null> {
-  const canvas = document.querySelector('canvas[data-engine]') as HTMLCanvasElement | null;
+  const previewRoot = getPreviewRoot(options.viewerId);
+  const canvas = (previewRoot?.querySelector('canvas[data-engine]') ??
+    document.querySelector('canvas[data-engine]')) as HTMLCanvasElement | null;
   if (canvas) {
     try {
       return canvas.toDataURL('image/png');
@@ -20,8 +36,13 @@ export async function captureCurrentPreview(
   }
 
   try {
+    const svgElement =
+      (previewRoot?.querySelector('[data-preview-svg]')?.closest('svg') as SVGSVGElement | null) ??
+      null;
+
     return await captureSvgPreviewImage({
       svgSourceUrl: options.svgSourceUrl,
+      svgElement,
       targetWidth: options.targetWidth,
       targetHeight: options.targetHeight,
     });

--- a/apps/ui/src/utils/resolveWorkingDirDeps.ts
+++ b/apps/ui/src/utils/resolveWorkingDirDeps.ts
@@ -40,6 +40,35 @@ export interface ResolveOptions {
   renderTargetDir?: string;
 }
 
+export interface ResolveWorkingDirDepsDetailedOptions extends ResolveOptions {
+  /**
+   * Dirty in-memory project files that should override disk reads.
+   * Used by MCP so unsaved Studio edits are preserved while clean files refresh from disk.
+   */
+  dirtyProjectFiles?: Record<string, string>;
+  /**
+   * When true, try reading clean project files from disk before falling back to
+   * projectFiles. Defaults to false to preserve the normal editor render path.
+   */
+  preferDiskForProjectFiles?: boolean;
+  /**
+   * When false, do not fall back to clean projectFiles after a disk miss.
+   * Useful for MCP renders where stale in-memory clean files are exactly what we
+   * want to avoid.
+   */
+  includeProjectFilesAsFallback?: boolean;
+}
+
+export interface ResolveWorkingDirDepsDetailedResult {
+  files: Record<string, string>;
+  missingPaths: string[];
+  stats: {
+    diskReads: number;
+    dirtyProjectFileHits: number;
+    projectFileFallbackHits: number;
+  };
+}
+
 /**
  * Normalize a relative path by resolving `.` and `..` segments.
  * Does NOT touch the filesystem — pure string manipulation.
@@ -65,59 +94,53 @@ export function normalizePath(p: string): string {
   return resolved.join('/');
 }
 
-/**
- * Resolve working-directory dependencies for the given OpenSCAD source code.
- *
- * Returns a map of `{ relativePath: fileContent }` containing only the files
- * that the code (and its transitive includes) actually reference from the
- * working directory.
- */
-export async function resolveWorkingDirDeps(
+function lookupProjectFileCandidate(
+  path: string,
+  projectFiles: Record<string, string> | undefined,
+  renderTargetDir: string | undefined
+): [string, string] | null {
+  if (!projectFiles) return null;
+  if (path in projectFiles) return [path, projectFiles[path]];
+  if (renderTargetDir) {
+    const prefixed = renderTargetDir + '/' + path;
+    if (prefixed in projectFiles) return [prefixed, projectFiles[prefixed]];
+  }
+  return null;
+}
+
+export async function resolveWorkingDirDepsDetailed(
   code: string,
-  options: ResolveOptions
-): Promise<Record<string, string>> {
-  const { workingDir, libraryFiles, platform, projectFiles, renderTargetDir } = options;
+  options: ResolveWorkingDirDepsDetailedOptions
+): Promise<ResolveWorkingDirDepsDetailedResult> {
+  const {
+    workingDir,
+    libraryFiles,
+    platform,
+    projectFiles,
+    dirtyProjectFiles,
+    renderTargetDir,
+    preferDiskForProjectFiles = false,
+    includeProjectFilesAsFallback = true,
+  } = options;
   const result: Record<string, string> = {};
   const visited = new Set<string>();
+  const missingPaths = new Set<string>();
+  const stats = {
+    diskReads: 0,
+    dirtyProjectFileHits: 0,
+    projectFileFallbackHits: 0,
+  };
 
-  /**
-   * Look up a path in projectFiles, trying both the bare path and the
-   * render-target-relative path.  Returns [matchedKey, content] or null.
-   */
-  function lookupProjectFile(path: string): [string, string] | null {
-    if (!projectFiles) return null;
-    if (path in projectFiles) return [path, projectFiles[path]];
-    // Try prefixing with the render target's directory so that sibling
-    // includes like `constants.scad` match `examples/keebcu/constants.scad`.
+  async function resolveFromDisk(path: string): Promise<[string, string] | null> {
+    const absolutePath = workingDir + '/' + path;
+    stats.diskReads += 1;
+    const content = await platform.readTextFile(absolutePath);
+    if (content !== null) return [path, content];
+
     if (renderTargetDir) {
       const prefixed = renderTargetDir + '/' + path;
-      if (prefixed in projectFiles) return [prefixed, projectFiles[prefixed]];
-    }
-    return null;
-  }
-
-  /**
-   * Resolve a single file path: check project store, then fall back to disk.
-   * Tries both the bare path and the renderTargetDir-prefixed path (matching
-   * the same fallback logic as lookupProjectFile).
-   * Returns [matchedKey, content] or null if the file can't be found.
-   */
-  async function resolveFile(normalizedPath: string): Promise<[string, string] | null> {
-    // Check project store first (works on both web and desktop)
-    const match = lookupProjectFile(normalizedPath);
-    if (match) return match;
-
-    // Fall back to reading from disk (desktop only, web returns null)
-    const absolutePath = workingDir + '/' + normalizedPath;
-    const content = await platform.readTextFile(absolutePath);
-    if (content !== null) return [normalizedPath, content];
-
-    // Try renderTargetDir-prefixed path on disk (e.g. include <lib/foo.scad>
-    // from render target examples/poly555/openscad/poly555.scad resolves to
-    // examples/poly555/openscad/lib/foo.scad on disk).
-    if (renderTargetDir) {
-      const prefixed = renderTargetDir + '/' + normalizedPath;
       const prefixedAbsolute = workingDir + '/' + prefixed;
+      stats.diskReads += 1;
       const prefixedContent = await platform.readTextFile(prefixedAbsolute);
       if (prefixedContent !== null) return [prefixed, prefixedContent];
     }
@@ -125,25 +148,52 @@ export async function resolveWorkingDirDeps(
     return null;
   }
 
-  /**
-   * Resolve include/use directives and import() calls from source code.
-   * @param sourceCode - The OpenSCAD source code to parse
-   * @param currentFileDir - Directory of the file being processed (project-relative,
-   *   e.g. "examples/poly555/openscad/lib"), used to resolve import() paths.
-   *   Empty string for files at the project root.
-   * @param depth - Current recursion depth
-   */
+  async function resolveFile(normalizedPath: string): Promise<[string, string] | null> {
+    const dirtyMatch = lookupProjectFileCandidate(normalizedPath, dirtyProjectFiles, renderTargetDir);
+    if (dirtyMatch) {
+      stats.dirtyProjectFileHits += 1;
+      return dirtyMatch;
+    }
+
+    if (preferDiskForProjectFiles) {
+      const diskMatch = await resolveFromDisk(normalizedPath);
+      if (diskMatch) return diskMatch;
+
+      if (includeProjectFilesAsFallback) {
+        const cleanFallback = lookupProjectFileCandidate(
+          normalizedPath,
+          projectFiles,
+          renderTargetDir
+        );
+        if (cleanFallback) {
+          stats.projectFileFallbackHits += 1;
+          return cleanFallback;
+        }
+      }
+
+      return null;
+    }
+
+    const projectMatch = lookupProjectFileCandidate(normalizedPath, projectFiles, renderTargetDir);
+    if (projectMatch) {
+      stats.projectFileFallbackHits += 1;
+      return projectMatch;
+    }
+
+    return resolveFromDisk(normalizedPath);
+  }
+
   async function resolve(sourceCode: string, currentFileDir: string, depth: number): Promise<void> {
     if (depth > MAX_DEPTH) {
       console.warn('[resolveWorkingDirDeps] Max recursion depth reached');
       return;
     }
 
-    // --- include/use directives (paths relative to project root) ---
     const directives = parseIncludes(sourceCode);
 
     for (const directive of directives) {
-      const normalizedPath = normalizePath(directive.path);
+      const joinedPath = currentFileDir ? currentFileDir + '/' + directive.path : directive.path;
+      const normalizedPath = normalizePath(joinedPath);
 
       if (visited.has(normalizedPath)) continue;
       visited.add(normalizedPath);
@@ -154,23 +204,22 @@ export async function resolveWorkingDirDeps(
       }
 
       const resolved = await resolveFile(normalizedPath);
-      if (!resolved) continue;
+      if (!resolved) {
+        missingPaths.add(normalizedPath);
+        continue;
+      }
 
       const [matchedKey, content] = resolved;
       result[matchedKey] = content;
 
-      // Derive the directory of this included file for its own import() resolution
       const lastSlash = matchedKey.lastIndexOf('/');
       const childDir = lastSlash > 0 ? matchedKey.substring(0, lastSlash) : '';
       await resolve(content, childDir, depth + 1);
     }
 
-    // --- import() calls (paths relative to the containing file) ---
     const imports = parseImports(sourceCode);
 
     for (const imp of imports) {
-      // Resolve the import path relative to the directory of the file that
-      // contains the import() call, then normalize to a project-relative path.
       const joinedPath = currentFileDir ? currentFileDir + '/' + imp.path : imp.path;
       const normalizedPath = normalizePath(joinedPath);
 
@@ -182,16 +231,36 @@ export async function resolveWorkingDirDeps(
       }
 
       const resolved = await resolveFile(normalizedPath);
-      if (!resolved) continue;
+      if (!resolved) {
+        missingPaths.add(normalizedPath);
+        continue;
+      }
 
       const [matchedKey, content] = resolved;
       result[matchedKey] = content;
-      // Do NOT recurse — imported files are assets (SVG/STL/DXF), not OpenSCAD code
     }
   }
 
-  // Determine the render target's directory for the initial resolve call
-  const initialDir = renderTargetDir ?? '';
-  await resolve(code, initialDir, 0);
-  return result;
+  await resolve(code, renderTargetDir ?? '', 0);
+
+  return {
+    files: result,
+    missingPaths: [...missingPaths].sort((a, b) => a.localeCompare(b)),
+    stats,
+  };
+}
+
+/**
+ * Resolve working-directory dependencies for the given OpenSCAD source code.
+ *
+ * Returns a map of `{ relativePath: fileContent }` containing only the files
+ * that the code (and its transitive includes) actually reference from the
+ * working directory.
+ */
+export async function resolveWorkingDirDeps(
+  code: string,
+  options: ResolveOptions
+): Promise<Record<string, string>> {
+  const resolved = await resolveWorkingDirDepsDetailed(code, options);
+  return resolved.files;
 }

--- a/apps/ui/src/utils/resolveWorkingDirDeps.ts
+++ b/apps/ui/src/utils/resolveWorkingDirDeps.ts
@@ -149,7 +149,11 @@ export async function resolveWorkingDirDepsDetailed(
   }
 
   async function resolveFile(normalizedPath: string): Promise<[string, string] | null> {
-    const dirtyMatch = lookupProjectFileCandidate(normalizedPath, dirtyProjectFiles, renderTargetDir);
+    const dirtyMatch = lookupProjectFileCandidate(
+      normalizedPath,
+      dirtyProjectFiles,
+      renderTargetDir
+    );
     if (dirtyMatch) {
       stats.dirtyProjectFileHits += 1;
       return dirtyMatch;

--- a/apps/ui/src/utils/workspaceFolder.ts
+++ b/apps/ui/src/utils/workspaceFolder.ts
@@ -1,0 +1,82 @@
+import type { PlatformBridge } from '../platform';
+import { DEFAULT_OPENSCAD_CODE, DEFAULT_TAB_NAME } from '../stores/workspaceFactories';
+
+export interface WorkspaceFolderLoadOptions {
+  createIfEmpty?: boolean;
+}
+
+export interface WorkspaceFolderLoadResult {
+  files: Record<string, string>;
+  renderTargetPath: string;
+  emptyFolders: string[];
+  createdDefaultFile: boolean;
+}
+
+type WorkspaceFolderPlatform = Pick<
+  PlatformBridge,
+  'createDirectory' | 'readDirectoryFiles' | 'readSubdirectories' | 'writeTextFile'
+>;
+
+/**
+ * Given all subdirectory paths and all file paths in a project,
+ * return the directories that have no file descendants (empty folders).
+ */
+export function findEmptyFolders(allDirs: string[], filePaths: string[]): string[] {
+  return allDirs.filter((dir) => {
+    const prefix = dir + '/';
+    return !filePaths.some((filePath) => filePath.startsWith(prefix));
+  });
+}
+
+function pickRenderTarget(filePaths: string[]): string | null {
+  if (filePaths.length === 0) {
+    return null;
+  }
+
+  return (
+    filePaths.find((filePath) => filePath === DEFAULT_TAB_NAME) ??
+    [...filePaths].sort((a, b) => a.localeCompare(b))[0]
+  );
+}
+
+export async function loadWorkspaceFolder(
+  platform: WorkspaceFolderPlatform,
+  dirPath: string,
+  options: WorkspaceFolderLoadOptions = {}
+): Promise<WorkspaceFolderLoadResult> {
+  let files = await platform.readDirectoryFiles(dirPath, ['scad'], true);
+  let filePaths = Object.keys(files);
+  let createdDefaultFile = false;
+
+  if (filePaths.length === 0) {
+    if (!options.createIfEmpty) {
+      throw new Error('No .scad files found in the selected folder');
+    }
+
+    createdDefaultFile = true;
+    await platform.createDirectory(dirPath);
+    await platform.writeTextFile(`${dirPath}/${DEFAULT_TAB_NAME}`, DEFAULT_OPENSCAD_CODE);
+    files = { [DEFAULT_TAB_NAME]: DEFAULT_OPENSCAD_CODE };
+    filePaths = [DEFAULT_TAB_NAME];
+  }
+
+  const renderTargetPath = pickRenderTarget(filePaths);
+  if (!renderTargetPath) {
+    throw new Error('Could not determine a render target for the workspace');
+  }
+
+  let emptyFolders: string[] = [];
+  try {
+    const allDirs = await platform.readSubdirectories(dirPath);
+    emptyFolders = findEmptyFolders(allDirs, filePaths);
+  } catch {
+    emptyFolders = [];
+  }
+
+  return {
+    files,
+    renderTargetPath,
+    emptyFolders,
+    createdDefaultFile,
+  };
+}

--- a/apps/ui/src/utils/workspaceFolder.ts
+++ b/apps/ui/src/utils/workspaceFolder.ts
@@ -17,18 +17,6 @@ type WorkspaceFolderPlatform = Pick<
   'createDirectory' | 'readDirectoryFiles' | 'readSubdirectories' | 'writeTextFile'
 >;
 
-function emitStartupDetail(phase: string, detail?: string) {
-  if (typeof window === 'undefined') return;
-  window.dispatchEvent(
-    new CustomEvent('openscad:startup-phase', {
-      detail: {
-        phase,
-        detail: detail ?? null,
-      },
-    })
-  );
-}
-
 /**
  * Given all subdirectory paths and all file paths in a project,
  * return the directories that have no file descendants (empty folders).
@@ -56,9 +44,7 @@ export async function loadWorkspaceFolder(
   dirPath: string,
   options: WorkspaceFolderLoadOptions = {}
 ): Promise<WorkspaceFolderLoadResult> {
-  emitStartupDetail('workspace_scan_files_begin', dirPath);
   let files = await platform.readDirectoryFiles(dirPath, ['scad'], true);
-  emitStartupDetail('workspace_scan_files_done', `${Object.keys(files).length} file(s)`);
   let filePaths = Object.keys(files);
   let createdDefaultFile = false;
 
@@ -68,32 +54,23 @@ export async function loadWorkspaceFolder(
     }
 
     createdDefaultFile = true;
-    emitStartupDetail('workspace_create_default_begin', dirPath);
     await platform.createDirectory(dirPath);
     await platform.writeTextFile(`${dirPath}/${DEFAULT_TAB_NAME}`, DEFAULT_OPENSCAD_CODE);
     files = { [DEFAULT_TAB_NAME]: DEFAULT_OPENSCAD_CODE };
     filePaths = [DEFAULT_TAB_NAME];
-    emitStartupDetail('workspace_create_default_done', DEFAULT_TAB_NAME);
   }
 
   const renderTargetPath = pickRenderTarget(filePaths);
   if (!renderTargetPath) {
     throw new Error('Could not determine a render target for the workspace');
   }
-  emitStartupDetail('workspace_pick_render_target', renderTargetPath);
 
   let emptyFolders: string[] = [];
   try {
-    emitStartupDetail('workspace_scan_directories_begin', dirPath);
     const allDirs = await platform.readSubdirectories(dirPath);
     emptyFolders = findEmptyFolders(allDirs, filePaths);
-    emitStartupDetail(
-      'workspace_scan_directories_done',
-      `${allDirs.length} dir(s), ${emptyFolders.length} empty`
-    );
   } catch {
     emptyFolders = [];
-    emitStartupDetail('workspace_scan_directories_failed');
   }
 
   return {

--- a/apps/ui/src/utils/workspaceFolder.ts
+++ b/apps/ui/src/utils/workspaceFolder.ts
@@ -1,5 +1,6 @@
 import type { PlatformBridge } from '../platform';
 import { DEFAULT_OPENSCAD_CODE, DEFAULT_TAB_NAME } from '../stores/workspaceFactories';
+import { pickOpenScadRenderTarget } from '../../../../packages/shared/src/openscadProjectFiles';
 
 export interface WorkspaceFolderLoadOptions {
   createIfEmpty?: boolean;
@@ -28,15 +29,11 @@ export function findEmptyFolders(allDirs: string[], filePaths: string[]): string
   });
 }
 
-function pickRenderTarget(filePaths: string[]): string | null {
-  if (filePaths.length === 0) {
-    return null;
-  }
-
-  return (
-    filePaths.find((filePath) => filePath === DEFAULT_TAB_NAME) ??
-    [...filePaths].sort((a, b) => a.localeCompare(b))[0]
-  );
+function getWorkspaceName(dirPath: string): string | null {
+  const normalizedPath = dirPath.replace(/\\/g, '/').replace(/\/+$/, '');
+  const lastSlash = normalizedPath.lastIndexOf('/');
+  const folderName = lastSlash >= 0 ? normalizedPath.slice(lastSlash + 1) : normalizedPath;
+  return folderName || null;
 }
 
 export async function loadWorkspaceFolder(
@@ -60,7 +57,7 @@ export async function loadWorkspaceFolder(
     filePaths = [DEFAULT_TAB_NAME];
   }
 
-  const renderTargetPath = pickRenderTarget(filePaths);
+  const renderTargetPath = pickOpenScadRenderTarget(filePaths, null, getWorkspaceName(dirPath));
   if (!renderTargetPath) {
     throw new Error('Could not determine a render target for the workspace');
   }

--- a/apps/ui/src/utils/workspaceFolder.ts
+++ b/apps/ui/src/utils/workspaceFolder.ts
@@ -17,6 +17,18 @@ type WorkspaceFolderPlatform = Pick<
   'createDirectory' | 'readDirectoryFiles' | 'readSubdirectories' | 'writeTextFile'
 >;
 
+function emitStartupDetail(phase: string, detail?: string) {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(
+    new CustomEvent('openscad:startup-phase', {
+      detail: {
+        phase,
+        detail: detail ?? null,
+      },
+    })
+  );
+}
+
 /**
  * Given all subdirectory paths and all file paths in a project,
  * return the directories that have no file descendants (empty folders).
@@ -44,7 +56,9 @@ export async function loadWorkspaceFolder(
   dirPath: string,
   options: WorkspaceFolderLoadOptions = {}
 ): Promise<WorkspaceFolderLoadResult> {
+  emitStartupDetail('workspace_scan_files_begin', dirPath);
   let files = await platform.readDirectoryFiles(dirPath, ['scad'], true);
+  emitStartupDetail('workspace_scan_files_done', `${Object.keys(files).length} file(s)`);
   let filePaths = Object.keys(files);
   let createdDefaultFile = false;
 
@@ -54,23 +68,32 @@ export async function loadWorkspaceFolder(
     }
 
     createdDefaultFile = true;
+    emitStartupDetail('workspace_create_default_begin', dirPath);
     await platform.createDirectory(dirPath);
     await platform.writeTextFile(`${dirPath}/${DEFAULT_TAB_NAME}`, DEFAULT_OPENSCAD_CODE);
     files = { [DEFAULT_TAB_NAME]: DEFAULT_OPENSCAD_CODE };
     filePaths = [DEFAULT_TAB_NAME];
+    emitStartupDetail('workspace_create_default_done', DEFAULT_TAB_NAME);
   }
 
   const renderTargetPath = pickRenderTarget(filePaths);
   if (!renderTargetPath) {
     throw new Error('Could not determine a render target for the workspace');
   }
+  emitStartupDetail('workspace_pick_render_target', renderTargetPath);
 
   let emptyFolders: string[] = [];
   try {
+    emitStartupDetail('workspace_scan_directories_begin', dirPath);
     const allDirs = await platform.readSubdirectories(dirPath);
     emptyFolders = findEmptyFolders(allDirs, filePaths);
+    emitStartupDetail(
+      'workspace_scan_directories_done',
+      `${allDirs.length} dir(s), ${emptyFolders.length} empty`
+    );
   } catch {
     emptyFolders = [];
+    emitStartupDetail('workspace_scan_directories_failed');
   }
 
   return {

--- a/e2e/tests/integration/startup-welcome.spec.ts
+++ b/e2e/tests/integration/startup-welcome.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '../../fixtures/app.fixture';
+
+test.describe('Startup welcome', () => {
+  test('fresh web startup shows the welcome screen until the user dismisses it', async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      (window as Window & { __PLAYWRIGHT__?: boolean }).__PLAYWRIGHT__ = true;
+      localStorage.clear();
+    });
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+    const nuxPicker = page.getByTestId('nux-layout-picker');
+    await expect(nuxPicker).toBeVisible({ timeout: 10_000 });
+    await page.getByTestId('nux-layout-option-default').click();
+    await page.getByTestId('nux-layout-continue').click();
+    await expect(nuxPicker).toBeHidden({ timeout: 10_000 });
+
+    await expect(page.getByTestId('welcome-container')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId('welcome-screen')).toBeVisible();
+    await expect(page.getByTestId('app-container')).toHaveCount(0);
+
+    await page.getByTestId('welcome-start-empty-project').click();
+
+    await expect(page.getByTestId('welcome-container')).toHaveCount(0);
+    await expect(page.getByTestId('app-container')).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/implementation-plans/ai-multifile-diagnostics.md
+++ b/implementation-plans/ai-multifile-diagnostics.md
@@ -1,0 +1,23 @@
+# AI Multi-File Diagnostics
+
+## Goal
+
+Make AI diagnostics validate multi-file projects through the same render-input assembly path used by the live preview, so the AI stops reporting false include/import failures on web.
+
+## Approach
+
+- [x] Extract a shared render-input builder for project files, working-directory dependencies, and library files.
+- [x] Update `useOpenScad` to consume the shared builder instead of assembling render inputs inline.
+- [x] Update AI diagnostics to build validation inputs through the same shared path.
+- [x] Extend render service syntax checks to accept render-context options like `auxiliaryFiles` and `inputPath`.
+- [x] Add regression coverage for AI diagnostics and render-service option forwarding.
+- [x] Run lint, typecheck, and targeted/full tests.
+
+## Affected Areas
+
+- `apps/ui/src/services/aiService.ts`
+- `apps/ui/src/hooks/useAiAgent.ts`
+- `apps/ui/src/hooks/useOpenScad.ts`
+- `apps/ui/src/services/renderService.ts`
+- `apps/ui/src/services/nativeRenderService.ts`
+- tests around AI tools and render services

--- a/implementation-plans/desktop-mcp-render-bridge.md
+++ b/implementation-plans/desktop-mcp-render-bridge.md
@@ -1,0 +1,30 @@
+# Desktop MCP Render Bridge
+
+## Goal
+
+Add a desktop-only localhost MCP server that exposes Studio-specific render and verification tools for external agents without duplicating file read/write abilities they already have through the repo.
+
+## Approach
+
+1. Add a Tauri-owned HTTP MCP server with runtime config, status reporting, and a frontend response bridge.
+2. Add a frontend desktop MCP tool executor that uses the current workspace, render target, diagnostics, and preview state.
+3. Add persisted MCP settings and an AI settings card with onboarding commands and copyable snippets.
+4. Add targeted tests for tool behavior, settings defaults, and the new onboarding UI.
+
+## Affected Areas
+
+- `apps/ui/src-tauri/src/`
+- `apps/ui/src/services/`
+- `apps/ui/src/stores/settingsStore.ts`
+- `apps/ui/src/components/settings/`
+- `apps/ui/src/App.tsx`
+- `implementation-plans/desktop-mcp-render-bridge.md`
+
+## Checklist
+
+- [x] Review current desktop/render/workspace architecture on `main`
+- [x] Add desktop MCP server state, commands, and HTTP transport in Tauri
+- [x] Add frontend MCP bridge and Studio-specific tool execution
+- [x] Persist MCP settings and sync them to the desktop server
+- [x] Add AI settings onboarding UI for external agents
+- [x] Add targeted tests and run validation

--- a/implementation-plans/desktop-mcp-render-bridge.md
+++ b/implementation-plans/desktop-mcp-render-bridge.md
@@ -19,6 +19,10 @@ Add a desktop-only localhost MCP server that exposes Studio-specific render and 
 11. Replace window-level "launch complete" bookkeeping with request-scoped open results that verify the exact folder opened before MCP binds the session.
 12. Move startup-open orchestration into `main.tsx` so the full app shell mounts only after the window reaches a stable `welcome`, `ready`, or `open_failed` state.
 13. Keep `App.tsx` focused on the editor shell while one shared window-open service handles startup opens, menu opens, recent-item opens, and MCP reuse.
+14. Tighten desktop MCP render failure signaling so `trigger_render` fails on actual render errors and preview-dependent tools return actionable troubleshooting guidance.
+15. Fix desktop workspace default render-target selection and nested render-target path handling so MCP can render entrypoints under subfolders without duplicated path segments.
+16. Make MCP-triggered renders refresh a coherent dependency snapshot from disk so external edits do not mix fresh entry files with stale in-memory includes.
+17. Redesign MCP preview readback around a canonical render artifact store so screenshots, diagnostics, and render completion no longer depend on active-tab UI state.
 
 ## Affected Areas
 
@@ -29,7 +33,9 @@ Add a desktop-only localhost MCP server that exposes Studio-specific render and 
 - `apps/ui/src/App.tsx`
 - `apps/ui/src/platform/`
 - `apps/ui/src/platform/eventBus.ts`
+- `packages/shared/src/openscadProjectFiles.ts`
 - `apps/ui/src/utils/workspaceFolder.ts`
+- `apps/ui/src-tauri/src/cmd/render.rs`
 - `implementation-plans/desktop-mcp-render-bridge.md`
 
 ## Checklist
@@ -61,3 +67,14 @@ Add a desktop-only localhost MCP server that exposes Studio-specific render and 
 - [x] Extract one shared window-open service for folder/file hydration across startup, menu, recent-item, and MCP flows
 - [x] Remove startup-open orchestration from `App.tsx` so MCP correctness no longer depends on passive effects
 - [x] Restore the codebase to production mode by removing temporary startup diagnosis logging and debug commands
+- [x] Make desktop MCP render-triggering fail on render/runtime and diagnostic errors instead of always returning success
+- [x] Add contextual troubleshooting guidance for screenshot/export failures when the preview or current render target is unusable
+- [x] Add desktop MCP bridge tests for render failure signaling and preview-related recovery guidance
+- [x] Unify folder-open render-target picking around the shared helper and prefer workspace-name entrypoints over support files
+- [x] Harden native desktop render path normalization so nested render targets remain project-relative and duplicated leading segments collapse safely
+- [x] Add regression coverage for nested default entrypoints and nested native render temp-file placement
+- [x] Refresh MCP render-target dependency snapshots from disk while preserving dirty in-app files as overrides
+- [x] Reuse the coherent MCP snapshot refresh path for diagnostics and export flows
+- [x] Add targeted tests for MCP snapshot refresh, missing dependencies, and disk-first dependency resolution
+- [x] Restore the desktop render-root contract so nested workspace targets render with the workspace root as `workingDir` and the nested file path only in `inputPath`
+- [x] Replace the MCP preview mirror with a canonical render artifact store and explicit-view screenshot contract

--- a/implementation-plans/desktop-mcp-render-bridge.md
+++ b/implementation-plans/desktop-mcp-render-bridge.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Add a desktop-only localhost MCP server that exposes Studio-specific render and verification tools for external agents without duplicating file read/write abilities they already have through the repo, plus a desktop-only export tool for writing render output to an explicit file path. Make the server safe for multiple Studio windows by binding each MCP session to a specific registered workspace window and routing requests only to that window.
+Add a desktop-only localhost MCP server that exposes Studio-specific render and verification tools for external agents without duplicating file read/write abilities they already have through the repo, plus a desktop-only export tool for writing render output to an explicit file path. Make the server safe for multiple Studio windows by binding each MCP session to a specific registered workspace window and routing requests only to that window. Replace the old "create a blank window, then steer it later" behavior with a bootstrap open controller, synchronous window bootstrap payloads, and request-scoped open acknowledgements so folders and files open reliably without getting stuck on the welcome screen.
 
 ## Approach
 
@@ -11,8 +11,14 @@ Add a desktop-only localhost MCP server that exposes Studio-specific render and 
 3. Add persisted MCP settings and an AI settings card with onboarding commands and copyable snippets.
 4. Add targeted tests for tool behavior, settings defaults, and the new onboarding UI.
 5. Add a desktop-only `export_file` MCP tool that exports the current render target to a caller-provided file path.
-6. Add per-session MCP workspace binding, explicit workspace-selection tools, and window-scoped request routing.
+6. Add per-session MCP workspace binding, window-scoped request routing, and a single safe public `get_or_create_workspace` entrypoint.
 7. Add desktop multi-window support with `Cmd+Shift+N` and focused-window menu dispatch.
+8. Add a workspace creation/attach MCP path that reuses an already-open matching workspace, prefers an unused welcome window, and only creates a new window when needed.
+9. Harden newly created or reused desktop windows with an explicit MCP bridge-ready handshake so the first tool request cannot race frontend startup.
+10. Introduce first-class window launch intents and a shared desktop open-folder/open-file flow so new windows can open targets during boot instead of depending on a later MCP event.
+11. Replace window-level "launch complete" bookkeeping with request-scoped open results that verify the exact folder opened before MCP binds the session.
+12. Move startup-open orchestration into `main.tsx` so the full app shell mounts only after the window reaches a stable `welcome`, `ready`, or `open_failed` state.
+13. Keep `App.tsx` focused on the editor shell while one shared window-open service handles startup opens, menu opens, recent-item opens, and MCP reuse.
 
 ## Affected Areas
 
@@ -22,6 +28,8 @@ Add a desktop-only localhost MCP server that exposes Studio-specific render and 
 - `apps/ui/src/components/settings/`
 - `apps/ui/src/App.tsx`
 - `apps/ui/src/platform/`
+- `apps/ui/src/platform/eventBus.ts`
+- `apps/ui/src/utils/workspaceFolder.ts`
 - `implementation-plans/desktop-mcp-render-bridge.md`
 
 ## Checklist
@@ -34,7 +42,22 @@ Add a desktop-only localhost MCP server that exposes Studio-specific render and 
 - [x] Add targeted tests and run validation
 - [x] Add desktop-only MCP export support for writing render output to a file path
 - [x] Add Rust-side window registry and per-session MCP binding
-- [x] Add MCP workspace listing/selection tools and enforce binding for render-oriented tools
+- [x] Replace public workspace selection tools with `get_or_create_workspace(folder_path)` and enforce binding for render-oriented tools
 - [x] Register/update current Studio window context from the frontend and route MCP requests to the bound window only
 - [x] Add desktop `New Window` support plus focused-window menu event routing
 - [x] Update onboarding copy and validation for multi-window/session behavior
+- [x] Add MCP workspace-creation/attach tool that binds to an existing matching workspace when possible
+- [x] Reuse blank welcome windows for MCP workspace creation instead of always spawning a new window
+- [x] Add targeted tests for workspace-creation routing and frontend folder initialization
+- [x] Add an explicit desktop MCP bridge-ready handshake so new-window workspace creation does not race the frontend listener
+- [x] Add a Tauri-owned window launch intent contract for welcome, open-folder, and open-file startup behavior
+- [x] Add a dedicated desktop open-request/result channel for reusing already-open welcome windows
+- [x] Unify folder/file opening in the frontend so launch-intent startup, menu actions, and MCP reuse the same codepath
+- [x] Return targeted open/launch failures instead of leaving `get_or_create_workspace` hanging on the welcome screen
+- [x] Inject new-window launch intents synchronously at webview creation time instead of storing them in Rust for later consumption
+- [x] Wait for exact request-scoped open acknowledgements rather than generic window launch flags before binding MCP sessions
+- [x] Show an explicit startup opening state instead of briefly settling on the welcome screen while a target is loading
+- [x] Add a bootstrap open controller in `main.tsx` that resolves startup state before mounting the main app shell
+- [x] Extract one shared window-open service for folder/file hydration across startup, menu, recent-item, and MCP flows
+- [x] Remove startup-open orchestration from `App.tsx` so MCP correctness no longer depends on passive effects
+- [x] Restore the codebase to production mode by removing temporary startup diagnosis logging and debug commands

--- a/implementation-plans/desktop-mcp-render-bridge.md
+++ b/implementation-plans/desktop-mcp-render-bridge.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Add a desktop-only localhost MCP server that exposes Studio-specific render and verification tools for external agents without duplicating file read/write abilities they already have through the repo.
+Add a desktop-only localhost MCP server that exposes Studio-specific render and verification tools for external agents without duplicating file read/write abilities they already have through the repo, plus a desktop-only export tool for writing render output to an explicit file path. Make the server safe for multiple Studio windows by binding each MCP session to a specific registered workspace window and routing requests only to that window.
 
 ## Approach
 
@@ -10,6 +10,9 @@ Add a desktop-only localhost MCP server that exposes Studio-specific render and 
 2. Add a frontend desktop MCP tool executor that uses the current workspace, render target, diagnostics, and preview state.
 3. Add persisted MCP settings and an AI settings card with onboarding commands and copyable snippets.
 4. Add targeted tests for tool behavior, settings defaults, and the new onboarding UI.
+5. Add a desktop-only `export_file` MCP tool that exports the current render target to a caller-provided file path.
+6. Add per-session MCP workspace binding, explicit workspace-selection tools, and window-scoped request routing.
+7. Add desktop multi-window support with `Cmd+Shift+N` and focused-window menu dispatch.
 
 ## Affected Areas
 
@@ -18,6 +21,7 @@ Add a desktop-only localhost MCP server that exposes Studio-specific render and 
 - `apps/ui/src/stores/settingsStore.ts`
 - `apps/ui/src/components/settings/`
 - `apps/ui/src/App.tsx`
+- `apps/ui/src/platform/`
 - `implementation-plans/desktop-mcp-render-bridge.md`
 
 ## Checklist
@@ -28,3 +32,9 @@ Add a desktop-only localhost MCP server that exposes Studio-specific render and 
 - [x] Persist MCP settings and sync them to the desktop server
 - [x] Add AI settings onboarding UI for external agents
 - [x] Add targeted tests and run validation
+- [x] Add desktop-only MCP export support for writing render output to a file path
+- [x] Add Rust-side window registry and per-session MCP binding
+- [x] Add MCP workspace listing/selection tools and enforce binding for render-oriented tools
+- [x] Register/update current Studio window context from the frontend and route MCP requests to the bound window only
+- [x] Add desktop `New Window` support plus focused-window menu event routing
+- [x] Update onboarding copy and validation for multi-window/session behavior

--- a/implementation-plans/mcp-agent-tabs.md
+++ b/implementation-plans/mcp-agent-tabs.md
@@ -4,12 +4,15 @@
 
 Replace the MCP agent setup accordions with a horizontal Radix tabs UI that defaults to Claude Code, while consolidating the shared setup content into a reusable component for both settings and empty-state surfaces.
 
+Follow-up: adapt the docked AI panel empty state so the MCP onboarding uses a landscape-aware layout when the panel is wide and short.
+
 ## Approach
 
 - Add a reusable Radix tabs primitive to the shared UI layer.
 - Build a shared MCP agent setup tabs component that owns tab ordering, copy affordances, and code/instruction rendering.
 - Update the settings card and AI empty state to use the shared component, with Claude Code first and selected by default.
 - Refresh tests to assert the new tabbed behavior and rerun validation before committing.
+- Add a panel-only responsive mode that switches the empty state and MCP setup into a split landscape layout based on component size.
 
 ## Affected Files
 
@@ -21,6 +24,7 @@ Replace the MCP agent setup accordions with a horizontal Radix tabs UI that defa
 - `apps/ui/src/components/settings/ExternalAgentsCard.tsx`
 - `apps/ui/src/components/__tests__/AiAccessEmptyState.test.tsx`
 - `apps/ui/src/components/__tests__/SettingsDialog.test.tsx`
+- `apps/ui/src/components/AiPromptPanel.tsx`
 
 ## Checklist
 
@@ -31,3 +35,6 @@ Replace the MCP agent setup accordions with a horizontal Radix tabs UI that defa
 - [x] Update tests for default selection and tab behavior
 - [x] Run lint, typecheck, and unit tests
 - [x] Commit the changes
+- [x] Add landscape-aware panel layout for wide/short AI empty states
+- [x] Update tests for panel responsive behavior
+- [x] Re-run validation after the responsive panel changes

--- a/implementation-plans/mcp-agent-tabs.md
+++ b/implementation-plans/mcp-agent-tabs.md
@@ -1,0 +1,33 @@
+# MCP Agent Tabs
+
+## Goal
+
+Replace the MCP agent setup accordions with a horizontal Radix tabs UI that defaults to Claude Code, while consolidating the shared setup content into a reusable component for both settings and empty-state surfaces.
+
+## Approach
+
+- Add a reusable Radix tabs primitive to the shared UI layer.
+- Build a shared MCP agent setup tabs component that owns tab ordering, copy affordances, and code/instruction rendering.
+- Update the settings card and AI empty state to use the shared component, with Claude Code first and selected by default.
+- Refresh tests to assert the new tabbed behavior and rerun validation before committing.
+
+## Affected Files
+
+- `apps/ui/package.json`
+- `apps/ui/src/components/ui/Tabs.tsx`
+- `apps/ui/src/components/ui/index.ts`
+- `apps/ui/src/components/mcp/AgentSetupTabs.tsx`
+- `apps/ui/src/components/AiAccessEmptyState.tsx`
+- `apps/ui/src/components/settings/ExternalAgentsCard.tsx`
+- `apps/ui/src/components/__tests__/AiAccessEmptyState.test.tsx`
+- `apps/ui/src/components/__tests__/SettingsDialog.test.tsx`
+
+## Checklist
+
+- [x] Identify current MCP setup surfaces and shared requirements
+- [x] Add a reusable Radix tabs primitive
+- [x] Build shared MCP agent setup tabs component
+- [x] Migrate settings and empty-state MCP UI to the shared tabs component
+- [x] Update tests for default selection and tab behavior
+- [x] Run lint, typecheck, and unit tests
+- [x] Commit the changes

--- a/packages/shared/src/openscadProjectFiles.ts
+++ b/packages/shared/src/openscadProjectFiles.ts
@@ -18,9 +18,21 @@ export function isRenderableOpenScadFilePath(path: string): boolean {
   return hasAllowedExtension(path, OPENSCAD_RENDERABLE_FILE_EXTENSIONS);
 }
 
+function getPathDepth(path: string): number {
+  return path.split('/').filter(Boolean).length;
+}
+
+function getRenderableBaseName(path: string): string {
+  const normalizedPath = path.replace(/\\/g, '/');
+  const lastSlash = normalizedPath.lastIndexOf('/');
+  const fileName = lastSlash >= 0 ? normalizedPath.slice(lastSlash + 1) : normalizedPath;
+  return fileName.replace(/\.scad$/i, '');
+}
+
 export function pickOpenScadRenderTarget(
   filePaths: Iterable<string>,
-  preferredPath?: string | null
+  preferredPath?: string | null,
+  workspaceName?: string | null
 ): string | null {
   const renderableFiles = [...filePaths]
     .filter(isRenderableOpenScadFilePath)
@@ -34,5 +46,21 @@ export function pickOpenScadRenderTarget(
     return preferredPath;
   }
 
-  return renderableFiles.find((path) => path === 'main.scad') ?? renderableFiles[0];
+  const mainTarget = renderableFiles.find((path) => path === 'main.scad');
+  if (mainTarget) {
+    return mainTarget;
+  }
+
+  const normalizedWorkspaceName = workspaceName?.trim().toLowerCase() ?? '';
+  if (normalizedWorkspaceName) {
+    const matchingFiles = renderableFiles
+      .filter((path) => getRenderableBaseName(path).toLowerCase() === normalizedWorkspaceName)
+      .sort((a, b) => getPathDepth(a) - getPathDepth(b) || a.localeCompare(b));
+
+    if (matchingFiles.length > 0) {
+      return matchingFiles[0];
+    }
+  }
+
+  return renderableFiles[0];
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       '@radix-ui/react-switch':
         specifier: ^1.2.6
         version: 1.2.6(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-tabs':
+        specifier: ^1.1.13
+        version: 1.1.13(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-tooltip':
         specifier: ^1.2.8
         version: 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1375,6 +1378,19 @@ packages:
 
   '@radix-ui/react-switch@1.2.6':
     resolution: {integrity: sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-tabs@1.1.13':
+    resolution: {integrity: sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -5636,6 +5652,22 @@ snapshots:
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.26)(react@18.3.1)
       '@radix-ui/react-use-previous': 1.1.1(@types/react@18.3.26)(react@18.3.1)
       '@radix-ui/react-use-size': 1.1.1(@types/react@18.3.26)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.26
+      '@types/react-dom': 18.3.7(@types/react@18.3.26)
+
+  '@radix-ui/react-tabs@1.1.13(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.26)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.26)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.26)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.26)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@posthog/react':
         specifier: ^1.8.2
         version: 1.8.2(@types/react@18.3.26)(posthog-js@1.360.2)(react@18.3.1)
+      '@radix-ui/react-accordion':
+        specifier: ^1.2.12
+        version: 1.2.12(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-context-menu':
         specifier: ^2.2.16
         version: 2.2.16(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1134,8 +1137,34 @@ packages:
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
+  '@radix-ui/react-accordion@1.2.12':
+    resolution: {integrity: sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collapsible@1.1.12':
+    resolution: {integrity: sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -5349,9 +5378,42 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
+  '@radix-ui/react-accordion@1.2.12(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.26)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.26)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.26)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.26)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.26)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.26
+      '@types/react-dom': 18.3.7(@types/react@18.3.26)
+
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.26
+      '@types/react-dom': 18.3.7(@types/react@18.3.26)
+
+  '@radix-ui/react-collapsible@1.1.12(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.26)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.26)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.26)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.26)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.26)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:


### PR DESCRIPTION
# Summary

## What changed

- added a desktop-only localhost MCP server in Tauri that auto-starts with the app and exposes only Studio-specific render tools: `get_project_context`, `set_render_target`, `get_diagnostics`, `trigger_render`, and `get_preview_screenshot`
- added a frontend desktop MCP bridge that executes those tools against the current workspace, render target, diagnostics, and preview state
- added persisted MCP settings plus an External Agents onboarding card in AI settings with status, endpoint, Claude/Codex setup commands, and an agent guidance snippet
- extracted shared Studio tooling helpers for project context summaries and preview screenshot capture
- documented the work in `implementation-plans/desktop-mcp-render-bridge.md`

## Why

- external agents like Claude Code and Codex already read and edit repo files well, but they cannot directly access OpenSCAD Studio's render target state, diagnostics, or preview output
- this keeps MCP focused on the Studio-specific value: render coordination and verification, not general filesystem access

## Implementation notes

- MCP transport is handled in `apps/ui/src-tauri/src/mcp.rs`, while tool execution stays in the frontend via `apps/ui/src/services/desktopMcp.ts`
- the server is loopback-only, unauthenticated, and app-lifetime-scoped in v1
- MCP config is stored in `settingsStore` with `enabled` and `port`, then synchronized from `App.tsx`
- the AI settings UI now includes desktop onboarding for external agents without changing the existing in-app AI flow
- implementation plan: `implementation-plans/desktop-mcp-render-bridge.md`

# Testing

## Coverage checklist

- [ ] Backend unit tests added or updated for changed Rust behavior
- [x] Client unit/component tests added or updated for changed frontend behavior
- [ ] E2E tests added or updated for net new user-facing flows
- [ ] No new tests were needed for this change

## Validation performed

- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm test:unit`
- [ ] `pnpm test:formatter:ci`
- [ ] `pnpm test:e2e:web`
- [x] `bash scripts/validate-changes.sh --dry-run ...`
- [x] `cd apps/ui/src-tauri && cargo fmt --check`
- [x] `cd apps/ui/src-tauri && cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cd apps/ui/src-tauri && cargo check --all-targets --all-features`

## Test details

- Added settings-store coverage for MCP defaults and a settings dialog test for the external agents card.
- Reused existing AI service tests after extracting shared Studio tooling helpers.
- Ran `bash scripts/validate-changes.sh --dry-run --scope baseline --scope rust` and then `bash scripts/validate-changes.sh --scope baseline --scope rust`.
- Skipped `pnpm test:formatter:ci` because formatter behavior did not change.
- Skipped `pnpm test:e2e:web` because this change is desktop MCP infrastructure plus settings UI and does not introduce a new web E2E flow.
- Rust validation required a temporary empty `apps/ui/src-tauri/binaries/OpenSCAD.app` directory because the existing Tauri resource config expects that bundle path during local checks; the placeholder was removed after validation.

# Performance

## Performance impact

- [x] Performance was considered for this change
- [x] No meaningful performance impact is expected

## Justification

- The MCP server is idle unless an external local agent connects, and the tool surface reuses existing render and preview flows instead of introducing extra background processing.

# UI changes

## Screenshots or recordings

- N/A

# Issue link

- Closes #
