### PR TITLE
Fix AI transcript auto-scroll behavior

### DIFF
--- a/apps/ui/src/components/AiPromptPanel.tsx
+++ b/apps/ui/src/components/AiPromptPanel.tsx
@@ -21,6 +21,8 @@ import type {
 } from '../types/aiChat';
 import { getUserMessageText } from '../types/aiChat';
 
+const AUTO_SCROLL_BOTTOM_THRESHOLD_PX = 48;
+
 function getImageDataUrlFromResult(result: unknown): string | null {
   if (!result) return null;
 
@@ -187,6 +189,10 @@ function getMissingToolResultLabel(state: ToolCallState): string {
   if (state === 'error') return 'No result returned before the tool failed.';
   if (state === 'denied') return 'No result returned because the tool output was denied.';
   return 'No result returned.';
+}
+
+function isTranscriptNearBottom(node: HTMLDivElement): boolean {
+  return node.scrollHeight - node.scrollTop - node.clientHeight <= AUTO_SCROLL_BOTTOM_THRESHOLD_PX;
 }
 
 interface ToolCallDetailSectionProps {
@@ -386,9 +392,11 @@ export const AiPromptPanel = forwardRef<AiPromptPanelRef, AiPromptPanelProps>(
     const responseRef = useRef<HTMLDivElement>(null);
     const composerRef = useRef<AiComposerRef>(null);
     const emptyStateHostRef = useRef<HTMLDivElement>(null);
+    const autoScrollPinnedRef = useRef(true);
     const [emptyStatePanelLayout, setEmptyStatePanelLayout] = useState<'stacked' | 'split'>(
       'stacked'
     );
+    const [showJumpToLatest, setShowJumpToLatest] = useState(false);
     const { restoreToCheckpoint } = useHistory();
 
     useImperativeHandle(ref, () => ({
@@ -397,11 +405,44 @@ export const AiPromptPanel = forwardRef<AiPromptPanelRef, AiPromptPanelProps>(
       },
     }));
 
+    const scrollTranscriptToBottom = () => {
+      if (!responseRef.current) return;
+
+      responseRef.current.scrollTop = responseRef.current.scrollHeight;
+      autoScrollPinnedRef.current = true;
+      setShowJumpToLatest(false);
+    };
+
+    const handleTranscriptScroll = () => {
+      if (!responseRef.current) return;
+
+      const isPinned = isTranscriptNearBottom(responseRef.current);
+      autoScrollPinnedRef.current = isPinned;
+      setShowJumpToLatest(!isPinned);
+    };
+
     useEffect(() => {
-      if (responseRef.current) {
-        responseRef.current.scrollTop = responseRef.current.scrollHeight;
+      const node = responseRef.current;
+      if (!node) return;
+
+      if (autoScrollPinnedRef.current) {
+        node.scrollTop = node.scrollHeight;
+        autoScrollPinnedRef.current = true;
+        setShowJumpToLatest(false);
+        return;
       }
+
+      setShowJumpToLatest(true);
     }, [messages, streamingResponse, currentToolCalls]);
+
+    useEffect(() => {
+      if (messages.length > 0 || streamingResponse || currentToolCalls.length > 0) {
+        return;
+      }
+
+      autoScrollPinnedRef.current = true;
+      setShowJumpToLatest(false);
+    }, [messages.length, streamingResponse, currentToolCalls.length]);
 
     useEffect(() => {
       if (import.meta.env?.DEV) {
@@ -563,6 +604,7 @@ export const AiPromptPanel = forwardRef<AiPromptPanelRef, AiPromptPanelProps>(
             ref={responseRef}
             data-testid="ai-transcript"
             className="flex-1 overflow-y-auto px-4 py-3 space-y-3 ph-no-capture"
+            onScroll={handleTranscriptScroll}
             style={{
               backgroundColor: 'var(--bg-secondary)',
               borderBottom: '1px solid var(--border-primary)',
@@ -745,6 +787,22 @@ export const AiPromptPanel = forwardRef<AiPromptPanelRef, AiPromptPanelProps>(
                   </div>
                 </div>
               )}
+
+            {showJumpToLatest && (
+              <div className="sticky bottom-2 z-10 flex justify-end pr-1 pointer-events-none">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="secondary"
+                  className="pointer-events-auto shadow-sm"
+                  onClick={scrollTranscriptToBottom}
+                  title="Jump to the latest response"
+                  data-testid="ai-scroll-to-latest"
+                >
+                  Jump to latest
+                </Button>
+              </div>
+            )}
           </div>
         )}
 

--- a/apps/ui/src/components/__tests__/AiPromptPanel.test.tsx
+++ b/apps/ui/src/components/__tests__/AiPromptPanel.test.tsx
@@ -117,6 +117,50 @@ function createUserMessage(): Message {
   };
 }
 
+function installScrollMetrics(
+  element: HTMLElement,
+  {
+    scrollTop = 0,
+    clientHeight = 240,
+    scrollHeight = 1000,
+  }: { scrollTop?: number; clientHeight?: number; scrollHeight?: number } = {}
+) {
+  let currentScrollTop = scrollTop;
+  let currentScrollHeight = scrollHeight;
+  let currentClientHeight = clientHeight;
+
+  Object.defineProperty(element, 'scrollTop', {
+    configurable: true,
+    get: () => currentScrollTop,
+    set: (value: number) => {
+      currentScrollTop = value;
+    },
+  });
+
+  Object.defineProperty(element, 'scrollHeight', {
+    configurable: true,
+    get: () => currentScrollHeight,
+  });
+
+  Object.defineProperty(element, 'clientHeight', {
+    configurable: true,
+    get: () => currentClientHeight,
+  });
+
+  return {
+    getScrollTop: () => currentScrollTop,
+    setScrollTop: (value: number) => {
+      currentScrollTop = value;
+    },
+    setScrollHeight: (value: number) => {
+      currentScrollHeight = value;
+    },
+    setClientHeight: (value: number) => {
+      currentClientHeight = value;
+    },
+  };
+}
+
 describe('AiPromptPanel', () => {
   beforeAll(async () => {
     ({ AiPromptPanel } = await import('@/components/AiPromptPanel'));
@@ -171,5 +215,60 @@ describe('AiPromptPanel', () => {
 
     expect(screen.getByText(/"view": "front"/)).toBeTruthy();
     expect(screen.getByText(/image_data_url/i)).toBeTruthy();
+  });
+
+  it('keeps auto-scrolling while the transcript is pinned to the bottom', () => {
+    const props = createBaseProps({
+      messages: [createUserMessage()],
+      streamingResponse: 'Working',
+      isStreaming: true,
+    });
+
+    const { rerender } = renderWithProviders(<AiPromptPanel {...props} />);
+    const transcript = screen.getByTestId('ai-transcript');
+    const scrollMetrics = installScrollMetrics(transcript, {
+      scrollTop: 760,
+      clientHeight: 240,
+      scrollHeight: 1000,
+    });
+
+    fireEvent.scroll(transcript);
+
+    scrollMetrics.setScrollHeight(1240);
+    rerender(<AiPromptPanel {...props} streamingResponse="Working a bit more" />);
+
+    expect(scrollMetrics.getScrollTop()).toBe(1240);
+    expect(screen.queryByTestId('ai-scroll-to-latest')).toBeNull();
+  });
+
+  it('lets the user pause auto-scroll while streaming and jump back to the latest response', () => {
+    const props = createBaseProps({
+      messages: [createUserMessage()],
+      streamingResponse: 'Working',
+      isStreaming: true,
+    });
+
+    const { rerender } = renderWithProviders(<AiPromptPanel {...props} />);
+    const transcript = screen.getByTestId('ai-transcript');
+    const scrollMetrics = installScrollMetrics(transcript, {
+      scrollTop: 760,
+      clientHeight: 240,
+      scrollHeight: 1000,
+    });
+
+    fireEvent.scroll(transcript);
+
+    scrollMetrics.setScrollTop(320);
+    fireEvent.scroll(transcript);
+
+    scrollMetrics.setScrollHeight(1320);
+    rerender(<AiPromptPanel {...props} streamingResponse="Working a bit more" />);
+
+    expect(scrollMetrics.getScrollTop()).toBe(320);
+
+    fireEvent.click(screen.getByTestId('ai-scroll-to-latest'));
+
+    expect(scrollMetrics.getScrollTop()).toBe(1320);
+    expect(screen.queryByTestId('ai-scroll-to-latest')).toBeNull();
   });
 });

--- a/implementation-plans/ai-transcript-auto-scroll.md
+++ b/implementation-plans/ai-transcript-auto-scroll.md
@@ -1,0 +1,26 @@
+# AI Transcript Auto-Scroll
+
+## Goal
+
+Make the AI transcript behave like a professional chat app while responses stream: keep following the latest output when the user is already at the bottom, but stop forcing the panel downward when they intentionally scroll up to read earlier text.
+
+## Approach
+
+- Replace the unconditional "always jump to the bottom" effect in `AiPromptPanel.tsx` with scroll-aware follow behavior.
+- Track whether the transcript is currently pinned near the bottom so new streaming content only auto-scrolls when the user has not opted out by scrolling upward.
+- Add a visible "Jump to latest" affordance so users can quickly resume following the live response after pausing the transcript.
+- Add component coverage for both the pinned and paused states.
+
+## Affected Areas
+
+- `apps/ui/src/components/AiPromptPanel.tsx`
+- `apps/ui/src/components/__tests__/AiPromptPanel.test.tsx`
+- `implementation-plans/ai-transcript-auto-scroll.md`
+
+## Checklist
+
+- [x] Capture the implementation plan before editing the transcript behavior.
+- [x] Update the AI transcript to pause auto-scroll when the user scrolls away from the bottom.
+- [x] Add or update component tests for the new transcript scroll behavior.
+- [x] Run relevant validation for the frontend-only changes.
+- [ ] Prepare the branch and draft PR handoff.

--- a/implementation-plans/ai-transcript-auto-scroll.md
+++ b/implementation-plans/ai-transcript-auto-scroll.md
@@ -23,4 +23,4 @@ Make the AI transcript behave like a professional chat app while responses strea
 - [x] Update the AI transcript to pause auto-scroll when the user scrolls away from the bottom.
 - [x] Add or update component tests for the new transcript scroll behavior.
 - [x] Run relevant validation for the frontend-only changes.
-- [ ] Prepare the branch and draft PR handoff.
+- [x] Prepare the branch and draft PR handoff.


### PR DESCRIPTION
# Summary

## What changed

- Pause AI transcript auto-scroll when the user scrolls away from the bottom during streaming.
- Add a `Jump to latest` control so the user can resume following the live response on demand.
- Add component coverage for pinned-bottom and paused-scroll transcript behavior.
- Record the delivery plan in `implementation-plans/ai-transcript-auto-scroll.md`.

## Why

- The transcript kept forcing the view back to the bottom on every streamed update, which made it hard to read earlier text while a response was still arriving.

## Implementation notes

- The transcript now tracks whether the scroll position is still near the bottom before deciding to auto-follow new content.
- Returning to the bottom or clicking `Jump to latest` re-enables follow mode.
- This change is frontend-only and does not alter provider, tool, or persistence behavior.

# Testing

## Coverage checklist

- [ ] Backend unit tests added or updated for changed Rust behavior
- [x] Client unit/component tests added or updated for changed frontend behavior
- [ ] E2E tests added or updated for net new user-facing flows
- [ ] No new tests were needed for this change

## Validation performed

- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm test:unit`
- [ ] `pnpm test:formatter:ci`
- [ ] `pnpm test:e2e:web`
- [x] `bash scripts/validate-changes.sh --dry-run ...`
- [ ] `cd apps/ui/src-tauri && cargo fmt --check`
- [ ] `cd apps/ui/src-tauri && cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cd apps/ui/src-tauri && cargo check --all-targets --all-features`

## Test details

- Ran `pnpm test -- --runInBand src/components/__tests__/AiPromptPanel.test.tsx` in `apps/ui` while developing the fix.
- Ran `bash scripts/validate-changes.sh --dry-run --changed-file apps/ui/src/components/AiPromptPanel.tsx --changed-file apps/ui/src/components/__tests__/AiPromptPanel.test.tsx`.
- Ran `bash scripts/validate-changes.sh --scope baseline`.
- Skipped formatter regression coverage because formatter behavior was unchanged.
- Skipped web E2E because this is a contained transcript interaction update with focused component coverage and full frontend unit coverage already in place.
- Skipped Rust validation because no files under `apps/ui/src-tauri` changed.

# Performance

## Performance impact

- [x] Performance was considered for this change
- [x] No meaningful performance impact is expected

## Justification

- The change adds a small near-bottom check on transcript scroll and a conditional button render. It does not change model transport, rendering, or any heavy client-side loop.

# UI changes

## Screenshots or recordings

- N/A

# Issue link

- Closes #
