### PR TITLE
Handle empty folder opens across desktop and web

### DIFF
--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -80,6 +80,7 @@ import { normalizeAppError, notifyError, notifySuccess } from './utils/notificat
 import { exportProjectZip } from './utils/projectZip';
 import { getRelativeProjectPath } from './utils/projectFilePaths';
 import { generateRandomProjectName } from './utils/projectNaming';
+import { resolveFolderImport } from './utils/folderImport';
 import { useShareEntry } from './hooks/useShareEntry';
 import { TbBrandGithub, TbSettings, TbDownload, TbShare3 } from 'react-icons/tb';
 import { Toaster } from 'sonner';
@@ -88,7 +89,6 @@ import type { WorkspaceTab as WorkspaceDocumentTab } from './stores/workspaceTyp
 import {
   OPENSCAD_PROJECT_FILE_EXTENSIONS,
   isOpenScadProjectFilePath,
-  pickOpenScadRenderTarget,
 } from '../../../packages/shared/src/openscadProjectFiles';
 
 const RELEASE_BASE = 'https://github.com/zacharyfmarion/openscad-studio/releases/latest/download';
@@ -133,13 +133,12 @@ function pickFolder(): Promise<{ files: Record<string, string>; renderTargetPath
         }
       }
 
-      const renderTargetPath = pickOpenScadRenderTarget(Object.keys(files), null, workspaceName);
-      if (!renderTargetPath) {
-        resolve(null);
-        return;
-      }
-
-      resolve({ files, renderTargetPath });
+      resolve(
+        resolveFolderImport(files, {
+          workspaceName,
+          createIfEmpty: true,
+        })
+      );
     };
     input.oncancel = () => resolve(null);
     input.click();

--- a/apps/ui/src/services/__tests__/windowOpenService.test.ts
+++ b/apps/ui/src/services/__tests__/windowOpenService.test.ts
@@ -4,7 +4,7 @@ import { jest } from '@jest/globals';
 import { openFileInWindow, openWorkspaceFolderInWindow } from '../windowOpenService';
 import { getProjectStore } from '../../stores/projectStore';
 import { getRenderRequestStore } from '../../stores/renderRequestStore';
-import { DEFAULT_TAB_NAME } from '../../stores/workspaceFactories';
+import { DEFAULT_OPENSCAD_CODE, DEFAULT_TAB_NAME } from '../../stores/workspaceFactories';
 import {
   getWorkspaceState,
   resetWorkspaceStore,
@@ -64,6 +64,52 @@ describe('windowOpenService', () => {
       trigger: 'file_open',
       immediate: true,
     });
+  });
+
+  it('creates main.scad when opening an empty desktop workspace folder', async () => {
+    const platform = {
+      capabilities: { hasFileSystem: true },
+      createDirectory: jest.fn(async () => {}),
+      readDirectoryFiles: jest.fn(async () => ({})),
+      readSubdirectories: jest.fn(async () => []),
+      writeTextFile: jest.fn(async () => {}),
+    };
+
+    const result = await openWorkspaceFolderInWindow('/tmp/empty-workspace', { platform });
+
+    expect(platform.createDirectory).toHaveBeenCalledWith('/tmp/empty-workspace');
+    expect(platform.writeTextFile).toHaveBeenCalledWith(
+      '/tmp/empty-workspace/main.scad',
+      DEFAULT_OPENSCAD_CODE
+    );
+    expect(result).toMatchObject({
+      workspaceRoot: '/tmp/empty-workspace',
+      renderTargetPath: 'main.scad',
+      fileCount: 1,
+      createdDefaultFile: true,
+      emptyFolders: [],
+    });
+    expect(getProjectStore().getState().files['main.scad']?.content).toBe(DEFAULT_OPENSCAD_CODE);
+    expect(getWorkspaceState().tabs[0]?.filePath).toBe('/tmp/empty-workspace/main.scad');
+  });
+
+  it('preserves strict empty-folder errors when createIfEmpty is disabled', async () => {
+    const platform = {
+      capabilities: { hasFileSystem: true },
+      createDirectory: jest.fn(async () => {}),
+      readDirectoryFiles: jest.fn(async () => ({})),
+      readSubdirectories: jest.fn(async () => []),
+      writeTextFile: jest.fn(async () => {}),
+    };
+
+    await expect(
+      openWorkspaceFolderInWindow('/tmp/strict-empty', {
+        platform,
+        createIfEmpty: false,
+      })
+    ).rejects.toThrow('No .scad files found in the selected folder');
+
+    expect(platform.writeTextFile).not.toHaveBeenCalled();
   });
 
   it('reuses an already-open file tab instead of duplicating the workspace', async () => {

--- a/apps/ui/src/services/windowOpenService.ts
+++ b/apps/ui/src/services/windowOpenService.ts
@@ -144,9 +144,10 @@ export async function openWorkspaceFolderInWindow(
   options: OpenWorkspaceFolderOptions = {}
 ): Promise<OpenWorkspaceFolderResult> {
   const platform = options.platform ?? getPlatform();
+  const shouldCreateIfEmpty = options.createIfEmpty ?? platform.capabilities.hasFileSystem;
 
   const workspace = await loadWorkspaceFolder(platform, dirPath, {
-    createIfEmpty: options.createIfEmpty,
+    createIfEmpty: shouldCreateIfEmpty,
   });
 
   const activeTabId = hydrateWindowWorkspace({

--- a/apps/ui/src/utils/__tests__/folderImport.test.ts
+++ b/apps/ui/src/utils/__tests__/folderImport.test.ts
@@ -1,0 +1,39 @@
+import { resolveFolderImport } from '../folderImport';
+import { DEFAULT_OPENSCAD_CODE, DEFAULT_TAB_NAME } from '../../stores/workspaceFactories';
+
+describe('resolveFolderImport', () => {
+  it('selects the preferred render target from imported files', () => {
+    expect(
+      resolveFolderImport(
+        {
+          'lib/helper.scad': '// helper',
+          'main.scad': 'cube(10);',
+        },
+        { workspaceName: 'widgets', createIfEmpty: true }
+      )
+    ).toEqual({
+      files: {
+        'lib/helper.scad': '// helper',
+        'main.scad': 'cube(10);',
+      },
+      renderTargetPath: 'main.scad',
+    });
+  });
+
+  it('creates a default main.scad file for empty folder imports when enabled', () => {
+    expect(resolveFolderImport({}, { createIfEmpty: true, workspaceName: 'empty-folder' })).toEqual(
+      {
+        files: {
+          [DEFAULT_TAB_NAME]: DEFAULT_OPENSCAD_CODE,
+        },
+        renderTargetPath: DEFAULT_TAB_NAME,
+      }
+    );
+  });
+
+  it('returns null for empty folder imports when creation is disabled', () => {
+    expect(resolveFolderImport({}, { createIfEmpty: false, workspaceName: 'empty-folder' })).toBe(
+      null
+    );
+  });
+});

--- a/apps/ui/src/utils/folderImport.ts
+++ b/apps/ui/src/utils/folderImport.ts
@@ -1,0 +1,42 @@
+import { pickOpenScadRenderTarget } from '../../../../packages/shared/src/openscadProjectFiles';
+import { DEFAULT_OPENSCAD_CODE, DEFAULT_TAB_NAME } from '../stores/workspaceFactories';
+
+export interface FolderImportResult {
+  files: Record<string, string>;
+  renderTargetPath: string;
+}
+
+export interface ResolveFolderImportOptions {
+  createIfEmpty?: boolean;
+  workspaceName?: string | null;
+}
+
+export function resolveFolderImport(
+  files: Record<string, string>,
+  options: ResolveFolderImportOptions = {}
+): FolderImportResult | null {
+  const filePaths = Object.keys(files);
+
+  if (filePaths.length === 0) {
+    if (!options.createIfEmpty) {
+      return null;
+    }
+
+    return {
+      files: {
+        [DEFAULT_TAB_NAME]: DEFAULT_OPENSCAD_CODE,
+      },
+      renderTargetPath: DEFAULT_TAB_NAME,
+    };
+  }
+
+  const renderTargetPath = pickOpenScadRenderTarget(filePaths, null, options.workspaceName);
+  if (!renderTargetPath) {
+    return null;
+  }
+
+  return {
+    files,
+    renderTargetPath,
+  };
+}

--- a/implementation-plans/desktop-empty-folder-open.md
+++ b/implementation-plans/desktop-empty-folder-open.md
@@ -1,0 +1,30 @@
+# Desktop Empty Folder Open
+
+## Goal
+
+Allow the desktop app to open a folder that contains no `.scad` files by creating `main.scad`, selecting it as the render target, and hydrating the workspace instead of surfacing an error.
+
+## Approach
+
+- Reuse the existing `loadWorkspaceFolder(..., { createIfEmpty: true })` path that already writes the default `main.scad` file.
+- Change the desktop workspace-open service to default to `createIfEmpty` when the platform has filesystem access, while still honoring explicit `false` for callers that want strict behavior.
+- Add regression coverage for both the new default desktop behavior and the explicit opt-out path.
+
+## Affected Areas
+
+- `apps/ui/src/services/windowOpenService.ts`
+- `apps/ui/src/services/__tests__/windowOpenService.test.ts`
+
+## Checklist
+
+- [x] Read required repo guidance and inspect the current folder-open flow.
+- [x] Implement the desktop empty-folder open fallback in the shared window-open service.
+- [x] Add regression tests for default creation and explicit opt-out behavior.
+- [x] Run deterministic validation for the changed files.
+- [ ] Review the final diff, commit, push, and open a draft PR against `main`.
+
+## Validation Notes
+
+- `pnpm install --frozen-lockfile`
+- `bash scripts/validate-changes.sh --dry-run --changed-file apps/ui/src/services/windowOpenService.ts --changed-file apps/ui/src/services/__tests__/windowOpenService.test.ts --changed-file implementation-plans/desktop-empty-folder-open.md`
+- `bash scripts/validate-changes.sh --changed-file apps/ui/src/services/windowOpenService.ts --changed-file apps/ui/src/services/__tests__/windowOpenService.test.ts --changed-file implementation-plans/desktop-empty-folder-open.md`

--- a/implementation-plans/desktop-empty-folder-open.md
+++ b/implementation-plans/desktop-empty-folder-open.md
@@ -1,25 +1,30 @@
-# Desktop Empty Folder Open
+# Empty Folder Open
 
 ## Goal
 
-Allow the desktop app to open a folder that contains no `.scad` files by creating `main.scad`, selecting it as the render target, and hydrating the workspace instead of surfacing an error.
+Allow both desktop folder opens and web folder imports to succeed when the chosen folder contains no `.scad` files by creating `main.scad`, selecting it as the render target, and hydrating the workspace instead of surfacing an error or doing nothing.
 
 ## Approach
 
 - Reuse the existing `loadWorkspaceFolder(..., { createIfEmpty: true })` path that already writes the default `main.scad` file.
 - Change the desktop workspace-open service to default to `createIfEmpty` when the platform has filesystem access, while still honoring explicit `false` for callers that want strict behavior.
-- Add regression coverage for both the new default desktop behavior and the explicit opt-out path.
+- Add a small shared folder-import resolver for the web `webkitdirectory` path so empty folder selections fall back to the same default `main.scad` starter file in memory.
+- Add regression coverage for the desktop behavior, the explicit opt-out path, and the web folder-import resolver.
 
 ## Affected Areas
 
 - `apps/ui/src/services/windowOpenService.ts`
 - `apps/ui/src/services/__tests__/windowOpenService.test.ts`
+- `apps/ui/src/App.tsx`
+- `apps/ui/src/utils/folderImport.ts`
+- `apps/ui/src/utils/__tests__/folderImport.test.ts`
 
 ## Checklist
 
 - [x] Read required repo guidance and inspect the current folder-open flow.
 - [x] Implement the desktop empty-folder open fallback in the shared window-open service.
 - [x] Add regression tests for default creation and explicit opt-out behavior.
+- [x] Extend the web folder-import flow to create `main.scad` for empty folder selections.
 - [x] Run deterministic validation for the changed files.
 - [x] Review the final diff, commit, push, and open a draft PR against `main`.
 
@@ -28,5 +33,8 @@ Allow the desktop app to open a folder that contains no `.scad` files by creatin
 - `pnpm install --frozen-lockfile`
 - `bash scripts/validate-changes.sh --dry-run --changed-file apps/ui/src/services/windowOpenService.ts --changed-file apps/ui/src/services/__tests__/windowOpenService.test.ts --changed-file implementation-plans/desktop-empty-folder-open.md`
 - `bash scripts/validate-changes.sh --changed-file apps/ui/src/services/windowOpenService.ts --changed-file apps/ui/src/services/__tests__/windowOpenService.test.ts --changed-file implementation-plans/desktop-empty-folder-open.md`
+- `bash scripts/validate-changes.sh --dry-run --changed-file apps/ui/src/App.tsx --changed-file apps/ui/src/utils/folderImport.ts --changed-file apps/ui/src/utils/__tests__/folderImport.test.ts --changed-file implementation-plans/desktop-empty-folder-open.md`
+- `pnpm prettier --write apps/ui/src/App.tsx`
+- `bash scripts/validate-changes.sh --changed-file apps/ui/src/App.tsx --changed-file apps/ui/src/utils/folderImport.ts --changed-file apps/ui/src/utils/__tests__/folderImport.test.ts --changed-file implementation-plans/desktop-empty-folder-open.md`
 - Draft PR: `https://github.com/zacharyfmarion/openscad-studio/pull/116`
 - Preview URL: `https://pr-116.openscad-studio.pages.dev/`

--- a/implementation-plans/desktop-empty-folder-open.md
+++ b/implementation-plans/desktop-empty-folder-open.md
@@ -21,10 +21,12 @@ Allow the desktop app to open a folder that contains no `.scad` files by creatin
 - [x] Implement the desktop empty-folder open fallback in the shared window-open service.
 - [x] Add regression tests for default creation and explicit opt-out behavior.
 - [x] Run deterministic validation for the changed files.
-- [ ] Review the final diff, commit, push, and open a draft PR against `main`.
+- [x] Review the final diff, commit, push, and open a draft PR against `main`.
 
 ## Validation Notes
 
 - `pnpm install --frozen-lockfile`
 - `bash scripts/validate-changes.sh --dry-run --changed-file apps/ui/src/services/windowOpenService.ts --changed-file apps/ui/src/services/__tests__/windowOpenService.test.ts --changed-file implementation-plans/desktop-empty-folder-open.md`
 - `bash scripts/validate-changes.sh --changed-file apps/ui/src/services/windowOpenService.ts --changed-file apps/ui/src/services/__tests__/windowOpenService.test.ts --changed-file implementation-plans/desktop-empty-folder-open.md`
+- Draft PR: `https://github.com/zacharyfmarion/openscad-studio/pull/116`
+- Preview URL: `https://pr-116.openscad-studio.pages.dev/`


### PR DESCRIPTION
# Summary

## What changed

- Defaulted desktop workspace-folder opens to create `main.scad` when the selected folder has no `.scad` files, while still allowing strict callers to opt out with `createIfEmpty: false`.
- Updated the web folder-import flow (`webkitdirectory`) to create the same in-memory `main.scad` starter project when the selected folder has no `.scad` files.
- Added regression coverage for the desktop empty-folder path, the explicit opt-out path, and the shared web folder-import resolver.
- Recorded the implementation plan and validation notes in `implementation-plans/desktop-empty-folder-open.md`.

## Why

- Desktop folder open previously failed with "No .scad files found in the selected folder" even though the app already knew how to initialize an empty project with `main.scad`.
- Web folder import had a similar dead-end: selecting a folder with no `.scad` files resulted in no opened project at all.
- Matching the existing empty-project behavior on both platforms makes blank-directory starts feel intentional instead of broken.

## Implementation notes

- `apps/ui/src/services/windowOpenService.ts` now defaults `createIfEmpty` based on filesystem capability, so desktop callers inherit the fallback without changing each call site.
- `apps/ui/src/utils/folderImport.ts` centralizes the web folder-import render-target resolution and empty-folder fallback.
- `apps/ui/src/App.tsx` now routes web folder imports through that shared resolver with `createIfEmpty: true`.
- The lower-level desktop loader behavior is unchanged for explicit strict callers.
- Implementation plan: `implementation-plans/desktop-empty-folder-open.md`

# Testing

## Coverage checklist

- [ ] Backend unit tests added or updated for changed Rust behavior
- [x] Client unit/component tests added or updated for changed frontend behavior
- [ ] E2E tests added or updated for net new user-facing flows
- [ ] No new tests were needed for this change

## Validation performed

- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm test:unit`
- [ ] `pnpm test:formatter:ci`
- [ ] `pnpm test:e2e:web`
- [x] `bash scripts/validate-changes.sh --dry-run ...`
- [ ] `cd apps/ui/src-tauri && cargo fmt --check`
- [ ] `cd apps/ui/src-tauri && cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cd apps/ui/src-tauri && cargo check --all-targets --all-features`

## Test details

- Ran `pnpm install --frozen-lockfile` in the worktree before validation because `node_modules` was not present.
- Ran `bash scripts/validate-changes.sh --dry-run --changed-file apps/ui/src/services/windowOpenService.ts --changed-file apps/ui/src/services/__tests__/windowOpenService.test.ts --changed-file implementation-plans/desktop-empty-folder-open.md`.
- Ran `bash scripts/validate-changes.sh --changed-file apps/ui/src/services/windowOpenService.ts --changed-file apps/ui/src/services/__tests__/windowOpenService.test.ts --changed-file implementation-plans/desktop-empty-folder-open.md`.
- Ran `bash scripts/validate-changes.sh --dry-run --changed-file apps/ui/src/App.tsx --changed-file apps/ui/src/utils/folderImport.ts --changed-file apps/ui/src/utils/__tests__/folderImport.test.ts --changed-file implementation-plans/desktop-empty-folder-open.md`.
- Ran `pnpm prettier --write apps/ui/src/App.tsx` after the second validation pass reported a formatting mismatch.
- Ran `bash scripts/validate-changes.sh --changed-file apps/ui/src/App.tsx --changed-file apps/ui/src/utils/folderImport.ts --changed-file apps/ui/src/utils/__tests__/folderImport.test.ts --changed-file implementation-plans/desktop-empty-folder-open.md`.
- Skipped formatter regression checks because formatter behavior did not change.
- Skipped web E2E because the change is covered by unit tests and does not introduce a broader browser interaction model beyond the existing folder import flow.
- Skipped Rust validation because no `src-tauri` code changed.

# Performance

## Performance impact

- [x] Performance was considered for this change
- [x] No meaningful performance impact is expected

## Justification

- The change only adds a small render-target resolution helper and the empty-folder fallback path for previously failing opens/imports.

# UI changes

## Screenshots or recordings

- N/A

# Issue link

- Closes #
