### PR TITLE
Fix export context for project renders

### DIFF
--- a/apps/ui/eslint.config.js
+++ b/apps/ui/eslint.config.js
@@ -77,5 +77,25 @@ export default tseslint.config(
         },
       ],
     },
+  },
+  {
+    files: ['**/*.{ts,tsx}'],
+    ignores: [
+      'src/services/renderService.ts',
+      'src/services/nativeRenderService.ts',
+      'src/services/exportService.ts',
+      'src/services/desktopMcp.ts',
+      'src/services/__tests__/*.test.ts',
+    ],
+    rules: {
+      'no-restricted-properties': [
+        'error',
+        {
+          property: 'exportModel',
+          message:
+            'Use exportModelWithContext() for app-level exports. Direct exportModel() calls are reserved for low-level render services and desktop MCP export plumbing.',
+        },
+      ],
+    },
   }
 );

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -51,7 +51,7 @@ import {
   syncDesktopMcpConfig,
   syncDesktopMcpWindowContext,
 } from './services/desktopMcp';
-import { getRenderService } from './services/renderService';
+import { exportModelWithContext } from './services/exportService';
 import { getPreviewSceneStyle } from './services/previewSceneConfig';
 import { isShareEnabled } from './services/shareService';
 import { openFileInWindow, openWorkspaceFolderInWindow } from './services/windowOpenService';
@@ -1788,10 +1788,11 @@ function App() {
           };
           const formatInfo = formatLabels[format];
           const rtContent = getRenderTargetContent(getProjectStore().getState()) ?? '';
-          const exportBytes = await getRenderService().exportModel(
-            rtContent,
-            format as 'stl' | 'obj' | 'amf' | '3mf' | 'svg' | 'dxf'
-          );
+          const exportBytes = await exportModelWithContext({
+            format,
+            source: rtContent,
+            library: loadSettings().library,
+          });
           await getPlatform().fileExport(exportBytes, `export.${formatInfo.ext}`, [
             { name: formatInfo.label, extensions: [formatInfo.ext] },
           ]);

--- a/apps/ui/src/components/ExportDialog.tsx
+++ b/apps/ui/src/components/ExportDialog.tsx
@@ -2,7 +2,8 @@ import { useState, useEffect } from 'react';
 import { useAnalytics } from '../analytics/runtime';
 import { getPlatform, type ExportFormat } from '../platform';
 import { isExportValidationError } from '../services/exportErrors';
-import { getRenderService, type ExportFormat as WasmExportFormat } from '../services/renderService';
+import { exportModelWithContext } from '../services/exportService';
+import { useSettings } from '../stores/settingsStore';
 import {
   Button,
   IconButton,
@@ -39,6 +40,7 @@ const FORMAT_OPTIONS_2D: { value: ExportFormat; label: string; ext: string }[] =
 
 export function ExportDialog({ isOpen, onClose, source, previewKind }: ExportDialogProps) {
   const analytics = useAnalytics();
+  const [settings] = useSettings();
   const [format, setFormat] = useState<ExportFormat>(previewKind === 'svg' ? 'svg' : 'stl');
   const [isExporting, setIsExporting] = useState(false);
   const [error, setError] = useState<string>('');
@@ -64,7 +66,11 @@ export function ExportDialog({ isOpen, onClose, source, previewKind }: ExportDia
       const selectedFormat = formatOptions.find((f) => f.value === format);
       if (!selectedFormat) return;
 
-      const exportBytes = await getRenderService().exportModel(source, format as WasmExportFormat);
+      const exportBytes = await exportModelWithContext({
+        format,
+        source,
+        library: settings.library,
+      });
 
       await getPlatform().fileExport(exportBytes, `export.${selectedFormat.ext}`, [
         { name: selectedFormat.label, extensions: [selectedFormat.ext] },

--- a/apps/ui/src/components/MenuBar.tsx
+++ b/apps/ui/src/components/MenuBar.tsx
@@ -1,7 +1,8 @@
 import { useState, useRef, useEffect } from 'react';
 import { toast } from 'sonner';
 import { getPlatform, type ExportFormat } from '../platform';
-import { getRenderService } from '../services/renderService';
+import { exportModelWithContext } from '../services/exportService';
+import { loadSettings } from '../stores/settingsStore';
 import { normalizeAppError } from '../utils/notifications';
 import { OPENSCAD_PROJECT_FILE_EXTENSIONS } from '../../../../packages/shared/src/openscadProjectFiles';
 
@@ -86,10 +87,11 @@ export function MenuBar({
       const formatInfo = EXPORT_FORMATS.find((f) => f.value === format);
       if (!formatInfo) return;
 
-      const exportBytes = await getRenderService().exportModel(
+      const exportBytes = await exportModelWithContext({
+        format,
         source,
-        format as 'stl' | 'obj' | 'amf' | '3mf' | 'svg' | 'dxf'
-      );
+        library: loadSettings().library,
+      });
 
       await getPlatform().fileExport(exportBytes, `export.${formatInfo.ext}`, [
         { name: formatInfo.label, extensions: [formatInfo.ext] },

--- a/apps/ui/src/components/__tests__/ExportDialog.test.tsx
+++ b/apps/ui/src/components/__tests__/ExportDialog.test.tsx
@@ -22,9 +22,8 @@ jest.unstable_mockModule('@/platform', () => ({
   getPlatform: () => ({ fileExport: jest.fn() }),
 }));
 
-jest.unstable_mockModule('@/services/renderService', () => ({
-  getRenderService: () => ({ exportModel: jest.fn() }),
-  RenderService: { getInstance: () => ({ exportModel: jest.fn() }) },
+jest.unstable_mockModule('@/services/exportService', () => ({
+  exportModelWithContext: jest.fn(),
 }));
 
 jest.unstable_mockModule('@/utils/notifications', () => ({

--- a/apps/ui/src/components/panels/PanelComponents.tsx
+++ b/apps/ui/src/components/panels/PanelComponents.tsx
@@ -12,7 +12,7 @@ import { PanelErrorBoundary } from '../ErrorBoundary';
 import { useWorkspace } from '../../contexts/WorkspaceContext';
 import { useProjectStore } from '../../stores/projectStore';
 import { isExportValidationError } from '../../services/exportErrors';
-import { getRenderService } from '../../services/renderService';
+import { exportModelWithContext } from '../../services/exportService';
 import { getPlatform } from '../../platform';
 import { notifyError } from '../../utils/notifications';
 import { MAIN_PREVIEW_VIEWER_ID } from '../../utils/capturePreview';
@@ -169,7 +169,11 @@ const CustomizerPanelWrapper: React.FC<IDockviewPanelProps> = () => {
     if (isDownloadingStl) return;
     setIsDownloadingStl(true);
     try {
-      const exportBytes = await getRenderService().exportModel(source, 'stl');
+      const exportBytes = await exportModelWithContext({
+        format: 'stl',
+        source,
+        library: settings.library,
+      });
       await getPlatform().fileExport(exportBytes, 'export.stl', [
         { name: 'STL Files', extensions: ['stl'] },
       ]);
@@ -186,13 +190,17 @@ const CustomizerPanelWrapper: React.FC<IDockviewPanelProps> = () => {
     } finally {
       setIsDownloadingStl(false);
     }
-  }, [isDownloadingStl, source, analytics]);
+  }, [isDownloadingStl, source, analytics, settings.library]);
 
   const handleDownloadSvg = useCallback(async () => {
     if (isDownloadingSvg) return;
     setIsDownloadingSvg(true);
     try {
-      const exportBytes = await getRenderService().exportModel(source, 'svg');
+      const exportBytes = await exportModelWithContext({
+        format: 'svg',
+        source,
+        library: settings.library,
+      });
       await getPlatform().fileExport(exportBytes, 'export.svg', [
         { name: 'SVG Files', extensions: ['svg'] },
       ]);
@@ -209,7 +217,7 @@ const CustomizerPanelWrapper: React.FC<IDockviewPanelProps> = () => {
     } finally {
       setIsDownloadingSvg(false);
     }
-  }, [isDownloadingSvg, source, analytics]);
+  }, [isDownloadingSvg, source, analytics, settings.library]);
 
   return (
     <PanelErrorBoundary panelId="customizer" panelName="Customizer">

--- a/apps/ui/src/services/__tests__/exportService.test.ts
+++ b/apps/ui/src/services/__tests__/exportService.test.ts
@@ -1,0 +1,77 @@
+import { jest } from '@jest/globals';
+import { exportModelWithContext } from '../exportService';
+import type { ProjectStoreState } from '../../stores/projectTypes';
+
+function createState(overrides: Partial<ProjectStoreState> = {}): ProjectStoreState {
+  return {
+    projectRoot: '/project',
+    renderTargetPath: 'models/main.scad',
+    contentVersion: 0,
+    emptyFolders: [],
+    files: {
+      'models/main.scad': {
+        content: 'use <shared/utils.scad>\ninclude <BOSL2/std.scad>\ncube(size);',
+        savedContent: 'use <shared/utils.scad>\ninclude <BOSL2/std.scad>\ncube(size);',
+        isDirty: false,
+        isVirtual: false,
+        customizerBaseContent: 'use <shared/utils.scad>\ninclude <BOSL2/std.scad>\ncube(size);',
+      },
+      'models/shared/utils.scad': {
+        content: 'size = 24;',
+        savedContent: 'size = 24;',
+        isDirty: false,
+        isVirtual: false,
+        customizerBaseContent: 'size = 24;',
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe('exportService', () => {
+  it('exports with shared project and library render inputs', async () => {
+    const exportModel = jest.fn(async () => new Uint8Array([1, 2, 3]));
+    const getLibraryPaths = jest.fn(async () => ['/lib/system']);
+    const readDirectoryFiles = jest
+      .fn()
+      .mockResolvedValueOnce({ 'BOSL2/std.scad': 'module std() {}' })
+      .mockResolvedValueOnce({ 'custom/std.scad': 'module custom() {}' });
+    const readTextFile = jest.fn(async () => null);
+
+    const result = await exportModelWithContext({
+      format: 'stl',
+      library: {
+        autoDiscoverSystem: true,
+        customPaths: ['/lib/custom'],
+      },
+      state: createState(),
+      renderService: { exportModel } as never,
+      platform: {
+        getLibraryPaths,
+        readDirectoryFiles,
+        readTextFile,
+      } as never,
+    });
+
+    expect(result).toEqual(new Uint8Array([1, 2, 3]));
+    expect(exportModel).toHaveBeenCalledWith(
+      'use <shared/utils.scad>\ninclude <BOSL2/std.scad>\ncube(size);',
+      'stl',
+      {
+        backend: 'manifold',
+        auxiliaryFiles: {
+          'BOSL2/std.scad': 'module std() {}',
+          'custom/std.scad': 'module custom() {}',
+          'models/shared/utils.scad': 'size = 24;',
+        },
+        inputPath: 'models/main.scad',
+        libraryFiles: {
+          'BOSL2/std.scad': 'module std() {}',
+          'custom/std.scad': 'module custom() {}',
+        },
+        libraryPaths: ['/lib/system', '/lib/custom'],
+        workingDir: '/project',
+      }
+    );
+  });
+});

--- a/apps/ui/src/services/exportService.ts
+++ b/apps/ui/src/services/exportService.ts
@@ -1,0 +1,43 @@
+import { getPlatform } from '../platform';
+import type { PlatformBridge } from '../platform/types';
+import { getProjectState } from '../stores/projectStore';
+import type { ProjectStoreState } from '../stores/projectTypes';
+import type { LibrarySettings } from '../stores/settingsStore';
+import { buildProjectRenderInputs, loadConfiguredLibraryAssets } from './projectRenderInputs';
+import { getRenderService, type ExportFormat, type IRenderService } from './renderService';
+
+interface ExportModelWithContextOptions {
+  format: ExportFormat;
+  library: LibrarySettings;
+  source?: string | null;
+  state?: ProjectStoreState;
+  workingDir?: string | null;
+  platform?: PlatformBridge;
+  renderService?: Pick<IRenderService, 'exportModel'>;
+}
+
+export async function exportModelWithContext(
+  options: ExportModelWithContextOptions
+): Promise<Uint8Array> {
+  const state = options.state ?? getProjectState();
+  const workingDir = options.workingDir ?? state.projectRoot;
+  const platform = options.platform ?? getPlatform();
+  const renderService = options.renderService ?? getRenderService();
+  const { libraryFiles, libraryPaths } = await loadConfiguredLibraryAssets(
+    options.library,
+    platform
+  );
+  const renderInputs = await buildProjectRenderInputs({
+    state,
+    code: options.source,
+    workingDir,
+    libraryFiles,
+    libraryPaths,
+    platform: workingDir ? platform : undefined,
+  });
+
+  return renderService.exportModel(renderInputs.code, options.format, {
+    backend: 'manifold',
+    ...renderInputs.renderOptions,
+  });
+}

--- a/apps/ui/src/services/renderService.ts
+++ b/apps/ui/src/services/renderService.ts
@@ -18,7 +18,7 @@ export interface Diagnostic {
   message: string;
 }
 
-export type ExportFormat = 'stl' | 'obj' | 'amf' | '3mf' | 'svg' | 'dxf';
+export type ExportFormat = 'stl' | 'obj' | 'amf' | '3mf' | 'png' | 'svg' | 'dxf';
 
 export interface ExportOptions extends Pick<
   RenderOptions,

--- a/implementation-plans/export-dialog-project-context.md
+++ b/implementation-plans/export-dialog-project-context.md
@@ -1,0 +1,31 @@
+# Export Dialog Project Context
+
+## Goal
+
+Make desktop export flows use the same project, working-directory, and library context as preview rendering so exports do not fail with empty output when the render target depends on sibling files or configured libraries.
+
+## Approach
+
+1. Add one shared export helper that reuses the existing project render-input builder and library loading logic.
+2. Route both dialog-driven and menu-driven exports through that helper instead of calling the render service with raw source alone.
+3. Add regression coverage for export context assembly and keep the implementation plan updated through validation and PR handoff.
+
+## Affected Areas
+
+- `apps/ui/src/components/ExportDialog.tsx`
+- `apps/ui/src/App.tsx`
+- `apps/ui/src/services/exportService.ts`
+- `apps/ui/src/services/renderService.ts`
+- `apps/ui/src/components/__tests__/ExportDialog.test.tsx`
+- `apps/ui/src/services/__tests__/exportService.test.ts`
+- `implementation-plans/export-dialog-project-context.md`
+
+## Checklist
+
+- [x] Reproduce the export failure and identify the missing render context
+- [x] Add a shared export helper that reuses project render-input assembly
+- [x] Update dialog and menu export paths to use the shared helper
+- [x] Add regression coverage for export context propagation
+- [x] Run shared validation through `scripts/validate-changes.sh`
+- [ ] Create a draft PR against `main` with implementation notes and validation details
+- [ ] Wait for the PR result and report the PR URL plus preview status

--- a/implementation-plans/export-dialog-project-context.md
+++ b/implementation-plans/export-dialog-project-context.md
@@ -27,5 +27,5 @@ Make desktop export flows use the same project, working-directory, and library c
 - [x] Update dialog and menu export paths to use the shared helper
 - [x] Add regression coverage for export context propagation
 - [x] Run shared validation through `scripts/validate-changes.sh`
-- [ ] Create a draft PR against `main` with implementation notes and validation details
-- [ ] Wait for the PR result and report the PR URL plus preview status
+- [x] Create a draft PR against `main` with implementation notes and validation details
+- [x] Wait for the PR result and report the PR URL plus preview status

--- a/implementation-plans/export-dialog-project-context.md
+++ b/implementation-plans/export-dialog-project-context.md
@@ -7,13 +7,17 @@ Make desktop export flows use the same project, working-directory, and library c
 ## Approach
 
 1. Add one shared export helper that reuses the existing project render-input builder and library loading logic.
-2. Route both dialog-driven and menu-driven exports through that helper instead of calling the render service with raw source alone.
-3. Add regression coverage for export context assembly and keep the implementation plan updated through validation and PR handoff.
+2. Route UI export entrypoints through that helper instead of calling the render service with raw source alone.
+3. Add a lint guard so app code cannot introduce new direct `exportModel()` calls outside the low-level service layer.
+4. Add regression coverage for export context assembly and keep the implementation plan updated through validation and PR handoff.
 
 ## Affected Areas
 
 - `apps/ui/src/components/ExportDialog.tsx`
 - `apps/ui/src/App.tsx`
+- `apps/ui/src/components/MenuBar.tsx`
+- `apps/ui/src/components/panels/PanelComponents.tsx`
+- `apps/ui/eslint.config.js`
 - `apps/ui/src/services/exportService.ts`
 - `apps/ui/src/services/renderService.ts`
 - `apps/ui/src/components/__tests__/ExportDialog.test.tsx`
@@ -24,7 +28,8 @@ Make desktop export flows use the same project, working-directory, and library c
 
 - [x] Reproduce the export failure and identify the missing render context
 - [x] Add a shared export helper that reuses project render-input assembly
-- [x] Update dialog and menu export paths to use the shared helper
+- [x] Update dialog, menu, and customizer export paths to use the shared helper
+- [x] Add a lint guard that blocks new direct app-level `exportModel()` calls
 - [x] Add regression coverage for export context propagation
 - [x] Run shared validation through `scripts/validate-changes.sh`
 - [x] Create a draft PR against `main` with implementation notes and validation details


### PR DESCRIPTION
# Summary

## What changed

- route dialog and menu exports through a shared export helper that reuses project render-input assembly
- include project files, working-directory dependencies, and configured library paths when exporting from the desktop UI
- add regression coverage for export context propagation and document the work in `implementation-plans/export-dialog-project-context.md`

## Why

- desktop export was invoking the native render service with only the raw render-target source
- previews could succeed while export failed with `Export produced no output` whenever the model depended on sibling files or configured libraries
- aligning export with the existing preview input pipeline fixes that mismatch and keeps export behavior consistent with render behavior

## Implementation notes

- added `apps/ui/src/services/exportService.ts` as a shared helper around `loadConfiguredLibraryAssets()` and `buildProjectRenderInputs()`
- updated `ExportDialog` and the native menu export handler in `App.tsx` to call the shared helper instead of `getRenderService().exportModel(...)` directly
- widened the render-service export format union to include `png` so the helper can accept the full app-level export format type without casting
- implementation plan: `implementation-plans/export-dialog-project-context.md`

# Testing

## Coverage checklist

- [ ] Backend unit tests added or updated for changed Rust behavior
- [x] Client unit/component tests added or updated for changed frontend behavior
- [ ] E2E tests added or updated for net new user-facing flows
- [ ] No new tests were needed for this change

## Validation performed

- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm test:unit`
- [ ] `pnpm test:formatter:ci`
- [ ] `pnpm test:e2e:web`
- [x] `bash scripts/validate-changes.sh --dry-run ...`
- [x] `cd apps/ui/src-tauri && cargo fmt --check`
- [ ] `cd apps/ui/src-tauri && cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cd apps/ui/src-tauri && cargo check --all-targets --all-features`

## Test details

- Ran `bash scripts/validate-changes.sh --dry-run --changed-file ...` to confirm scope selection for this frontend-only change.
- Ran `bash scripts/validate-changes.sh --changed-file ...`, which executed `pnpm format:check`, `pnpm lint`, `pnpm type-check`, and `pnpm test:unit` successfully.
- Formatter-specific tests were skipped because no formatter logic changed.
- Web E2E was skipped because this is a focused export-path bug fix with unit coverage and no new end-to-end flow.
- Rust `clippy` and `cargo check` were skipped because no Rust files changed; `cargo fmt --check` still ran as part of `pnpm format:check`.

# Performance

## Performance impact

- [x] Performance was considered for this change
- [x] No meaningful performance impact is expected

## Justification

- Export now reuses the same project-input assembly already used by preview rendering, so the change should align behavior without introducing a materially new runtime cost profile.

# UI changes

## Screenshots or recordings

- N/A

# Issue link

- Closes #
