### PR TITLE
feat: add analytics coverage for v1.0 new functionality

### DIFF
--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -682,6 +682,7 @@ function App() {
 
       revokeBlobUrl(tab.render.previewSrc);
       closeTabLocal(id);
+      analytics.track('tab closed', { had_unsaved_changes: isDirty });
 
       // If closing this tab caused workspace to reset to welcome, also reset project
       const wsState = getWorkspaceState();
@@ -689,7 +690,7 @@ function App() {
         getProjectStore().getState().resetToUntitledProject();
       }
     },
-    [closeTabLocal, tabs, capabilities.hasFileSystem]
+    [analytics, closeTabLocal, tabs, capabilities.hasFileSystem]
   );
 
   const reorderTabs = useCallback(
@@ -764,10 +765,11 @@ function App() {
       // Open in a new tab
       const absolutePath = store.projectRoot ? `${store.projectRoot}/${path}` : null;
       createNewTab(absolutePath, content, path);
+      analytics.track('file created', { in_subfolder: parentDir !== '' });
 
       return path;
     },
-    [createNewTab]
+    [analytics, createNewTab]
   );
 
   const handleCreateFolder = useCallback(
@@ -778,8 +780,9 @@ function App() {
         await getPlatform().createDirectory(`${store.projectRoot}/${folderPath}`);
       }
       store.addFolder(folderPath);
+      analytics.track('folder created', { in_subfolder: parentDir !== '' });
     },
-    []
+    [analytics]
   );
 
   const handleRenameFile = useCallback(
@@ -809,8 +812,9 @@ function App() {
         markTabSaved(tab.id, { filePath: absolutePath, name: newName });
         renameTab(tab.id, newName, newPath);
       }
+      analytics.track('file renamed');
     },
-    [tabs, markTabSaved, renameTab]
+    [analytics, tabs, markTabSaved, renameTab]
   );
 
   const handleDeleteFile = useCallback(
@@ -841,6 +845,7 @@ function App() {
       }
 
       store.removeFile(filePath);
+      analytics.track('file deleted', { had_open_tab: Boolean(tab) });
 
       // If we deleted everything, reset to a fresh untitled project
       const remaining = Object.keys(store.files);
@@ -849,7 +854,7 @@ function App() {
         createNewTab(null, undefined, DEFAULT_TAB_NAME);
       }
     },
-    [tabs, closeTabLocal, createNewTab]
+    [analytics, tabs, closeTabLocal, createNewTab]
   );
 
   const handleDeleteFolder = useCallback(
@@ -893,6 +898,7 @@ function App() {
       }
 
       store.removeFolder(folderPath);
+      analytics.track('folder deleted', { file_count: affected.length });
 
       // If we deleted everything, reset to a fresh untitled project
       if (Object.keys(store.files).length === 0) {
@@ -900,12 +906,16 @@ function App() {
         createNewTab(null, undefined, DEFAULT_TAB_NAME);
       }
     },
-    [tabs, closeTabLocal, createNewTab]
+    [analytics, tabs, closeTabLocal, createNewTab]
   );
 
-  const handleSetRenderTarget = useCallback((filePath: string) => {
-    getProjectStore().getState().setRenderTarget(filePath);
-  }, []);
+  const handleSetRenderTarget = useCallback(
+    (filePath: string) => {
+      getProjectStore().getState().setRenderTarget(filePath);
+      analytics.track('render target changed');
+    },
+    [analytics]
+  );
 
   const handleMoveItem = useCallback(
     async (sourcePath: string, destFolderPath: string, isFolder: boolean) => {
@@ -978,11 +988,12 @@ function App() {
             renameTab(tab.id, newPath.split('/').pop()!, newPath);
           }
         }
+        analytics.track('item moved', { kind: isFolder ? 'folder' : 'file' });
       } catch (err) {
         notifyError({ operation: 'Move failed', error: err });
       }
     },
-    [tabs, markTabSaved, renameTab]
+    [analytics, tabs, markTabSaved, renameTab]
   );
 
   const handleAddExternalFiles = useCallback(

--- a/apps/ui/src/components/SvgViewer.tsx
+++ b/apps/ui/src/components/SvgViewer.tsx
@@ -11,6 +11,7 @@ import { buildOverlayModel } from './svg-viewer/overlayModel';
 import { attachBrowserPinchZoomGuard } from './svg-viewer/browserPinchZoomGuard';
 import { SVG_2D_TOOLS } from './svg-viewer/toolRegistry';
 import { useSvgViewerAnalytics } from './svg-viewer/useSvgViewerAnalytics';
+import { useAnalytics } from '../analytics/runtime';
 import {
   createCommittedMeasurement,
   formatMeasurementReadout,
@@ -395,6 +396,7 @@ export function SvgViewer({
   const sceneStyle = useMemo(() => getPreviewSceneStyle(theme), [theme]);
   const annotationSession = useViewerAnnotationSession();
   const resetAnnotationSession = annotationSession.resetSession;
+  const analytics = useAnalytics();
 
   const themeColors = useMemo(
     () => ({
@@ -642,6 +644,21 @@ export function SvgViewer({
     setViewMode('pan');
   };
 
+  const handleAnnotationCommit = () => {
+    const shape = annotationSession.completeDraft();
+    if (shape) {
+      analytics.track('annotation committed', { viewer_kind: '2d', shape_type: shape.kind });
+    }
+  };
+
+  const handleAnnotationClear = () => {
+    const count = annotationSession.shapes.length + (annotationSession.draft ? 1 : 0);
+    annotationSession.clearAll();
+    if (count > 0) {
+      analytics.track('annotations cleared', { viewer_kind: '2d', cleared_count: count });
+    }
+  };
+
   const handleAnnotationAttach = async () => {
     if (!containerRef.current || !annotationStageRef.current) {
       notifyError({
@@ -696,8 +713,14 @@ export function SvgViewer({
         'viewer-annotation-2d.png'
       );
 
+      const shapeCount = annotationSession.shapes.length;
       const result = await onAttachToAi(attachmentFile);
       if (result.status === 'attached') {
+        analytics.track('annotation attached', {
+          viewer_kind: '2d',
+          shape_count: shapeCount,
+          result: 'attached',
+        });
         notifySuccess('Annotation attached to AI', {
           toastId: 'viewer-annotation-attached',
         });
@@ -706,6 +729,11 @@ export function SvgViewer({
       }
 
       if (result.status === 'missing-api-key') {
+        analytics.track('annotation attached', {
+          viewer_kind: '2d',
+          shape_count: shapeCount,
+          result: 'missing-api-key',
+        });
         notifyError({
           operation: 'viewer-annotation-attach',
           fallbackMessage: 'Add an AI API key in Settings to attach annotations to the chat panel.',
@@ -715,6 +743,11 @@ export function SvgViewer({
       }
 
       if (result.status === 'busy') {
+        analytics.track('annotation attached', {
+          viewer_kind: '2d',
+          shape_count: shapeCount,
+          result: 'busy',
+        });
         notifyError({
           operation: 'viewer-annotation-attach',
           fallbackMessage: 'Wait for the current AI request or attachment processing to finish.',
@@ -723,6 +756,11 @@ export function SvgViewer({
         return;
       }
 
+      analytics.track('annotation attached', {
+        viewer_kind: '2d',
+        shape_count: shapeCount,
+        result: 'error',
+      });
       notifyError({
         operation: 'viewer-annotation-attach',
         fallbackMessage: result.errors[0] ?? 'Failed to attach the annotation image.',
@@ -1567,9 +1605,7 @@ export function SvgViewer({
                 }
                 annotationSession.updateDraft(normalizeViewerPoint(point, containerSize));
               }}
-              onEnd={() => {
-                annotationSession.completeDraft();
-              }}
+              onEnd={handleAnnotationCommit}
             />
           ) : null}
 
@@ -1659,7 +1695,7 @@ export function SvgViewer({
               tool={annotationSession.tool}
               onToolChange={annotationSession.setTool}
               onUndo={annotationSession.undoLast}
-              onClear={annotationSession.clearAll}
+              onClear={handleAnnotationClear}
               onCancel={exitAnnotationMode}
               onAttach={handleAnnotationAttach}
               canUndo={Boolean(annotationSession.draft) || annotationSession.shapes.length > 0}

--- a/apps/ui/src/components/ThreeViewer.tsx
+++ b/apps/ui/src/components/ThreeViewer.tsx
@@ -64,6 +64,7 @@ import {
   getSectionPlaneVisualTransform,
 } from './three-viewer/sectionPlaneController';
 import { useThreeViewerAnalytics } from './three-viewer/useThreeViewerAnalytics';
+import { useAnalytics } from '../analytics/runtime';
 import type {
   InteractionMode,
   LoadedPreviewModel,
@@ -1064,6 +1065,7 @@ export function ThreeViewer({
   const [isAttachingAnnotation, setIsAttachingAnnotation] = useState(false);
   const annotationSession = useViewerAnnotationSession();
   const resetAnnotationSession = annotationSession.resetSession;
+  const analytics = useAnalytics();
 
   const gridMetrics = useMemo(() => derivePreviewGridMetrics(modelFrame), [modelFrame]);
   const axisMetrics = useMemo(
@@ -1260,6 +1262,21 @@ export function ThreeViewer({
     setInteractionMode('orbit');
   }, [resetAnnotationSession]);
 
+  const handleAnnotationCommit = useCallback(() => {
+    const shape = annotationSession.completeDraft();
+    if (shape) {
+      analytics.track('annotation committed', { viewer_kind: '3d', shape_type: shape.kind });
+    }
+  }, [analytics, annotationSession]);
+
+  const handleAnnotationClear = useCallback(() => {
+    const count = annotationSession.shapes.length + (annotationSession.draft ? 1 : 0);
+    annotationSession.clearAll();
+    if (count > 0) {
+      analytics.track('annotations cleared', { viewer_kind: '3d', cleared_count: count });
+    }
+  }, [analytics, annotationSession]);
+
   const handleAnnotationAttach = useCallback(async () => {
     if (!previewSurfaceRef.current || !annotationStageRef.current) {
       notifyError({
@@ -1303,9 +1320,15 @@ export function ThreeViewer({
         composedDataUrl,
         'viewer-annotation-3d.png'
       );
+      const shapeCount = annotationSession.shapes.length;
       const result = await onAttachToAi(attachmentFile);
 
       if (result.status === 'attached') {
+        analytics.track('annotation attached', {
+          viewer_kind: '3d',
+          shape_count: shapeCount,
+          result: 'attached',
+        });
         notifySuccess('Annotation attached to AI', {
           toastId: 'viewer-annotation-attached',
         });
@@ -1314,6 +1337,11 @@ export function ThreeViewer({
       }
 
       if (result.status === 'missing-api-key') {
+        analytics.track('annotation attached', {
+          viewer_kind: '3d',
+          shape_count: shapeCount,
+          result: 'missing-api-key',
+        });
         notifyError({
           operation: 'viewer-annotation-attach',
           fallbackMessage: 'Add an AI API key in Settings to attach annotations to the chat panel.',
@@ -1323,6 +1351,11 @@ export function ThreeViewer({
       }
 
       if (result.status === 'busy') {
+        analytics.track('annotation attached', {
+          viewer_kind: '3d',
+          shape_count: shapeCount,
+          result: 'busy',
+        });
         notifyError({
           operation: 'viewer-annotation-attach',
           fallbackMessage: 'Wait for the current AI request or attachment processing to finish.',
@@ -1331,6 +1364,11 @@ export function ThreeViewer({
         return;
       }
 
+      analytics.track('annotation attached', {
+        viewer_kind: '3d',
+        shape_count: shapeCount,
+        result: 'error',
+      });
       notifyError({
         operation: 'viewer-annotation-attach',
         fallbackMessage: result.errors[0] ?? 'Failed to attach the annotation image.',
@@ -1346,7 +1384,13 @@ export function ThreeViewer({
     } finally {
       setIsAttachingAnnotation(false);
     }
-  }, [exitAnnotationMode, onAttachToAi, sceneStyle.backgroundColor]);
+  }, [
+    analytics,
+    annotationSession.shapes.length,
+    exitAnnotationMode,
+    onAttachToAi,
+    sceneStyle.backgroundColor,
+  ]);
 
   const handleMeasurementDelete = useCallback(
     (id: string) => {
@@ -1908,9 +1952,7 @@ export function ThreeViewer({
                 }
                 annotationSession.updateDraft(normalizeViewerPoint(point, previewSurfaceSize));
               }}
-              onEnd={() => {
-                annotationSession.completeDraft();
-              }}
+              onEnd={handleAnnotationCommit}
             />
           ) : null}
 
@@ -1931,7 +1973,7 @@ export function ThreeViewer({
               tool={annotationSession.tool}
               onToolChange={annotationSession.setTool}
               onUndo={annotationSession.undoLast}
-              onClear={annotationSession.clearAll}
+              onClear={handleAnnotationClear}
               onCancel={exitAnnotationMode}
               onAttach={handleAnnotationAttach}
               canUndo={Boolean(annotationSession.draft) || annotationSession.shapes.length > 0}

--- a/implementation-plans/v1-analytics-coverage.md
+++ b/implementation-plans/v1-analytics-coverage.md
@@ -1,0 +1,26 @@
+# v1.0 Analytics Coverage
+
+## Goal
+
+Add analytics instrumentation for all new functionality shipped in v1.0 that currently lacks tracking: multi-file project interactions (file tree CRUD, moves, render target changes, tab closes) and viewer annotation workflow events (annotation committed, annotations cleared, annotation attached).
+
+## Approach
+
+- Add `analytics.track()` calls directly in the existing handlers in `App.tsx` using the already-imported `useAnalytics()` hook.
+- Add `useAnalytics()` directly to `ThreeViewer.tsx` and `SvgViewer.tsx` (neither currently uses it) and wire calls into the annotation callbacks.
+- No new abstractions needed; follows existing inline tracking patterns throughout the codebase.
+
+## Affected Areas
+
+- `apps/ui/src/App.tsx` — 8 new events in multi-file handlers
+- `apps/ui/src/components/ThreeViewer.tsx` — 3 new annotation events
+- `apps/ui/src/components/SvgViewer.tsx` — 3 new annotation events
+
+## Checklist
+
+- [x] Create implementation plan
+- [x] Add multi-file events to `App.tsx` (file created, folder created, file renamed, file deleted, folder deleted, item moved, render target changed, tab closed)
+- [x] Add annotation events to `ThreeViewer.tsx` (annotation committed, annotations cleared, annotation attached)
+- [x] Add annotation events to `SvgViewer.tsx` (annotation committed, annotations cleared, annotation attached)
+- [x] Run baseline validation — format:check, lint, type-check, test:unit all pass (68 suites, 495 tests)
+- [x] Open draft PR


### PR DESCRIPTION
## Summary

- Adds `analytics.track()` calls for 8 multi-file project interactions in `App.tsx` that shipped in v1.0 with no tracking (file created, folder created, file renamed, file deleted, folder deleted, item moved, render target changed, tab closed)
- Adds 3 viewer annotation events to both `ThreeViewer.tsx` and `SvgViewer.tsx` (annotation committed, annotations cleared, annotation attached with result status)
- Follows existing inline tracking patterns throughout the codebase; no new abstractions introduced

Implementation plan: `implementation-plans/v1-analytics-coverage.md`

## What changed

- **`apps/ui/src/App.tsx`**: 8 new `analytics.track()` calls in the multi-file project handlers, with corresponding `analytics` dependency array updates
- **`apps/ui/src/components/ThreeViewer.tsx`**: Added `useAnalytics()`, `handleAnnotationCommit` and `handleAnnotationClear` callbacks wrapping the session methods, and instrumented all result branches of `handleAnnotationAttach`
- **`apps/ui/src/components/SvgViewer.tsx`**: Same annotation instrumentation as ThreeViewer

## Why

v1.0 shipped multi-file project support and viewer annotations but neither feature had analytics coverage. Share links and color-aware preview were already tracked. This closes the gap.

## Testing

## Coverage checklist

- [ ] Backend unit tests added or updated for changed Rust behavior
- [ ] Client unit/component tests added or updated for changed frontend behavior
- [ ] E2E tests added or updated for net new user-facing flows
- [x] No new tests were needed for this change

Analytics tracking calls don't have unit test coverage elsewhere in the codebase (events are verified in PostHog directly).

## Validation performed

- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm test:unit`
- [ ] `pnpm test:formatter:ci` — not needed, no formatter changes
- [ ] `pnpm test:e2e:web` — not needed, no new user-facing flows
- [ ] Rust checks — not needed, no Rust changes

68 test suites, 495 tests, all passing.

## Performance

## Performance impact

- [x] Performance was considered for this change
- [x] No meaningful performance impact is expected

## Justification

All new calls delegate through the existing PostHog analytics infrastructure with the same privacy scrubbing and opt-out gating. No synchronous work added to render paths.

## UI changes

## Screenshots or recordings

- N/A (analytics-only change)

# Issue link

- Closes #