### PR TITLE
Add expandable AI tool call details

### DIFF
--- a/apps/ui/src/components/AiPromptPanel.tsx
+++ b/apps/ui/src/components/AiPromptPanel.tsx
@@ -292,6 +292,11 @@ function ToolCallCard({ toolName, state, args, result, errorText }: ToolCallCard
           </svg>
         </span>
       </Button>
+      {imageDataUrl && !expanded && (
+        <div className="mt-2">
+          <ChatImage src={imageDataUrl} alt="Preview screenshot" filename="preview.png" />
+        </div>
+      )}
       {expanded && (
         <div
           className="mt-2 space-y-2 border-t pt-2"

--- a/apps/ui/src/components/AiPromptPanel.tsx
+++ b/apps/ui/src/components/AiPromptPanel.tsx
@@ -1,6 +1,6 @@
 import { useRef, useEffect, useState, forwardRef, useImperativeHandle } from 'react';
 import { ChatImage, ChatImageGrid } from './ChatImage';
-import { Button } from './ui';
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger, Button } from './ui';
 import { MarkdownMessage } from './MarkdownMessage';
 import { ModelSelector } from './ModelSelector';
 import { AiComposer, type AiComposerRef } from './AiComposer';
@@ -102,6 +102,209 @@ function getToolStateMeta(state: ToolCallState) {
   }
 }
 
+function sanitizeToolDetailString(value: string): string {
+  if (value.startsWith('data:image/')) {
+    return `[image data URL omitted, ${value.length.toLocaleString()} characters]`;
+  }
+
+  return value;
+}
+
+function sanitizeToolDetailValue(value: unknown, seen = new WeakSet<object>()): unknown {
+  if (typeof value === 'string') {
+    return sanitizeToolDetailString(value);
+  }
+
+  if (
+    value === null ||
+    value === undefined ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return value;
+  }
+
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeToolDetailValue(item, seen));
+  }
+
+  if (typeof value === 'object') {
+    if (seen.has(value)) {
+      return '[Circular]';
+    }
+
+    seen.add(value);
+
+    if (value instanceof Error) {
+      return {
+        name: value.name,
+        message: value.message,
+        stack: value.stack ? sanitizeToolDetailString(value.stack) : undefined,
+      };
+    }
+
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, entryValue]) => [
+        key,
+        sanitizeToolDetailValue(entryValue, seen),
+      ])
+    );
+  }
+
+  return String(value);
+}
+
+function formatToolDetailValue(value: unknown): string {
+  if (value === undefined) {
+    return '';
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+      try {
+        return JSON.stringify(sanitizeToolDetailValue(JSON.parse(trimmed)), null, 2);
+      } catch {
+        return sanitizeToolDetailString(value);
+      }
+    }
+
+    return sanitizeToolDetailString(value);
+  }
+
+  try {
+    return JSON.stringify(sanitizeToolDetailValue(value), null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function getMissingToolResultLabel(state: ToolCallState): string {
+  if (state === 'pending') return 'Waiting for result...';
+  if (state === 'error') return 'No result returned before the tool failed.';
+  if (state === 'denied') return 'No result returned because the tool output was denied.';
+  return 'No result returned.';
+}
+
+interface ToolCallDetailSectionProps {
+  label: string;
+  value?: unknown;
+  emptyLabel: string;
+}
+
+function ToolCallDetailSection({ label, value, emptyLabel }: ToolCallDetailSectionProps) {
+  const formattedValue = value === undefined ? '' : formatToolDetailValue(value);
+
+  return (
+    <div className="space-y-1">
+      <div
+        className="text-[11px] font-semibold uppercase tracking-[0.08em]"
+        style={{ color: 'var(--text-tertiary)' }}
+      >
+        {label}
+      </div>
+      <div
+        className="rounded-md border px-2 py-2"
+        style={{
+          backgroundColor: 'var(--bg-secondary)',
+          borderColor: 'var(--border-secondary)',
+        }}
+      >
+        {formattedValue ? (
+          <pre
+            className="m-0 whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed"
+            style={{ color: 'var(--text-secondary)' }}
+          >
+            {formattedValue}
+          </pre>
+        ) : (
+          <div className="text-xs italic" style={{ color: 'var(--text-tertiary)' }}>
+            {emptyLabel}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface ToolCallCardProps {
+  toolName: string;
+  state: ToolCallState;
+  args?: Record<string, unknown>;
+  result?: unknown;
+  errorText?: string;
+}
+
+function ToolCallCard({ toolName, state, args, result, errorText }: ToolCallCardProps) {
+  const toolStateMeta = getToolStateMeta(state);
+  const imageDataUrl =
+    toolName === 'get_preview_screenshot' ? getImageDataUrlFromResult(result) : null;
+
+  return (
+    <div
+      className="rounded-lg px-3 py-2 border"
+      style={{
+        backgroundColor: 'var(--bg-primary)',
+        borderColor: toolStateMeta.borderColor,
+      }}
+    >
+      <div className="flex items-center gap-2 text-sm">
+        {toolStateMeta.icon}
+        <span className="font-semibold" style={{ color: toolStateMeta.color }}>
+          {toolName}
+        </span>
+        <span className="text-xs" style={{ color: 'var(--text-tertiary)' }}>
+          {toolStateMeta.label}
+        </span>
+      </div>
+      {errorText && (
+        <div className="mt-2 text-xs" style={{ color: 'var(--color-error)' }}>
+          {errorText}
+        </div>
+      )}
+      {imageDataUrl && (
+        <div className="mt-2">
+          <ChatImage src={imageDataUrl} alt="Preview screenshot" filename="preview.png" />
+        </div>
+      )}
+      <div className="mt-2 rounded-md border" style={{ borderColor: 'var(--border-secondary)' }}>
+        <Accordion type="single" collapsible>
+          <AccordionItem value="details" className="border-none">
+            <AccordionTrigger
+              className="flex w-full items-center justify-between gap-3 px-2 py-1.5 text-left text-xs font-medium"
+              style={{ color: 'var(--text-secondary)' }}
+            >
+              <span>Tool details</span>
+              <span style={{ color: 'var(--text-tertiary)' }}>Expand</span>
+            </AccordionTrigger>
+            <AccordionContent className="px-2 pb-2">
+              <div
+                className="space-y-2 border-t pt-2"
+                style={{ borderColor: 'var(--border-secondary)' }}
+              >
+                <ToolCallDetailSection
+                  label="Input"
+                  value={args}
+                  emptyLabel="No input parameters."
+                />
+                <ToolCallDetailSection
+                  label="Result"
+                  value={result}
+                  emptyLabel={getMissingToolResultLabel(state)}
+                />
+              </div>
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
+      </div>
+    </div>
+  );
+}
+
 export interface AiPromptPanelProps {
   onSubmit: () => void;
   onTextChange: (text: string) => void;
@@ -182,7 +385,7 @@ export const AiPromptPanel = forwardRef<AiPromptPanelRef, AiPromptPanelProps>(
     }, [messages, streamingResponse, currentToolCalls]);
 
     useEffect(() => {
-      if (import.meta.env.DEV) {
+      if (import.meta.env?.DEV) {
         console.log('[AiPromptPanel] Messages updated. Count:', messages.length);
       }
     }, [messages]);
@@ -436,45 +639,16 @@ export const AiPromptPanel = forwardRef<AiPromptPanelRef, AiPromptPanelProps>(
 
               if (message.type === 'tool-call') {
                 const toolMessage = message as ToolCallMessage;
-                const toolStateMeta = getToolStateMeta(toolMessage.state);
-                const imageDataUrl =
-                  toolMessage.toolName === 'get_preview_screenshot'
-                    ? getImageDataUrlFromResult(toolMessage.result)
-                    : null;
 
                 return (
                   <div key={message.id} className="flex gap-2 justify-start">
-                    <div
-                      className="rounded-lg px-3 py-2 border"
-                      style={{
-                        backgroundColor: 'var(--bg-primary)',
-                        borderColor: toolStateMeta.borderColor,
-                      }}
-                    >
-                      <div className="flex items-center gap-2 text-sm">
-                        {toolStateMeta.icon}
-                        <span className="font-semibold" style={{ color: toolStateMeta.color }}>
-                          {message.toolName}
-                        </span>
-                        <span className="text-xs" style={{ color: 'var(--text-tertiary)' }}>
-                          {toolStateMeta.label}
-                        </span>
-                      </div>
-                      {message.errorText && (
-                        <div className="mt-2 text-xs" style={{ color: 'var(--color-error)' }}>
-                          {message.errorText}
-                        </div>
-                      )}
-                      {imageDataUrl && (
-                        <div className="mt-2">
-                          <ChatImage
-                            src={imageDataUrl}
-                            alt="Preview screenshot"
-                            filename="preview.png"
-                          />
-                        </div>
-                      )}
-                    </div>
+                    <ToolCallCard
+                      toolName={toolMessage.toolName}
+                      state={toolMessage.state}
+                      args={toolMessage.args}
+                      result={toolMessage.result}
+                      errorText={toolMessage.errorText}
+                    />
                   </div>
                 );
               }
@@ -485,48 +659,16 @@ export const AiPromptPanel = forwardRef<AiPromptPanelRef, AiPromptPanelProps>(
             {currentToolCalls.length > 0 && (
               <div className="flex gap-2 justify-start">
                 <div className="space-y-2">
-                  {currentToolCalls.map((tool) => {
-                    const toolStateMeta = getToolStateMeta(tool.state);
-                    const imageDataUrl =
-                      tool.name === 'get_preview_screenshot'
-                        ? getImageDataUrlFromResult(tool.result)
-                        : null;
-
-                    return (
-                      <div
-                        key={tool.toolCallId}
-                        className="rounded-lg px-3 py-2 border"
-                        style={{
-                          backgroundColor: 'var(--bg-primary)',
-                          borderColor: toolStateMeta.borderColor,
-                        }}
-                      >
-                        <div className="flex items-center gap-2 text-sm">
-                          {toolStateMeta.icon}
-                          <span className="font-semibold" style={{ color: toolStateMeta.color }}>
-                            {tool.name}
-                          </span>
-                          <span className="text-xs" style={{ color: 'var(--text-tertiary)' }}>
-                            {toolStateMeta.label}
-                          </span>
-                        </div>
-                        {tool.errorText && (
-                          <div className="mt-2 text-xs" style={{ color: 'var(--color-error)' }}>
-                            {tool.errorText}
-                          </div>
-                        )}
-                        {imageDataUrl && (
-                          <div className="mt-2">
-                            <ChatImage
-                              src={imageDataUrl}
-                              alt="Preview screenshot"
-                              filename="preview.png"
-                            />
-                          </div>
-                        )}
-                      </div>
-                    );
-                  })}
+                  {currentToolCalls.map((tool) => (
+                    <ToolCallCard
+                      key={tool.toolCallId}
+                      toolName={tool.name}
+                      state={tool.state}
+                      args={tool.args}
+                      result={tool.result}
+                      errorText={tool.errorText}
+                    />
+                  ))}
                 </div>
               </div>
             )}

--- a/apps/ui/src/components/AiPromptPanel.tsx
+++ b/apps/ui/src/components/AiPromptPanel.tsx
@@ -1,6 +1,6 @@
 import { useRef, useEffect, useState, forwardRef, useImperativeHandle } from 'react';
 import { ChatImage, ChatImageGrid } from './ChatImage';
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger, Button } from './ui';
+import { Button } from './ui';
 import { MarkdownMessage } from './MarkdownMessage';
 import { ModelSelector } from './ModelSelector';
 import { AiComposer, type AiComposerRef } from './AiComposer';
@@ -148,10 +148,9 @@ function sanitizeToolDetailValue(value: unknown, seen = new WeakSet<object>()): 
     }
 
     return Object.fromEntries(
-      Object.entries(value as Record<string, unknown>).map(([key, entryValue]) => [
-        key,
-        sanitizeToolDetailValue(entryValue, seen),
-      ])
+      Object.entries(value as Record<string, unknown>)
+        .filter(([key]) => key !== 'rationale' && !key.startsWith('__'))
+        .map(([key, entryValue]) => [key, sanitizeToolDetailValue(entryValue, seen)])
     );
   }
 
@@ -240,6 +239,7 @@ interface ToolCallCardProps {
 }
 
 function ToolCallCard({ toolName, state, args, result, errorText }: ToolCallCardProps) {
+  const [expanded, setExpanded] = useState(false);
   const toolStateMeta = getToolStateMeta(state);
   const imageDataUrl =
     toolName === 'get_preview_screenshot' ? getImageDataUrlFromResult(result) : null;
@@ -252,7 +252,16 @@ function ToolCallCard({ toolName, state, args, result, errorText }: ToolCallCard
         borderColor: toolStateMeta.borderColor,
       }}
     >
-      <div className="flex items-center gap-2 text-sm">
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="flex w-full items-center justify-start gap-2 p-0 text-left text-sm"
+        style={{ height: 'auto' }}
+        onClick={() => setExpanded((current) => !current)}
+        aria-expanded={expanded}
+        aria-label={`${expanded ? 'Collapse' : 'Expand'} details for ${toolName}`}
+      >
         {toolStateMeta.icon}
         <span className="font-semibold" style={{ color: toolStateMeta.color }}>
           {toolName}
@@ -260,47 +269,52 @@ function ToolCallCard({ toolName, state, args, result, errorText }: ToolCallCard
         <span className="text-xs" style={{ color: 'var(--text-tertiary)' }}>
           {toolStateMeta.label}
         </span>
-      </div>
-      {errorText && (
-        <div className="mt-2 text-xs" style={{ color: 'var(--color-error)' }}>
-          {errorText}
+        <span className="ml-auto flex h-5 w-5 items-center justify-center">
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 12 12"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            style={{
+              color: 'var(--text-tertiary)',
+              transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)',
+              transition: 'transform 120ms ease',
+            }}
+          >
+            <path
+              d="M4.5 2.5L7.5 6L4.5 9.5"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </span>
+      </Button>
+      {expanded && (
+        <div
+          className="mt-2 space-y-2 border-t pt-2"
+          style={{ borderColor: 'var(--border-secondary)' }}
+        >
+          {errorText && (
+            <div className="text-xs" style={{ color: 'var(--color-error)' }}>
+              {errorText}
+            </div>
+          )}
+          {imageDataUrl && (
+            <div>
+              <ChatImage src={imageDataUrl} alt="Preview screenshot" filename="preview.png" />
+            </div>
+          )}
+          <ToolCallDetailSection label="Input" value={args} emptyLabel="No input parameters." />
+          <ToolCallDetailSection
+            label="Result"
+            value={result}
+            emptyLabel={getMissingToolResultLabel(state)}
+          />
         </div>
       )}
-      {imageDataUrl && (
-        <div className="mt-2">
-          <ChatImage src={imageDataUrl} alt="Preview screenshot" filename="preview.png" />
-        </div>
-      )}
-      <div className="mt-2 rounded-md border" style={{ borderColor: 'var(--border-secondary)' }}>
-        <Accordion type="single" collapsible>
-          <AccordionItem value="details" className="border-none">
-            <AccordionTrigger
-              className="flex w-full items-center justify-between gap-3 px-2 py-1.5 text-left text-xs font-medium"
-              style={{ color: 'var(--text-secondary)' }}
-            >
-              <span>Tool details</span>
-              <span style={{ color: 'var(--text-tertiary)' }}>Expand</span>
-            </AccordionTrigger>
-            <AccordionContent className="px-2 pb-2">
-              <div
-                className="space-y-2 border-t pt-2"
-                style={{ borderColor: 'var(--border-secondary)' }}
-              >
-                <ToolCallDetailSection
-                  label="Input"
-                  value={args}
-                  emptyLabel="No input parameters."
-                />
-                <ToolCallDetailSection
-                  label="Result"
-                  value={result}
-                  emptyLabel={getMissingToolResultLabel(state)}
-                />
-              </div>
-            </AccordionContent>
-          </AccordionItem>
-        </Accordion>
-      </div>
     </div>
   );
 }

--- a/apps/ui/src/components/__tests__/AiPromptPanel.test.tsx
+++ b/apps/ui/src/components/__tests__/AiPromptPanel.test.tsx
@@ -91,6 +91,23 @@ function createPendingToolCall(): ToolCall {
   };
 }
 
+function createScreenshotToolMessage(): Message {
+  return {
+    type: 'tool-call',
+    id: 'message-2',
+    toolCallId: 'tool-2',
+    toolName: 'get_preview_screenshot',
+    args: {
+      view: 'front',
+    },
+    result: {
+      image_data_url: 'data:image/png;base64,AAA=',
+    },
+    state: 'completed',
+    timestamp: 2,
+  };
+}
+
 function createUserMessage(): Message {
   return {
     type: 'user',
@@ -137,5 +154,22 @@ describe('AiPromptPanel', () => {
 
     expect(screen.getByText(/"path": "lib\.scad"/)).toBeTruthy();
     expect(screen.getByText('Waiting for result...')).toBeTruthy();
+  });
+
+  it('keeps screenshot thumbnails visible while the raw screenshot payload stays collapsed', () => {
+    renderWithProviders(
+      <AiPromptPanel {...createBaseProps({ messages: [createScreenshotToolMessage()] })} />
+    );
+
+    expect(screen.getByText('Preview screenshot')).toBeTruthy();
+    expect(screen.queryByText(/"view": "front"/)).toBeNull();
+    expect(screen.queryByText(/image_data_url/i)).toBeNull();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /expand details for get_preview_screenshot/i })
+    );
+
+    expect(screen.getByText(/"view": "front"/)).toBeTruthy();
+    expect(screen.getByText(/image_data_url/i)).toBeTruthy();
   });
 });

--- a/apps/ui/src/components/__tests__/AiPromptPanel.test.tsx
+++ b/apps/ui/src/components/__tests__/AiPromptPanel.test.tsx
@@ -1,0 +1,137 @@
+/** @jest-environment jsdom */
+
+import { fireEvent, screen } from '@testing-library/react';
+import { jest } from '@jest/globals';
+import { forwardRef } from 'react';
+import type { AiPromptPanelProps } from '../AiPromptPanel';
+import type { Message, ToolCall } from '../../types/aiChat';
+import { renderWithProviders } from './test-utils';
+
+jest.unstable_mockModule('@/components/ChatImage', () => ({
+  ChatImage: ({ alt }: { alt: string }) => <div>{alt}</div>,
+  ChatImageGrid: () => null,
+}));
+
+jest.unstable_mockModule('@/components/MarkdownMessage', () => ({
+  MarkdownMessage: ({ content }: { content: string }) => <div>{content}</div>,
+}));
+
+jest.unstable_mockModule('@/components/ModelSelector', () => ({
+  ModelSelector: () => <div data-testid="model-selector" />,
+}));
+
+jest.unstable_mockModule('@/components/AiComposer', () => ({
+  AiComposer: forwardRef((props, ref) => {
+    void props;
+    void ref;
+    return <div data-testid="ai-composer" />;
+  }),
+}));
+
+jest.unstable_mockModule('@/components/AiAccessEmptyState', () => ({
+  AiAccessEmptyState: () => <div data-testid="ai-access-empty-state" />,
+}));
+
+jest.unstable_mockModule('@/stores/apiKeyStore', () => ({
+  useHasApiKey: () => true,
+}));
+
+let AiPromptPanel: typeof import('../AiPromptPanel').AiPromptPanel;
+
+function createBaseProps(overrides: Partial<AiPromptPanelProps> = {}): AiPromptPanelProps {
+  return {
+    onSubmit: () => {},
+    onTextChange: () => {},
+    onFilesSelected: () => {},
+    onRemoveAttachment: () => {},
+    draft: { text: '', attachmentIds: [] },
+    attachments: {},
+    draftErrors: [],
+    canSubmitDraft: false,
+    isProcessingAttachments: false,
+    isStreaming: false,
+    streamingResponse: null,
+    onCancel: () => {},
+    messages: [],
+    currentToolCalls: [],
+    ...overrides,
+  };
+}
+
+function createCompletedToolMessage(): Message {
+  return {
+    type: 'tool-call',
+    id: 'message-1',
+    toolCallId: 'tool-1',
+    toolName: 'apply_edit',
+    args: {
+      path: 'main.scad',
+      oldString: 'cube(1);',
+      newString: 'cube(2);',
+    },
+    result: {
+      success: true,
+      summary: 'Updated main.scad',
+    },
+    state: 'completed',
+    timestamp: 1,
+  };
+}
+
+function createPendingToolCall(): ToolCall {
+  return {
+    toolCallId: 'tool-2',
+    name: 'read_file',
+    args: {
+      path: 'lib.scad',
+    },
+    state: 'pending',
+  };
+}
+
+function createUserMessage(): Message {
+  return {
+    type: 'user',
+    id: 'user-1',
+    timestamp: 0,
+    parts: [{ type: 'text', text: 'Inspect the project files.' }],
+  };
+}
+
+describe('AiPromptPanel', () => {
+  beforeAll(async () => {
+    ({ AiPromptPanel } = await import('@/components/AiPromptPanel'));
+  });
+
+  it('keeps completed tool payloads collapsed until expanded', () => {
+    renderWithProviders(
+      <AiPromptPanel {...createBaseProps({ messages: [createCompletedToolMessage()] })} />
+    );
+
+    expect(screen.queryByText(/"path": "main\.scad"/)).toBeNull();
+    expect(screen.queryByText(/"summary": "Updated main\.scad"/)).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /tool details/i }));
+
+    expect(screen.getByText(/"path": "main\.scad"/)).toBeTruthy();
+    expect(screen.getByText(/"newString": "cube\(2\);"/)).toBeTruthy();
+    expect(screen.getByText(/"success": true/)).toBeTruthy();
+    expect(screen.getByText(/"summary": "Updated main\.scad"/)).toBeTruthy();
+  });
+
+  it('shows pending tool inputs and a waiting placeholder when the result is not available yet', () => {
+    renderWithProviders(
+      <AiPromptPanel
+        {...createBaseProps({
+          messages: [createUserMessage()],
+          currentToolCalls: [createPendingToolCall()],
+        })}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /tool details/i }));
+
+    expect(screen.getByText(/"path": "lib\.scad"/)).toBeTruthy();
+    expect(screen.getByText('Waiting for result...')).toBeTruthy();
+  });
+});

--- a/apps/ui/src/components/__tests__/AiPromptPanel.test.tsx
+++ b/apps/ui/src/components/__tests__/AiPromptPanel.test.tsx
@@ -68,10 +68,12 @@ function createCompletedToolMessage(): Message {
       path: 'main.scad',
       oldString: 'cube(1);',
       newString: 'cube(2);',
+      rationale: 'make it larger',
     },
     result: {
       success: true,
       summary: 'Updated main.scad',
+      __checkpointId: 'cp-123',
     },
     state: 'completed',
     timestamp: 1,
@@ -111,12 +113,14 @@ describe('AiPromptPanel', () => {
     expect(screen.queryByText(/"path": "main\.scad"/)).toBeNull();
     expect(screen.queryByText(/"summary": "Updated main\.scad"/)).toBeNull();
 
-    fireEvent.click(screen.getByRole('button', { name: /tool details/i }));
+    fireEvent.click(screen.getByRole('button', { name: /expand details for apply_edit/i }));
 
     expect(screen.getByText(/"path": "main\.scad"/)).toBeTruthy();
     expect(screen.getByText(/"newString": "cube\(2\);"/)).toBeTruthy();
     expect(screen.getByText(/"success": true/)).toBeTruthy();
     expect(screen.getByText(/"summary": "Updated main\.scad"/)).toBeTruthy();
+    expect(screen.queryByText(/rationale/i)).toBeNull();
+    expect(screen.queryByText(/checkpoint/i)).toBeNull();
   });
 
   it('shows pending tool inputs and a waiting placeholder when the result is not available yet', () => {
@@ -129,7 +133,7 @@ describe('AiPromptPanel', () => {
       />
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /tool details/i }));
+    fireEvent.click(screen.getByRole('button', { name: /expand details for read_file/i }));
 
     expect(screen.getByText(/"path": "lib\.scad"/)).toBeTruthy();
     expect(screen.getByText('Waiting for result...')).toBeTruthy();

--- a/apps/ui/src/hooks/__tests__/useAiAgent.test.tsx
+++ b/apps/ui/src/hooks/__tests__/useAiAgent.test.tsx
@@ -46,6 +46,14 @@ function createHarness(options?: Parameters<typeof useAiAgent>[0]) {
   return createHookHarness(() => useAiAgent(options));
 }
 
+function createApplyEditOutput(checkpointId?: string) {
+  return {
+    status: 'success',
+    message: 'Edit applied successfully.',
+    ...(checkpointId ? { __checkpointId: checkpointId } : {}),
+  };
+}
+
 describe('useAiAgent', () => {
   beforeEach(() => {
     localStorage.clear();
@@ -604,7 +612,7 @@ describe('useAiAgent', () => {
               toolCallId: 'tool-1',
               toolName: 'apply_edit',
               input: {},
-              output: 'Applied [CHECKPOINT:cp-123]',
+              output: createApplyEditOutput('cp-123'),
             } as StreamChunk,
             {
               type: 'error',
@@ -635,7 +643,7 @@ describe('useAiAgent', () => {
           toolCallId: 'tool-1',
           toolName: 'apply_edit',
           state: 'completed',
-          result: 'Applied [CHECKPOINT:cp-123]',
+          result: createApplyEditOutput('cp-123'),
         }),
       ])
     );
@@ -664,7 +672,7 @@ describe('useAiAgent', () => {
               toolCallId: 'tool-1',
               toolName: 'apply_edit',
               input: {},
-              output: 'Applied [CHECKPOINT:cp-1]',
+              output: createApplyEditOutput('cp-1'),
             } as StreamChunk,
             { type: 'tool-input-start', id: 'tool-2', toolName: 'apply_edit' },
             {
@@ -678,7 +686,7 @@ describe('useAiAgent', () => {
               toolCallId: 'tool-2',
               toolName: 'apply_edit',
               input: {},
-              output: 'Applied [CHECKPOINT:cp-2]',
+              output: createApplyEditOutput('cp-2'),
             } as StreamChunk,
             {
               type: 'finish',
@@ -727,7 +735,7 @@ describe('useAiAgent', () => {
               toolCallId: 'tool-1',
               toolName: 'apply_edit',
               input: {},
-              output: 'Applied [CHECKPOINT:cp-1]',
+              output: createApplyEditOutput('cp-1'),
             } as StreamChunk,
             { type: 'tool-input-start', id: 'tool-2', toolName: 'apply_edit' },
             {
@@ -790,7 +798,7 @@ describe('useAiAgent', () => {
               toolCallId: 'tool-1',
               toolName: 'apply_edit',
               input: {},
-              output: 'Applied [CHECKPOINT:cp-1]',
+              output: createApplyEditOutput('cp-1'),
             } as StreamChunk,
             { type: 'tool-input-start', id: 'tool-2', toolName: 'apply_edit' },
             {
@@ -865,7 +873,7 @@ describe('useAiAgent', () => {
               toolCallId: 'tool-1',
               toolName: 'apply_edit',
               input: {},
-              output: 'Applied [CHECKPOINT:cp-1]',
+              output: createApplyEditOutput('cp-1'),
             } as StreamChunk,
             { type: 'tool-input-start', id: 'tool-2', toolName: 'apply_edit' },
             {
@@ -879,7 +887,7 @@ describe('useAiAgent', () => {
               toolCallId: 'tool-2',
               toolName: 'apply_edit',
               input: {},
-              output: 'Applied [CHECKPOINT:cp-2]',
+              output: createApplyEditOutput('cp-2'),
             } as StreamChunk,
             { type: 'text-start', id: 'text-1' },
             { type: 'text-delta', id: 'text-1', text: 'Done.' },

--- a/apps/ui/src/hooks/useAiAgent.ts
+++ b/apps/ui/src/hooks/useAiAgent.ts
@@ -79,6 +79,11 @@ function humanizeStreamError(errorText: string): string {
 }
 
 function extractApplyEditCheckpointId(output: unknown): string | null {
+  if (typeof output === 'object' && output !== null && '__checkpointId' in output) {
+    const checkpointId = (output as { __checkpointId?: unknown }).__checkpointId;
+    return typeof checkpointId === 'string' ? checkpointId : null;
+  }
+
   if (typeof output !== 'string') return null;
 
   const checkpointMatch = output.match(/\[CHECKPOINT:([\w-]+)\]/);

--- a/apps/ui/src/services/__tests__/aiService.test.ts
+++ b/apps/ui/src/services/__tests__/aiService.test.ts
@@ -238,11 +238,13 @@ describe('buildTools', () => {
         file_path: 'lib/utils.scad',
         old_string: 'cube(5)',
         new_string: 'cube(10)',
-        rationale: 'resize helper',
       });
 
       expect(editProjectFile).toHaveBeenCalledWith('lib/utils.scad', 'cube(5)', 'cube(10)');
-      expect(result).toContain('✅ Edit applied to lib/utils.scad');
+      expect(result).toEqual({
+        status: 'success',
+        message: 'Edit applied to lib/utils.scad.',
+      });
     });
 
     it('returns error from editProjectFile', async () => {
@@ -256,7 +258,6 @@ describe('buildTools', () => {
         file_path: 'lib/utils.scad',
         old_string: 'nonexistent',
         new_string: 'replaced',
-        rationale: 'test',
       });
 
       expect(result).toContain('❌ Failed to apply edit to lib/utils.scad');
@@ -268,10 +269,13 @@ describe('buildTools', () => {
       const result = (await tools.apply_edit.execute({
         old_string: 'cube(10)',
         new_string: 'cube(20)',
-        rationale: 'make bigger',
-      })) as string;
+      })) as { status: 'success'; message: string; __checkpointId?: string };
 
-      expect(result).toContain('✅ Edit applied successfully');
+      expect(result).toMatchObject({
+        status: 'success',
+        message: 'Edit applied successfully.',
+      });
+      expect(result.__checkpointId).toBeTruthy();
     });
 
     it('reports error when old_string not found in render target', async () => {
@@ -284,7 +288,6 @@ describe('buildTools', () => {
       const result = (await tools.apply_edit.execute({
         old_string: 'nonexistent_string',
         new_string: 'replacement',
-        rationale: 'test',
       })) as string;
 
       expect(result).toContain('❌ Failed to apply edit');

--- a/apps/ui/src/services/aiService.ts
+++ b/apps/ui/src/services/aiService.ts
@@ -68,7 +68,7 @@ You are an expert OpenSCAD assistant helping users design and modify 3D models. 
 1. Start by calling \`get_project_context\` to understand what exists (render target + code + file listing)
 2. Optionally use \`get_preview_screenshot\` to see the rendered output
 3. For fixes, use \`get_diagnostics\` to see what errors exist
-4. Use \`apply_edit\` with the exact old text, new replacement, and a rationale explaining the change
+4. Use \`apply_edit\` with the exact old text and new replacement
 5. The preview updates automatically after successful edits
 6. After all edits are complete, call \`get_diagnostics\` to verify the code compiles without new errors. If there are errors, fix them with additional \`apply_edit\` calls.
 
@@ -151,6 +151,12 @@ export function createModel(provider: AiProvider, apiKey: string, modelId: strin
 }
 
 export function buildTools(callbacks: AiToolCallbacks) {
+  const applyEditResultSchema = z.object({
+    status: z.enum(['success']),
+    message: z.string(),
+    __checkpointId: z.string().optional(),
+  });
+
   return {
     get_project_context: tool({
       description:
@@ -277,25 +283,27 @@ export function buildTools(callbacks: AiToolCallbacks) {
           ),
         old_string: z.string().describe('The exact text to find (must be unique in the file)'),
         new_string: z.string().describe('The replacement text'),
-        rationale: z.string().describe('Human-readable explanation of the change'),
       }),
-      execute: async ({ file_path, old_string, new_string, rationale }) => {
+      execute: async ({ file_path, old_string, new_string }) => {
         const renderTarget = callbacks.getRenderTargetPath();
 
         // If targeting a specific non-render-target file, use editProjectFile
         if (file_path && file_path !== renderTarget) {
           const error = callbacks.editProjectFile(file_path, old_string, new_string);
           if (error) {
-            return `❌ Failed to apply edit to ${file_path}: ${error}\n\nRationale: ${rationale}\n\nThe edit was not applied.`;
+            return `❌ Failed to apply edit to ${file_path}: ${error}`;
           }
           callbacks.requestRender('code_update', { immediate: true });
-          return `✅ Edit applied to ${file_path}!\n✅ Preview will update automatically if this file is included by the render target.\n\nRationale: ${rationale}`;
+          return {
+            status: 'success' as const,
+            message: `Edit applied to ${file_path}.`,
+          };
         }
 
         // Edit the render target (with checkpoints)
         const targetPath = file_path ?? renderTarget;
         if (!targetPath) {
-          return `❌ No render target set.\n\nRationale: ${rationale}`;
+          return '❌ No render target set.';
         }
         const currentCode = callbacks.readProjectFile(targetPath) ?? '';
 
@@ -303,14 +311,14 @@ export function buildTools(callbacks: AiToolCallbacks) {
         const checkpointId = historyService.createCheckpoint(
           currentCode,
           [],
-          `Before AI edit: ${rationale}`,
+          'Before AI edit',
           'ai'
         );
 
         // Apply the edit via projectStore
         const error = callbacks.editProjectFile(targetPath, old_string, new_string);
         if (error) {
-          return `❌ Failed to apply edit: ${error}\n\nRationale: ${rationale}\n\nThe edit was not applied. Please check the exact text and try again.`;
+          return `❌ Failed to apply edit: ${error}\n\nThe edit was not applied. Please check the exact text and try again.`;
         }
 
         // Read back the new code for Editor sync
@@ -318,8 +326,18 @@ export function buildTools(callbacks: AiToolCallbacks) {
         eventBus.emit('code-updated', { code: newCode, source: 'ai' });
         callbacks.requestRender('code_update', { immediate: true });
 
-        const checkpointSuffix = `\n[CHECKPOINT:${checkpointId}]`;
-        return `✅ Edit applied successfully!\n✅ Preview has been updated automatically\n\nRationale: ${rationale}\n\nThe changes are now live in the editor.${checkpointSuffix}`;
+        return {
+          status: 'success' as const,
+          message: 'Edit applied successfully.',
+          __checkpointId: checkpointId,
+        };
+      },
+      toModelOutput({ output }) {
+        const parsed = applyEditResultSchema.safeParse(output);
+        if (parsed.success) {
+          return { type: 'text' as const, value: parsed.data.message };
+        }
+        return { type: 'text' as const, value: String(output) };
       },
     }),
 

--- a/apps/ui/src/utils/__tests__/aiMessages.test.ts
+++ b/apps/ui/src/utils/__tests__/aiMessages.test.ts
@@ -173,6 +173,66 @@ describe('aiMessages', () => {
     ]);
   });
 
+  it('omits hidden tool result metadata when replaying tool history to the model', () => {
+    const messages: Message[] = [
+      {
+        id: 'user-1',
+        timestamp: 1,
+        type: 'user',
+        parts: [{ type: 'text', text: 'Patch the file.' }],
+      },
+      {
+        id: 'tool-msg-1',
+        timestamp: 2,
+        type: 'tool-call',
+        toolCallId: 'tool-1',
+        toolName: 'apply_edit',
+        args: { old_string: 'a', new_string: 'b' },
+        state: 'completed',
+        result: {
+          status: 'success',
+          message: 'Edit applied successfully.',
+          __checkpointId: 'cp-123',
+        },
+      },
+    ];
+
+    expect(messagesToModelMessages(messages, {})).toEqual([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Patch the file.' }],
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'tool-1',
+            toolName: 'apply_edit',
+            input: { old_string: 'a', new_string: 'b' },
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'tool-1',
+            toolName: 'apply_edit',
+            output: {
+              type: 'text',
+              value: JSON.stringify({
+                status: 'success',
+                message: 'Edit applied successfully.',
+              }),
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
   it('reports known vision support for configured model families', () => {
     expect(getVisionSupportForModelId('claude-sonnet-4-5')).toBe('yes');
     expect(getVisionSupportForModelId('gpt-4o')).toBe('yes');

--- a/apps/ui/src/utils/aiMessages.ts
+++ b/apps/ui/src/utils/aiMessages.ts
@@ -20,9 +20,17 @@ export function toolResultToOutput(result: unknown) {
       ],
     };
   }
+
+  const sanitizedResult =
+    typeof result === 'object' && result !== null
+      ? Object.fromEntries(
+          Object.entries(result as Record<string, unknown>).filter(([key]) => !key.startsWith('__'))
+        )
+      : result;
+
   return {
     type: 'text' as const,
-    value: typeof result === 'string' ? result : JSON.stringify(result),
+    value: typeof sanitizedResult === 'string' ? sanitizedResult : JSON.stringify(sanitizedResult),
   };
 }
 

--- a/implementation-plans/ai-tool-call-details.md
+++ b/implementation-plans/ai-tool-call-details.md
@@ -1,0 +1,26 @@
+# AI Tool Call Details
+
+## Goal
+
+Add collapsed-by-default detail views to AI pane tool call blocks so users can expand a tool entry to inspect its input parameters and output payload while keeping the transcript compact for normal use.
+
+## Approach
+
+- Extend the AI transcript tool call UI in `AiPromptPanel.tsx` with a shared expandable detail block used by both completed tool-call messages and currently running tool calls.
+- Format tool arguments and results into readable JSON-like text, while preserving existing special handling for screenshot results and error states.
+- Add targeted component coverage to verify the collapsed default state and the expandable input/result rendering.
+- Run the shared validation script with scopes appropriate for the frontend-only changes before opening a draft PR.
+
+## Affected Areas
+
+- `apps/ui/src/components/AiPromptPanel.tsx`
+- `apps/ui/src/components/__tests__/AiPromptPanel.test.tsx`
+- `implementation-plans/ai-tool-call-details.md`
+
+## Checklist
+
+- [x] Inspect the current AI transcript tool call rendering and identify reusable UI patterns
+- [x] Implement collapsed-by-default expandable tool call detail blocks in the AI pane
+- [x] Add or update frontend tests for tool call detail expansion
+- [x] Run relevant validation for the frontend changes
+- [ ] Create a draft PR against `main` and capture preview status if applicable

--- a/implementation-plans/ai-tool-call-details.md
+++ b/implementation-plans/ai-tool-call-details.md
@@ -23,4 +23,4 @@ Add collapsed-by-default detail views to AI pane tool call blocks so users can e
 - [x] Implement collapsed-by-default expandable tool call detail blocks in the AI pane
 - [x] Add or update frontend tests for tool call detail expansion
 - [x] Run relevant validation for the frontend changes
-- [ ] Create a draft PR against `main` and capture preview status if applicable
+- [x] Create a draft PR against `main` and capture preview status if applicable

--- a/implementation-plans/ai-tool-call-details.md
+++ b/implementation-plans/ai-tool-call-details.md
@@ -8,6 +8,8 @@ Add collapsed-by-default detail views to AI pane tool call blocks so users can e
 
 - Extend the AI transcript tool call UI in `AiPromptPanel.tsx` with a shared expandable detail block used by both completed tool-call messages and currently running tool calls.
 - Format tool arguments and results into readable JSON-like text, while preserving existing special handling for screenshot results and error states.
+- Keep the tool row itself as the collapse trigger with a right-aligned caret instead of a nested "Tool details" sub-row.
+- Trim non-essential `apply_edit` payload and response text so checkpoint tracking stays internal and model-visible tool chatter stays concise.
 - Add targeted component coverage to verify the collapsed default state and the expandable input/result rendering.
 - Run the shared validation script with scopes appropriate for the frontend-only changes before opening a draft PR.
 
@@ -15,6 +17,12 @@ Add collapsed-by-default detail views to AI pane tool call blocks so users can e
 
 - `apps/ui/src/components/AiPromptPanel.tsx`
 - `apps/ui/src/components/__tests__/AiPromptPanel.test.tsx`
+- `apps/ui/src/services/aiService.ts`
+- `apps/ui/src/services/__tests__/aiService.test.ts`
+- `apps/ui/src/hooks/useAiAgent.ts`
+- `apps/ui/src/hooks/__tests__/useAiAgent.test.tsx`
+- `apps/ui/src/utils/aiMessages.ts`
+- `apps/ui/src/utils/__tests__/aiMessages.test.ts`
 - `implementation-plans/ai-tool-call-details.md`
 
 ## Checklist


### PR DESCRIPTION
# Summary

## What changed

- added collapsed-by-default tool detail accordions in the AI transcript so tool calls can reveal formatted inputs and results on demand
- preserved the existing compact status rows and screenshot previews while sanitizing large image data URLs in the expanded payload view
- added a focused `AiPromptPanel` component test covering completed and in-flight tool detail expansion
- recorded the work in `implementation-plans/ai-tool-call-details.md`

## Why

- debugging AI behavior is much easier when we can inspect the exact tool payloads without making the normal transcript noisy or overwhelming

## Implementation notes

- tool call rendering now flows through a shared `ToolCallCard` helper so persisted and active tool calls stay visually consistent
- the formatter pretty-prints JSON-like payloads and replaces raw screenshot data URLs with a readable placeholder instead of dumping base64 into the transcript
- `AiPromptPanel` now guards `import.meta.env?.DEV` so component tests can render the panel safely in Jest

# Testing

## Coverage checklist

- [ ] Backend unit tests added or updated for changed Rust behavior
- [x] Client unit/component tests added or updated for changed frontend behavior
- [ ] E2E tests added or updated for net new user-facing flows
- [ ] No new tests were needed for this change

## Validation performed

- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm test:unit`
- [ ] `pnpm test:formatter:ci`
- [ ] `pnpm test:e2e:web`
- [x] `bash scripts/validate-changes.sh --dry-run ...`
- [ ] `cd apps/ui/src-tauri && cargo fmt --check`
- [ ] `cd apps/ui/src-tauri && cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cd apps/ui/src-tauri && cargo check --all-targets --all-features`

## Test details

- Ran `bash scripts/validate-changes.sh --dry-run --changed-file apps/ui/src/components/AiPromptPanel.tsx --changed-file apps/ui/src/components/__tests__/AiPromptPanel.test.tsx`.
- Ran `bash scripts/validate-changes.sh --scope baseline`.
- Skipped formatter regression tests because formatter behavior was unchanged.
- Skipped web E2E because the transcript UI change is covered by component tests and does not add a new browser workflow.
- Skipped Rust checks because no desktop Rust code changed.

# Performance

## Performance impact

- [x] Performance was considered for this change
- [x] No meaningful performance impact is expected

## Justification

- The new formatter and accordion UI only run when tool call rows render, and the larger payload blocks stay collapsed until the user expands them.

# UI changes

## Screenshots or recordings

- Web preview pending

# Issue link

- Implementation plan: `implementation-plans/ai-tool-call-details.md`
