### PR TITLE
Fix AI diagnostics for 2D render targets

### DIFF
--- a/apps/ui/src/components/__tests__/svgViewerHelpers.test.ts
+++ b/apps/ui/src/components/__tests__/svgViewerHelpers.test.ts
@@ -68,6 +68,23 @@ describe('svg viewer helpers', () => {
     expect(parsed.markup).not.toContain('fill="lightgray"');
   });
 
+  it('replaces the desktop native default outline-only style with the provided theme fill', () => {
+    const parsed = parseSvgMetrics(
+      `
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 -21 22 22">
+          <path d="M 0,-0 L 20,-0 L 20,-20 L 0,-20 z" stroke="black" fill="none" stroke-width="0.35" />
+        </svg>
+      `,
+      {
+        defaultFillColor: '#2aa198',
+      }
+    );
+
+    expect(parsed.markup).toContain('fill="#2aa198"');
+    expect(parsed.markup).toContain('stroke="black"');
+    expect(parsed.markup).not.toContain('fill="none"');
+  });
+
   it('keeps explicit non-default style fills intact when a theme fill is provided', () => {
     const parsed = parseSvgMetrics(
       `
@@ -81,6 +98,23 @@ describe('svg viewer helpers', () => {
     );
 
     expect(parsed.markup).toContain('style="fill:#123456;stroke:#000000"');
+    expect(parsed.markup).not.toContain('fill="#2aa198"');
+  });
+
+  it('keeps explicit outline-only styling intact when the stroke is non-default', () => {
+    const parsed = parseSvgMetrics(
+      `
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 10">
+          <path d="M 0,0 L 20,0 L 20,10 z" fill="none" stroke="#ff0000" />
+        </svg>
+      `,
+      {
+        defaultFillColor: '#2aa198',
+      }
+    );
+
+    expect(parsed.markup).toContain('fill="none"');
+    expect(parsed.markup).toContain('stroke="#ff0000"');
     expect(parsed.markup).not.toContain('fill="#2aa198"');
   });
 

--- a/apps/ui/src/components/svg-viewer/parseSvgMetrics.ts
+++ b/apps/ui/src/components/svg-viewer/parseSvgMetrics.ts
@@ -9,6 +9,14 @@ const OPENSCAD_DEFAULT_FILL_VALUES = new Set([
   'rgb(211,211,211)',
   'rgba(211,211,211,1)',
 ]);
+const OPENSCAD_DEFAULT_STROKE_VALUES = new Set([
+  'black',
+  '#000',
+  '#000000',
+  'rgb(0,0,0)',
+  'rgba(0,0,0,1)',
+]);
+const FILL_CAPABLE_GEOMETRY_TAGS = new Set(['path', 'circle', 'ellipse', 'rect', 'polygon', 'text', 'use']);
 
 interface ParseSvgMetricsOptions {
   defaultFillColor?: string;
@@ -73,6 +81,43 @@ function styleContainsExplicitNonDefaultFill(styleValue: string | null) {
   return !!fillValue && fillValue !== 'none' && !OPENSCAD_DEFAULT_FILL_VALUES.has(fillValue);
 }
 
+function getStyleDeclaration(styleValue: string | null, propertyName: string): string | null {
+  if (!styleValue) {
+    return null;
+  }
+
+  const propertyNameLower = propertyName.toLowerCase();
+  const declaration = styleValue
+    .split(';')
+    .map((entry) => entry.trim())
+    .find((entry) => entry.toLowerCase().startsWith(`${propertyNameLower}:`));
+
+  if (!declaration) {
+    return null;
+  }
+
+  return declaration.slice(declaration.indexOf(':') + 1).trim();
+}
+
+function hasOpenScadDefaultOutlineOnlyStyle(geometryElement: Element) {
+  if (!FILL_CAPABLE_GEOMETRY_TAGS.has(geometryElement.tagName.toLowerCase())) {
+    return false;
+  }
+
+  const styleValue = geometryElement.getAttribute('style');
+  const fillValue = normalizeColorToken(
+    geometryElement.getAttribute('fill') ?? getStyleDeclaration(styleValue, 'fill')
+  );
+  if (fillValue !== 'none') {
+    return false;
+  }
+
+  const strokeValue = normalizeColorToken(
+    geometryElement.getAttribute('stroke') ?? getStyleDeclaration(styleValue, 'stroke')
+  );
+  return !!strokeValue && OPENSCAD_DEFAULT_STROKE_VALUES.has(strokeValue);
+}
+
 function shouldApplyDefaultFill(
   geometryElement: Element,
   defaultFillColor: string | undefined
@@ -91,7 +136,7 @@ function shouldApplyDefaultFill(
   }
 
   if (fillValue === 'none') {
-    return false;
+    return hasOpenScadDefaultOutlineOnlyStyle(geometryElement);
   }
 
   return OPENSCAD_DEFAULT_FILL_VALUES.has(fillValue);

--- a/apps/ui/src/components/svg-viewer/parseSvgMetrics.ts
+++ b/apps/ui/src/components/svg-viewer/parseSvgMetrics.ts
@@ -16,7 +16,15 @@ const OPENSCAD_DEFAULT_STROKE_VALUES = new Set([
   'rgb(0,0,0)',
   'rgba(0,0,0,1)',
 ]);
-const FILL_CAPABLE_GEOMETRY_TAGS = new Set(['path', 'circle', 'ellipse', 'rect', 'polygon', 'text', 'use']);
+const FILL_CAPABLE_GEOMETRY_TAGS = new Set([
+  'path',
+  'circle',
+  'ellipse',
+  'rect',
+  'polygon',
+  'text',
+  'use',
+]);
 
 interface ParseSvgMetricsOptions {
   defaultFillColor?: string;

--- a/apps/ui/src/services/__tests__/nativeRenderService.test.ts
+++ b/apps/ui/src/services/__tests__/nativeRenderService.test.ts
@@ -169,4 +169,48 @@ describe('NativeRenderService', () => {
       })
     );
   });
+
+  it('retries syntax checks in 2D mode when the 3D pass only reports a top-level mismatch', async () => {
+    invoke.mockImplementation(async (command: string) => {
+      if (command === 'render_init') return 'OpenSCAD 2026.03.16';
+      if (command === 'render_native') {
+        const renderCalls = invoke.mock.calls.filter(([name]) => name === 'render_native').length;
+        return {
+          output: [],
+          stderr:
+            renderCalls === 1 ? 'Current top level object is not a 3D object.' : 'WARNING: 2D note',
+          exit_code: 0,
+          duration_ms: 1,
+        };
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    const { NativeRenderService } = await import('../nativeRenderService');
+    const service = new NativeRenderService();
+
+    await expect(service.checkSyntax('square(10);')).resolves.toEqual({
+      diagnostics: [
+        {
+          severity: 'warning',
+          line: undefined,
+          col: undefined,
+          message: 'WARNING: 2D note',
+        },
+      ],
+    });
+
+    const nativeCalls = invoke.mock.calls.filter(([command]) => command === 'render_native');
+    expect(nativeCalls).toHaveLength(2);
+    expect(nativeCalls[0][1]).toEqual(
+      expect.objectContaining({
+        args: ['/input.scad', '-o', '/output.stl', '--backend=manifold'],
+      })
+    );
+    expect(nativeCalls[1][1]).toEqual(
+      expect.objectContaining({
+        args: ['/input.scad', '-o', '/output.svg', '--backend=manifold'],
+      })
+    );
+  });
 });

--- a/apps/ui/src/services/__tests__/renderService.test.ts
+++ b/apps/ui/src/services/__tests__/renderService.test.ts
@@ -429,6 +429,56 @@ describe('RenderService', () => {
     });
   });
 
+  it('retries syntax checks in 2D mode when the 3D pass only reports a top-level mismatch', async () => {
+    const service = new RenderService();
+    const initPromise = service.init();
+    mockWorkers[0].emitMessage({ type: 'ready' });
+    await initPromise;
+
+    const checkPromise = service.checkSyntax('square(10);');
+    const firstRequest = await waitForRenderRequestCount(1);
+
+    expect(firstRequest.request.args).toEqual([
+      '/input.scad',
+      '-o',
+      '/output.stl',
+      '--backend=manifold',
+    ]);
+
+    firstRequest.worker.emitMessage({
+      type: 'result',
+      id: firstRequest.request.id,
+      output: new Uint8Array(),
+      stderr: 'Current top level object is not a 3D object.',
+    });
+
+    const secondRequest = await waitForRenderRequestCount(2);
+    expect(secondRequest.request.args).toEqual([
+      '/input.scad',
+      '-o',
+      '/output.svg',
+      '--backend=manifold',
+    ]);
+
+    secondRequest.worker.emitMessage({
+      type: 'result',
+      id: secondRequest.request.id,
+      output: new Uint8Array(),
+      stderr: 'WARNING: 2D note',
+    });
+
+    await expect(checkPromise).resolves.toEqual({
+      diagnostics: [
+        {
+          severity: 'warning',
+          line: undefined,
+          col: undefined,
+          message: 'WARNING: 2D note',
+        },
+      ],
+    });
+  });
+
   it('rejects init when the worker reports an __init__ error', async () => {
     const service = new RenderService();
     const initPromise = service.init();

--- a/apps/ui/src/services/nativeRenderService.ts
+++ b/apps/ui/src/services/nativeRenderService.ts
@@ -16,6 +16,7 @@ import {
   type Diagnostic,
   RenderCache,
   generateRenderCacheKey,
+  hasOnlyTopLevelDimensionMismatchErrors,
   parseOpenScadStderr,
 } from './renderService';
 import { createExportValidationError } from './exportErrors';
@@ -208,22 +209,33 @@ export class NativeRenderService implements IRenderService {
   async checkSyntax(code: string, options: RenderOptions = {}): Promise<SyntaxCheckResult> {
     await this.init();
 
-    const args = ['/input.scad', '-o', '/output.stl', '--backend=manifold'];
+    const preferredView = options.view ?? '3d';
     const allFiles =
       options.libraryFiles || options.auxiliaryFiles
         ? { ...(options.libraryFiles || {}), ...(options.auxiliaryFiles || {}) }
         : undefined;
-    const result = await this.invokeRender(
-      code,
-      args,
-      allFiles,
-      options.inputPath,
-      options.workingDir,
-      options.libraryPaths
-    );
-    const diagnostics = parseOpenScadStderr(result.stderr);
 
-    return { diagnostics };
+    const runSyntaxCheck = async (view: '2d' | '3d') => {
+      const outputPath = view === '3d' ? '/output.stl' : '/output.svg';
+      const args = ['/input.scad', '-o', outputPath, '--backend=manifold'];
+      const result = await this.invokeRender(
+        code,
+        args,
+        allFiles,
+        options.inputPath,
+        options.workingDir,
+        options.libraryPaths
+      );
+      return parseOpenScadStderr(result.stderr);
+    };
+
+    const diagnostics = await runSyntaxCheck(preferredView);
+    if (!hasOnlyTopLevelDimensionMismatchErrors(diagnostics)) {
+      return { diagnostics };
+    }
+
+    const fallbackView = preferredView === '3d' ? '2d' : '3d';
+    return { diagnostics: await runSyntaxCheck(fallbackView) };
   }
 
   /**

--- a/apps/ui/src/services/renderService.ts
+++ b/apps/ui/src/services/renderService.ts
@@ -149,6 +149,24 @@ export function parseOpenScadStderr(stderr: string): Diagnostic[] {
   return diagnostics;
 }
 
+export function isTopLevelDimensionMismatchDiagnostic(message: string): boolean {
+  const normalized = message.trim().toLowerCase();
+  return (
+    normalized.includes('current top level object is not a 2d object.') ||
+    normalized.includes('current top level object is not a 3d object.') ||
+    (normalized.includes('2d') && normalized.includes('3d mode')) ||
+    (normalized.includes('3d') && normalized.includes('2d mode'))
+  );
+}
+
+export function hasOnlyTopLevelDimensionMismatchErrors(diagnostics: Diagnostic[]): boolean {
+  const errors = diagnostics.filter((diagnostic) => diagnostic.severity === 'error');
+  return (
+    errors.length > 0 &&
+    errors.every((diagnostic) => isTopLevelDimensionMismatchDiagnostic(diagnostic.message))
+  );
+}
+
 // ============================================================================
 // Cache
 // ============================================================================
@@ -447,15 +465,26 @@ export class WasmRenderService implements IRenderService {
    * Check syntax by attempting to render. Returns diagnostics only.
    */
   async checkSyntax(code: string, options: RenderOptions = {}): Promise<SyntaxCheckResult> {
-    const args = this.buildArgs('/output.stl', { backend: 'manifold' });
+    const preferredView = options.view ?? '3d';
     const allFiles =
       options.libraryFiles || options.auxiliaryFiles
         ? { ...(options.libraryFiles || {}), ...(options.auxiliaryFiles || {}) }
         : undefined;
-    const result = await this.sendRequest(code, args, allFiles, options.inputPath);
-    const diagnostics = parseOpenScadStderr(result.stderr);
 
-    return { diagnostics };
+    const runSyntaxCheck = async (view: '2d' | '3d') => {
+      const outputPath = view === '3d' ? '/output.stl' : '/output.svg';
+      const args = this.buildArgs(outputPath, { backend: 'manifold' });
+      const result = await this.sendRequest(code, args, allFiles, options.inputPath);
+      return parseOpenScadStderr(result.stderr);
+    };
+
+    const diagnostics = await runSyntaxCheck(preferredView);
+    if (!hasOnlyTopLevelDimensionMismatchErrors(diagnostics)) {
+      return { diagnostics };
+    }
+
+    const fallbackView = preferredView === '3d' ? '2d' : '3d';
+    return { diagnostics: await runSyntaxCheck(fallbackView) };
   }
 
   /**

--- a/implementation-plans/ai-2d-diagnostics-dimension-fallback.md
+++ b/implementation-plans/ai-2d-diagnostics-dimension-fallback.md
@@ -1,0 +1,26 @@
+# AI 2D Diagnostics Dimension Fallback
+
+## Goal
+
+Root-cause and fix the AI `get_diagnostics` false positive where valid 2D render targets report `Current top level object is not a 3D object.` even though the preview renders successfully as a 2D SVG.
+
+## Approach
+
+- Confirm how AI diagnostics differ from the live preview render path.
+- Add a shared render-service helper that recognizes pure 2D/3D top-level mismatch diagnostics.
+- Update both WASM and native syntax checks to retry the opposite dimension when the first pass only fails because of a view mismatch.
+- Add regression coverage for the fallback behavior and context forwarding.
+
+## Affected Areas
+
+- `apps/ui/src/services/renderService.ts`
+- `apps/ui/src/services/nativeRenderService.ts`
+- `apps/ui/src/services/__tests__/renderService.test.ts`
+- `apps/ui/src/services/__tests__/nativeRenderService.test.ts`
+
+## Checklist
+
+- [x] Inspect the AI diagnostics and preview render paths to identify the root cause.
+- [x] Implement dimension-mismatch fallback for syntax checks in the shared render services.
+- [x] Add regression tests for WASM and native syntax checks.
+- [x] Run targeted validation and update this plan with the completed steps.


### PR DESCRIPTION
# Summary

## What changed

- Made `checkSyntax()` retry the opposite render dimension when the first pass only reports the OpenSCAD top-level 2D/3D mismatch error.
- Added shared mismatch-detection helpers in the render service so both WASM and native diagnostics follow the same fallback behavior.
- Normalized desktop-native OpenSCAD 2D SVG defaults so outline-only `fill="none"` plus default black stroke output is treated as default geometry and recolored with the viewer theme fill.
- Added regression tests for both render backends covering the exact 2D false-positive seen by AI `get_diagnostics`, plus SVG normalization tests covering the desktop default outline-only export.
- Added implementation plan notes at `implementation-plans/ai-2d-diagnostics-dimension-fallback.md`.

## Why

- AI `get_diagnostics` validated models by writing to a 3D STL target unconditionally.
- Valid 2D render targets therefore emitted `Current top level object is not a 3D object.` even though the preview path already knew how to recover by rendering as 2D.
- That mismatch caused the AI to treat healthy 2D models as broken and try to convert them to 3D.
- Separately, the desktop native OpenSCAD binary emits a plain `square()` SVG as outline-only geometry with `fill="none"` and `stroke="black"`, which became nearly invisible against the dark 2D viewer background while the web renderer still showed a filled shape.

## Implementation notes

- The diagnostics fallback only triggers when every error diagnostic is a dimension-mismatch diagnostic, so real compile errors still return immediately.
- The retry stays inside the render-service layer, which fixes both web and desktop diagnostics without changing AI-tool callers.
- The SVG normalization change only treats native default outline-only output as theme-fillable geometry; explicitly styled non-default outline-only SVGs remain untouched.
- Implementation plan: `implementation-plans/ai-2d-diagnostics-dimension-fallback.md`

# Testing

## Coverage checklist

- [ ] Backend unit tests added or updated for changed Rust behavior
- [x] Client unit/component tests added or updated for changed frontend behavior
- [ ] E2E tests added or updated for net new user-facing flows
- [ ] No new tests were needed for this change

## Validation performed

- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm test:unit`
- [ ] `pnpm test:formatter:ci`
- [ ] `pnpm test:e2e:web`
- [x] `bash scripts/validate-changes.sh --dry-run ...`
- [ ] `cd apps/ui/src-tauri && cargo fmt --check`
- [ ] `cd apps/ui/src-tauri && cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cd apps/ui/src-tauri && cargo check --all-targets --all-features`

## Test details

- Added unit regressions in `renderService.test.ts` and `nativeRenderService.test.ts` that assert syntax checking falls back from 3D to 2D when the only error is the top-level dimension mismatch.
- Added SVG viewer helper regressions for desktop-native outline-only 2D SVG normalization and for preserving explicitly styled non-default outline-only SVGs.
- Ran targeted Jest coverage for `renderService.test.ts`, `nativeRenderService.test.ts`, `aiService.test.ts`, `svgViewerHelpers.test.ts`, and `SvgViewer.test.tsx`.
- Ran `bash scripts/validate-changes.sh --changed-file ...`, which completed the baseline suite (`pnpm format:check`, `pnpm lint`, `pnpm type-check`, `pnpm test:unit`) for the diagnostics fix.
- Skipped formatter-specific tests because formatter behavior did not change.
- Skipped web e2e because these fixes change diagnostics orchestration and SVG normalization, both of which are covered by deterministic unit tests.
- Skipped Rust validation because no Rust files changed.

# Performance

## Performance impact

- [x] Performance was considered for this change
- [ ] No meaningful performance impact is expected

## Justification

- 3D syntax checks for valid 3D models are unchanged.
- Valid 2D models now incur one extra fallback syntax pass during diagnostics, which is a small targeted cost that replaces a false error state.
- SVG normalization adds lightweight DOM attribute checks during 2D preview parsing and should not meaningfully affect render responsiveness.

# UI changes

## Screenshots or recordings

- N/A

# Issue link

- Closes #
