### PR TITLE
fix(analytics): rename preset → layout in workspace layout selected event

### DIFF
--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -1481,7 +1481,7 @@ function App() {
       updateSetting('ui', { hasCompletedNux: true, defaultLayoutPreset: preset });
       setShowNux(false);
       analytics.track('workspace layout selected', {
-        preset,
+        layout: preset,
         source: 'nux' satisfies LayoutSelectionSource,
         is_first_run: true,
       });
@@ -1507,7 +1507,7 @@ function App() {
 
       if (changed) {
         analytics.track('workspace layout selected', {
-          preset,
+          layout: preset,
           source: 'header' satisfies LayoutSelectionSource,
           is_first_run: false,
         });

--- a/apps/ui/src/components/SettingsDialog.tsx
+++ b/apps/ui/src/components/SettingsDialog.tsx
@@ -156,7 +156,7 @@ export function SettingsDialog({ isOpen, onClose, initialTab }: SettingsDialogPr
       saveSettings(updated);
       if (changed) {
         analytics.track('workspace layout selected', {
-          preset,
+          layout: preset,
           source: 'settings' satisfies LayoutSelectionSource,
           is_first_run: false,
         });

--- a/apps/ui/src/components/__tests__/SettingsDialog.test.tsx
+++ b/apps/ui/src/components/__tests__/SettingsDialog.test.tsx
@@ -254,7 +254,7 @@ describe('SettingsDialog privacy copy', () => {
     expect(mockTrack).toHaveBeenCalledWith(
       'workspace layout selected',
       expect.objectContaining({
-        preset: 'customizer-first',
+        layout: 'customizer-first',
         source: 'settings',
         is_first_run: false,
       })
@@ -262,7 +262,7 @@ describe('SettingsDialog privacy copy', () => {
     expect(mockTrack).toHaveBeenCalledWith(
       'workspace layout selected',
       expect.objectContaining({
-        preset: 'customizer-first',
+        layout: 'customizer-first',
         source: 'layout_reset',
         is_first_run: false,
       })

--- a/apps/ui/src/components/settings/AppearanceSettings.tsx
+++ b/apps/ui/src/components/settings/AppearanceSettings.tsx
@@ -63,7 +63,7 @@ export function AppearanceSettings({
             variant="secondary"
             onClick={() => {
               analytics.track('workspace layout selected', {
-                preset: settings.ui.defaultLayoutPreset,
+                layout: settings.ui.defaultLayoutPreset,
                 source: 'layout_reset' satisfies LayoutSelectionSource,
                 is_first_run: false,
               });


### PR DESCRIPTION
## Summary

- Renames the `preset` property key to `layout` in all four `workspace layout selected` event tracking calls (`nux`, `header`, `settings`, `layout_reset` sources)
- Updates test assertions in `SettingsDialog.test.tsx` to match

## Motivation

PostHog showed the layout field as null across 439 recorded events because the property was being sent under the key `preset`, not `layout`. This meant breakdowns by layout preference were impossible for the most-used personalization event in the product.

## Affected files

- `apps/ui/src/App.tsx` — NUX and header layout selection handlers
- `apps/ui/src/components/SettingsDialog.tsx` — settings dialog layout change handler
- `apps/ui/src/components/settings/AppearanceSettings.tsx` — Reset layout button handler
- `apps/ui/src/components/__tests__/SettingsDialog.test.tsx` — assertion update

## Test plan

- [x] All 79 unit test suites pass (`pnpm test:unit`)
- [x] Format check, lint, and type-check pass (`pnpm format:check`, `pnpm lint`, `pnpm type-check`)
- [x] No Rust or E2E changes — pure TypeScript property-key rename, no UI or behavior change

**Validations run:** `baseline` (format:check, lint, type-check, test:unit)
**Skipped:** `formatter`, `rust`, `e2e-web` — no formatter logic, Rust, or user-facing flow changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)