### PR TITLE
chore: prepare release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-04-10
+
+### Added
+- Desktop MCP support for external agents to access project context, diagnostics, renders, and preview screenshots from OpenSCAD Studio.
+- Desktop AI settings now include external agent setup guidance and MCP connection details.
+
+### Changed
+- Improved MCP onboarding and preview artifact flows for desktop agent workflows.
+- Unified AI diagnostics with project render inputs to keep preview and validation feedback aligned.
+
+### Fixed
+- Fixed web startup and AI validation regressions.
+- Fixed the Tauri dev rebuild loop in worktree sessions on macOS.
+
 ## [1.1.0] - 2026-04-08
 
 ### Added

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/ui/src-tauri/Cargo.lock
+++ b/apps/ui/src-tauri/Cargo.lock
@@ -2722,7 +2722,7 @@ dependencies = [
 
 [[package]]
 name = "openscad-studio"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "axum",
  "chrono",

--- a/apps/ui/src-tauri/Cargo.toml
+++ b/apps/ui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openscad-studio"
-version = "1.1.0"
+version = "1.2.0"
 description = "Modern OpenSCAD editor with AI assistance"
 authors = ["OpenSCAD Studio Contributors"]
 edition = "2021"

--- a/apps/ui/src-tauri/tauri.conf.json
+++ b/apps/ui/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenSCAD Studio",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "identifier": "com.openscad.studio",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/apps/ui/src/constants/appInfo.ts
+++ b/apps/ui/src/constants/appInfo.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '1.1.0';
+export const APP_VERSION = '1.2.0';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openscad-studio",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "description": "Modern OpenSCAD editor with live preview and AI copilot",
   "packageManager": "pnpm@10.12.4",


### PR DESCRIPTION
## Summary

- prepare release v1.2.0
- update release version files
- add changelog entry for v1.2.0

## Release flow

After this PR is merged to `main`, run:

```bash
./scripts/release.sh publish 1.2.0
```