### PR TITLE
docs: refresh architecture and roadmap docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,8 @@ This document describes the AI system that is currently implemented in OpenSCAD 
 OpenSCAD Studio runs the AI copilot entirely on the client side.
 
 - The same React/TypeScript AI stack is used in both the standalone web app and the Tauri desktop app.
-- Tauri provides desktop shell features such as native file dialogs and filesystem access, but it does not proxy or execute AI requests.
-- Model requests are made from the frontend with the Vercel AI SDK.
+- Model requests are still made directly from the frontend with the Vercel AI SDK.
+- Tauri provides desktop shell features such as native file dialogs, filesystem access, native rendering, and a desktop-only localhost MCP bridge for external agents.
 - OpenSCAD rendering is client-side: web uses `openscad-wasm` in a Web Worker, while the desktop app uses a bundled native OpenSCAD binary invoked via Tauri IPC commands.
 
 The top-level `README.md` is user-facing. Keep it focused on product-level information and avoid turning it into an engineering index; architecture, roadmap, analytics, and implementation details should live in assistant/developer docs instead.
@@ -65,6 +65,7 @@ Desktop-only shell services:
 │ ├── native menus                                            │
 │ ├── file open/save/export commands                          │
 │ ├── native OpenSCAD binary rendering (render.rs)            │
+│ ├── localhost MCP server for external agents (mcp.rs)       │
 │ ├── working-directory/history helpers                       │
 │ └── desktop packaging/runtime                               │
 └─────────────────────────────────────────────────────────────┘
@@ -112,7 +113,7 @@ Relevant code:
 4. Streaming text and tool calls update the transcript in real time.
 5. Tool execution happens locally in the frontend.
 
-There is no Rust AI transport layer, no Tauri AI IPC command, and no backend conversation loop.
+The in-app copilot still has no Rust-side model transport or backend conversation loop. Desktop builds now also expose a localhost MCP server from Tauri for external-agent workflows, with requests bridged into the active workspace window.
 
 ### Provider selection
 
@@ -139,6 +140,7 @@ The client-side AI agent currently exposes these tools through `aiService.ts`:
 - `set_render_target`
 - `get_diagnostics`
 - `trigger_render`
+- `set_measurement_unit`
 
 All tool execution is implemented in TypeScript and runs inside the app frontend.
 
@@ -159,6 +161,7 @@ All tool execution is implemented in TypeScript and runs inside the app frontend
 - native menus
 - desktop packaging/runtime
 - native OpenSCAD binary rendering
+- localhost MCP endpoint for external agents
 - multi-file project directory management
 - library path resolution
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ The top-level `README.md` is user-facing. Keep it focused on product overview, i
 - **Desktop Runtime**: Rust + Tauri for native shell features, packaging, and filesystem access
 - **Rendering**: Web uses openscad-wasm via Web Worker; desktop uses a bundled native OpenSCAD binary via Tauri IPC
 - **AI Agent**: TypeScript with Vercel AI SDK (`streamText`)
+- **External Agent Bridge (desktop)**: Tauri-hosted localhost MCP server bound to workspace windows
 - **Web Deployment**: Cloudflare Pages
 - **Package Manager**: pnpm (monorepo workspace)
 
@@ -101,6 +102,9 @@ React Frontend (TypeScript)
 └──────────────────────────┴──────────────────────────┘
     ↓
 Vercel AI SDK → Anthropic/OpenAI API (HTTPS)
+
+Desktop-only external agent path:
+Local MCP client → Tauri MCP server (`mcp.rs`) → active workspace window bridge
 ```
 
 ### Key Design Patterns
@@ -113,13 +117,14 @@ Vercel AI SDK → Anthropic/OpenAI API (HTTPS)
    - Interactive STL/3D mesh for manipulation
    - SVG for 2D designs
 
-4. **Shared Client-Side AI**: Both web and desktop use the same frontend AI stack. Requests are made directly from the React app with Vercel AI SDK's `streamText`, and API keys are currently stored in local storage state inside the browser/webview.
+4. **Shared Client-Side AI**: Both web and desktop use the same frontend AI stack for the in-app copilot. Requests are made directly from the React app with Vercel AI SDK's `streamText`, and API keys are currently stored in local storage state inside the browser/webview.
 
 5. **Diff-based AI Editing**: AI returns exact string replacements, not full file rewrites.
 
 6. **Content-hash Caching**: SHA-256 of source + params → cached artifact path. Avoids redundant renders.
 
 7. **Platform Bridge**: Components use a `PlatformBridge` interface (`apps/ui/src/platform/types.ts`) and never import Tauri or web-specific APIs directly.
+8. **Desktop MCP Bridge**: Desktop builds can expose a loopback-only MCP server from Tauri that binds external-agent sessions to a specific Studio window and routes render/diagnostic/screenshot/export requests through the frontend bridge.
 
 ## Important Files
 
@@ -145,6 +150,7 @@ Vercel AI SDK → Anthropic/OpenAI API (HTTPS)
 ### Services
 
 - **`apps/ui/src/services/aiService.ts`**: AI agent using Vercel AI SDK (`streamText`). Handles streaming, tool calls, multi-turn conversations.
+- **`apps/ui/src/services/desktopMcp.ts`**: Desktop MCP bridge. Connects the Tauri localhost MCP server to the active workspace window and implements external-agent render, screenshot, diagnostics, and export handlers.
 - **`apps/ui/src/services/renderService.ts`**: Render orchestration — manages Web Worker communication, caching, diagnostics.
 - **`apps/ui/src/services/openscad-worker.ts`**: Web Worker that loads openscad-wasm and handles render requests off the main thread.
 - **`apps/ui/src/services/nativeRenderService.ts`**: Native OpenSCAD binary IPC bridge (desktop only). Communicates with the Tauri backend to invoke the bundled binary.
@@ -160,6 +166,7 @@ Vercel AI SDK → Anthropic/OpenAI API (HTTPS)
 
 - **`apps/ui/src-tauri/src/lib.rs`**: Tauri app initialization, command registration.
 - **`apps/ui/src-tauri/src/cmd/render.rs`**: Native render workspace management, binary invocation, and output collection.
+- **`apps/ui/src-tauri/src/mcp.rs`**: Desktop localhost MCP server, session/window binding, and request routing for external agents.
 
 ## Development Workflow
 
@@ -287,6 +294,12 @@ pnpm validate:changes   # Run the shared validation helper
 - **Workspace management**: Source files are written to a temporary render workspace so the native binary can resolve `include`/`use` paths and multi-file projects.
 - **Diagnostics**: Stderr from the native binary is captured and parsed using the same TypeScript diagnostics pipeline as the WASM path.
 
+### Desktop MCP (External Agents)
+
+- **Loopback-only server**: Desktop builds can run a localhost MCP endpoint, configured in Settings → External Agents.
+- **Window binding**: Each MCP session binds to a specific Studio workspace window so external-agent actions stay scoped.
+- **Tool routing**: MCP requests are mediated by Tauri and fulfilled in the frontend bridge (`desktopMcp.ts`), not by a separate backend AI loop.
+
 ### Performance
 
 - **Debounced rendering**: 300ms debounce on code changes (configurable)
@@ -301,7 +314,7 @@ pnpm validate:changes   # Run the shared validation helper
 
 ## Current Status
 
-### Current Capabilities (v1.0.1)
+### Current Capabilities (v1.2.0)
 
 ✅ Monaco editor with OpenSCAD syntax highlighting
 ✅ Live STL/SVG preview (web: openscad-wasm, desktop: native binary)
@@ -331,6 +344,7 @@ pnpm validate:changes   # Run the shared validation helper
 ✅ Multi-file project support with file tree, tabs, and include/use resolution
 ✅ Auto-created project directories on desktop
 ✅ Native OpenSCAD binary bundling for desktop (faster rendering, full filesystem access)
+✅ Desktop External Agents settings with localhost MCP access
 
 ### Planned
 
@@ -390,5 +404,5 @@ pnpm validate:changes   # Run the shared validation helper
 
 ---
 
-**Last Updated**: 2026-04-05
-**Current Version**: v1.0.1 — Web + Desktop
+**Last Updated**: 2026-04-12
+**Current Version**: v1.2.0 — Web + Desktop

--- a/PRODUCT_ROADMAP.md
+++ b/PRODUCT_ROADMAP.md
@@ -4,7 +4,7 @@
 >
 > OpenSCAD is the engine, not the product. The product is: you describe what you want, it makes it, you print it.
 
-**Current version**: v1.0.1 | **Last updated**: 2026-04-05
+**Current version**: v1.2.0 | **Last updated**: 2026-04-12
 
 This roadmap mixes shipped milestones with future planning. Older sections may describe the implementation assumptions that existed when they were written rather than the current client-side `openscad-wasm` architecture.
 
@@ -20,7 +20,7 @@ This roadmap mixes shipped milestones with future planning. Older sections may d
 
 ---
 
-## What We Have (v1.0.1)
+## What We Have (v1.2.0)
 
 | Area                                                                                  | Status |
 | ------------------------------------------------------------------------------------- | ------ |

--- a/engineering-roadmap.md
+++ b/engineering-roadmap.md
@@ -1,6 +1,6 @@
 # OpenSCAD Studio — Engineering Roadmap
 
-> Current app version: **v1.0.1**. This roadmap mixes historical milestone notes with future planning, so older phase sections may reference the version they originally shipped in rather than the current release.
+> Current app version: **v1.2.0**. This roadmap mixes historical milestone notes with future planning, so older phase sections may reference the version they originally shipped in rather than the current release.
 >
 > A modern OpenSCAD editor with live preview and AI copilot capabilities, available as both a web app and a macOS desktop app. The application uses openscad-wasm for rendering and provides a superior editing experience with real-time feedback and AI-assisted code generation.
 
@@ -582,6 +582,6 @@ Decisions made during roadmap planning that affect ordering:
 
 ---
 
-**Last Updated:** 2026-04-05
-**Current Phase:** v1.0.1 — web + desktop app shipping with sharing, analytics/privacy controls, formatter coverage, and advanced viewer tooling
+**Last Updated:** 2026-04-12
+**Current Phase:** v1.2.0 — web + desktop app shipping with sharing, analytics/privacy controls, formatter coverage, advanced viewer tooling, and desktop MCP support for external agents
 **Next Milestone:** Phase 4B.1/4B.3 (App.tsx decomposition, centralized state) or Phase 5 (AI experience) based on user feedback


### PR DESCRIPTION
# Summary

## What changed

- Updated `AGENTS.md` and `CLAUDE.md` to reflect the current desktop MCP / external-agent bridge and the current AI tool surface.
- Refreshed stale version markers in `PRODUCT_ROADMAP.md` and `engineering-roadmap.md` from `v1.0.1` to `v1.2.0`.
- Kept the top-level `README.md` unchanged so it stays user-facing and does not accumulate maintainer implementation detail.

## Why

- The maintainer docs had drifted from the current codebase and app behavior.
- In particular, the desktop localhost MCP server and external-agent workflow now exist, while several roadmap/version references were still describing an older release state.

## Implementation notes

- This is a docs-only refresh.
- No product code, runtime behavior, or release assets were changed.
- The architecture docs now distinguish between the in-app client-side copilot flow and the desktop-only MCP bridge for external agents.

# Testing

## Coverage checklist

- [ ] Backend unit tests added or updated for changed Rust behavior
- [ ] Client unit/component tests added or updated for changed frontend behavior
- [ ] E2E tests added or updated for net new user-facing flows
- [x] No new tests were needed for this change

## Validation performed

- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm test:unit`
- [ ] `pnpm test:formatter:ci`
- [ ] `pnpm test:e2e:web`
- [ ] `bash scripts/validate-changes.sh --dry-run ...`
- [ ] `cd apps/ui/src-tauri && cargo fmt --check`
- [ ] `cd apps/ui/src-tauri && cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cd apps/ui/src-tauri && cargo check --all-targets --all-features`

## Test details

- Ran `bash scripts/validate-changes.sh --scope baseline`, which completed successfully and covered `pnpm format:check`, `pnpm lint`, `pnpm type-check`, and `pnpm test:unit`.
- Skipped formatter-specific, e2e, and Rust-only validation because this change only updates repository documentation.

# Performance

## Performance impact

- [ ] Performance was considered for this change
- [x] No meaningful performance impact is expected

## Justification

- Docs-only changes do not affect runtime behavior, bundle size, rendering, or external-agent performance.

# UI changes

## Screenshots or recordings

- N/A

# Issue link

- Closes #
