### PR TITLE
docs: refresh repo documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ Desktop-only shell services:
 
 ### API keys
 
-AI API keys are currently stored client-side in local storage state, including when the app runs inside the Tauri webview.
+AI API keys are currently stored client-side in obfuscated localStorage-backed state, including when the app runs inside the Tauri webview.
 
 - This is a convenience tradeoff for a shared web + desktop AI implementation.
 - It is not equivalent to backend-only secret storage.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ Local MCP client → Tauri MCP server (`mcp.rs`) → active workspace window bri
    - Interactive STL/3D mesh for manipulation
    - SVG for 2D designs
 
-4. **Shared Client-Side AI**: Both web and desktop use the same frontend AI stack for the in-app copilot. Requests are made directly from the React app with Vercel AI SDK's `streamText`, and API keys are currently stored in local storage state inside the browser/webview.
+4. **Shared Client-Side AI**: Both web and desktop use the same frontend AI stack for the in-app copilot. Requests are made directly from the React app with Vercel AI SDK's `streamText`, and API keys are currently stored in obfuscated localStorage-backed state inside the browser/webview.
 
 5. **Diff-based AI Editing**: AI returns exact string replacements, not full file rewrites.
 
@@ -279,7 +279,7 @@ pnpm validate:changes   # Run the shared validation helper
 ### Platform Abstraction
 
 - **PlatformBridge**: Components should use the `PlatformBridge` interface (`apps/ui/src/platform/types.ts`), never import Tauri or web APIs directly.
-- **API keys**: Stored client-side in local storage state today, including in the Tauri webview. This is a convenience tradeoff, not hardened secret isolation.
+- **API keys**: Stored client-side in obfuscated localStorage-backed state today, including in the Tauri webview. This is a convenience tradeoff, not hardened secret isolation.
 - **File I/O**: Desktop uses native file dialogs via Tauri. Web uses File System Access API with fallbacks.
 
 ### WASM Rendering (Web)
@@ -314,7 +314,7 @@ pnpm validate:changes   # Run the shared validation helper
 
 ## Current Status
 
-### Current Capabilities (v1.2.0)
+### Current Capabilities (v1.2.1)
 
 ✅ Monaco editor with OpenSCAD syntax highlighting
 ✅ Live STL/SVG preview (web: openscad-wasm, desktop: native binary)
@@ -404,5 +404,5 @@ pnpm validate:changes   # Run the shared validation helper
 
 ---
 
-**Last Updated**: 2026-04-12
-**Current Version**: v1.2.0 — Web + Desktop
+**Last Updated**: 2026-04-19
+**Current Version**: v1.2.1 — Web + Desktop

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,7 +160,7 @@ The project uses a mix of automated and manual testing. When contributing:
    - [ ] Feature works as expected
    - [ ] No console errors
    - [ ] No TypeScript errors
-   - [ ] Works on your target platform (macOS/Windows/Linux)
+   - [ ] Works on your target platform/browser (desktop currently macOS; web in the target browser)
 
 3. **Test edge cases**:
    - [ ] Empty files
@@ -198,7 +198,7 @@ When reporting bugs, please include:
 4. **Actual behavior**: What actually happened
 5. **Environment**:
    - OS: (macOS 14.0, Windows 11, Ubuntu 22.04, etc.)
-   - App surface: web app or desktop app
+   - App surface: web app or desktop app (desktop is currently macOS-focused)
    - Browser (for web) or desktop app version (from About dialog)
    - App version: (from About dialog)
 6. **Screenshots/logs**: If applicable

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -122,7 +122,7 @@ openscad-studio/
 
 ## AI Copilot Setup
 
-The AI copilot uses the [Vercel AI SDK](https://sdk.vercel.ai/) with streaming support. AI requests are made client-side in both the web app and the Tauri desktop app, and API keys are currently stored in local storage state inside the browser/webview. This is a convenience tradeoff, not backend-style secret isolation.
+The AI copilot uses the [Vercel AI SDK](https://sdk.vercel.ai/) with streaming support. AI requests are made client-side in both the web app and the Tauri desktop app, and API keys are currently stored in obfuscated localStorage-backed state inside the browser/webview. This is a convenience tradeoff, not backend-style secret isolation.
 
 1. Open Settings (⌘,)
 2. Navigate to "AI" tab

--- a/PRODUCT_ROADMAP.md
+++ b/PRODUCT_ROADMAP.md
@@ -4,7 +4,7 @@
 >
 > OpenSCAD is the engine, not the product. The product is: you describe what you want, it makes it, you print it.
 
-**Current version**: v1.2.0 | **Last updated**: 2026-04-12
+**Current version**: v1.2.1 | **Last updated**: 2026-04-19
 
 This roadmap mixes shipped milestones with future planning. Older sections may describe the implementation assumptions that existed when they were written rather than the current client-side `openscad-wasm` architecture.
 
@@ -20,14 +20,14 @@ This roadmap mixes shipped milestones with future planning. Older sections may d
 
 ---
 
-## What We Have (v1.2.0)
+## What We Have (v1.2.1)
 
 | Area                                                                                  | Status |
 | ------------------------------------------------------------------------------------- | ------ |
 | Monaco editor with OpenSCAD syntax, 27 themes, vim mode, tree-sitter formatting       | ✅     |
 | Live 3D preview (Three.js mesh viewer, orbit controls, wireframe/solid/section tools) | ✅     |
 | 2D SVG mode for laser cutting / engraving                                             | ✅     |
-| AI copilot (Claude + GPT, streaming, tool-calling, diff-based editing, auto-rollback) | ✅     |
+| AI copilot (Claude + GPT, streaming, tool-calling, diff-based editing, image attachments, auto-rollback) | ✅     |
 | AI can see the 3D preview (screenshot tool returns base64 PNG to vision models)       | ✅     |
 | Customizer panel (tree-sitter parsed parameters → sliders, dropdowns, vectors)        | ✅     |
 | Share links with remixable web entry and thumbnail support                            | ✅     |

--- a/docs/index.html
+++ b/docs/index.html
@@ -177,7 +177,7 @@
                     </a>
                 </div>
                 <p class="text-xs text-gray-500">
-                    Web version works in Chrome &amp; Edge. Desktop requires macOS 10.15+
+                    Web version works in recent Chrome, Edge, and Firefox builds. Desktop requires macOS 10.15+
                 </p>
             </div>
         </div>

--- a/engineering-roadmap.md
+++ b/engineering-roadmap.md
@@ -1,6 +1,6 @@
 # OpenSCAD Studio — Engineering Roadmap
 
-> Current app version: **v1.2.0**. This roadmap mixes historical milestone notes with future planning, so older phase sections may reference the version they originally shipped in rather than the current release.
+> Current app version: **v1.2.1**. This roadmap mixes historical milestone notes with future planning, so older phase sections may reference the version they originally shipped in rather than the current release.
 >
 > A modern OpenSCAD editor with live preview and AI copilot capabilities, available as both a web app and a macOS desktop app. The application uses openscad-wasm for rendering and provides a superior editing experience with real-time feedback and AI-assisted code generation.
 
@@ -582,6 +582,6 @@ Decisions made during roadmap planning that affect ordering:
 
 ---
 
-**Last Updated:** 2026-04-12
-**Current Phase:** v1.2.0 — web + desktop app shipping with sharing, analytics/privacy controls, formatter coverage, advanced viewer tooling, and desktop MCP support for external agents
+**Last Updated:** 2026-04-19
+**Current Phase:** v1.2.1 — web + desktop app shipping with sharing, analytics/privacy controls, formatter coverage, advanced viewer tooling, and desktop MCP support for external agents
 **Next Milestone:** Phase 4B.1/4B.3 (App.tsx decomposition, centralized state) or Phase 5 (AI experience) based on user feedback


### PR DESCRIPTION
# Summary

## What changed

- Refreshed maintainer and roadmap docs to match the current `v1.2.1` release and the April 19, 2026 documentation audit.
- Clarified that AI API keys are stored in obfuscated localStorage-backed state rather than the older plain local storage wording.
- Updated contributor guidance and docs-site browser support copy to reflect the current desktop/browser support surface.

## Why

- Several docs had drifted from the current repo state, especially version/date metadata and a few support/storage details.
- This keeps user-facing and maintainer-facing documentation aligned without adding implementation detail to `README.md`.

## Implementation notes

- Docs only; no code or behavior changes.
- Kept `README.md` focused on product-facing information.

# Testing

## Coverage checklist

- [ ] Backend unit tests added or updated for changed Rust behavior
- [ ] Client unit/component tests added or updated for changed frontend behavior
- [ ] E2E tests added or updated for net new user-facing flows
- [x] No new tests were needed for this change

## Validation performed

- [ ] `pnpm format:check`
- [ ] `pnpm lint`
- [ ] `pnpm type-check`
- [ ] `pnpm test:unit`
- [ ] `pnpm test:formatter:ci`
- [ ] `pnpm test:e2e:web`
- [x] `bash scripts/validate-changes.sh --dry-run ...`
- [ ] `cd apps/ui/src-tauri && cargo fmt --check`
- [ ] `cd apps/ui/src-tauri && cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cd apps/ui/src-tauri && cargo check --all-targets --all-features`

## Test details

- Ran `bash scripts/validate-changes.sh --dry-run --scope baseline` to confirm the default validation set for baseline changes.
- Skipped code-focused checks because this PR only updates documentation and static docs-site copy.

# Performance

## Performance impact

- [x] Performance was considered for this change
- [x] No meaningful performance impact is expected

## Justification

- Documentation-only edits do not affect runtime behavior or build output used by the app.

# UI changes

## Screenshots or recordings

- N/A

# Issue link

- Closes #