### PR TITLE
Add textarea support for large customizer text

### DIFF
--- a/apps/ui/src/components/CustomizerPanel.tsx
+++ b/apps/ui/src/components/CustomizerPanel.tsx
@@ -316,7 +316,7 @@ export function CustomizerPanel({
         formattedValue = `[${newValue.join(', ')}]`;
       } else if (typeof newValue === 'string') {
         if (param.rawValue.startsWith('"') || param.rawValue.startsWith("'")) {
-          formattedValue = `"${newValue}"`;
+          formattedValue = JSON.stringify(newValue);
         } else {
           formattedValue = newValue;
         }

--- a/apps/ui/src/components/__tests__/CustomizerPanel.test.tsx
+++ b/apps/ui/src/components/__tests__/CustomizerPanel.test.tsx
@@ -388,6 +388,77 @@ describe('CustomizerPanel', () => {
     });
   });
 
+  it('renders textarea-backed string params for large text fields', () => {
+    mockParseCustomizerParams.mockReturnValue([
+      {
+        name: 'Parameters',
+        params: [
+          {
+            name: 'engraving',
+            type: 'string',
+            value: 'Line 1\nLine 2',
+            rawValue: '"Line 1\\nLine 2"',
+            line: 1,
+            tab: 'Parameters',
+            label: 'Engraving',
+            input: 'textarea',
+            rows: 5,
+            source: 'hybrid',
+          },
+        ],
+      },
+    ]);
+
+    renderWithProviders(
+      <CustomizerPanel
+        code='engraving = "Line 1\\nLine 2";'
+        baselineCode='engraving = "Line 1\\nLine 2";'
+      />
+    );
+
+    const textarea = screen.getByLabelText('Engraving') as HTMLTextAreaElement;
+    expect(textarea.tagName).toBe('TEXTAREA');
+    expect(textarea.rows).toBe(5);
+    expect(textarea.value).toBe('Line 1\nLine 2');
+  });
+
+  it('escapes textarea edits before writing them back to code', () => {
+    mockParseCustomizerParams.mockReturnValue([
+      {
+        name: 'Parameters',
+        params: [
+          {
+            name: 'engraving',
+            type: 'string',
+            value: 'Line 1\nLine 2',
+            rawValue: '"Line 1\\nLine 2"',
+            line: 1,
+            tab: 'Parameters',
+            label: 'Engraving',
+            input: 'textarea',
+            rows: 5,
+          },
+        ],
+      },
+    ]);
+
+    renderWithProviders(
+      <CustomizerPanel
+        code='engraving = "Line 1\\nLine 2";'
+        baselineCode='engraving = "Line 1\\nLine 2";'
+      />
+    );
+
+    const textarea = screen.getByLabelText('Engraving');
+    fireEvent.change(textarea, { target: { value: 'Line 1\n"Quoted"' } });
+    fireEvent.blur(textarea);
+
+    expect(mockEmit).toHaveBeenCalledWith('code-updated', {
+      code: 'engraving = "Line 1\\n\\"Quoted\\"";',
+      source: 'customizer',
+    });
+  });
+
   it('treats slider changes as resettable against the opened-file baseline', () => {
     jest.useFakeTimers();
 

--- a/apps/ui/src/components/customizer/ParameterControl.tsx
+++ b/apps/ui/src/components/customizer/ParameterControl.tsx
@@ -43,6 +43,10 @@ function getDisplayLabel(param: CustomizerParam): string {
 }
 
 function getControlLayout(param: CustomizerParam): ControlLayout {
+  if (param.type === 'string' && param.input === 'textarea') {
+    return 'stacked';
+  }
+
   if (param.source === 'hybrid' || param.description) {
     return 'stacked';
   }
@@ -572,6 +576,8 @@ function NumberControl({
 function StringControl({ param, onChange, isDirty, onReset }: ParameterControlProps) {
   const [localValue, setLocalValue] = useState(String(param.value));
   const layout = getControlLayout(param);
+  const textareaRows =
+    param.input === 'textarea' ? Math.min(Math.max(param.rows ?? 4, 3), 12) : undefined;
 
   useEffect(() => {
     setLocalValue(String(param.value));
@@ -583,29 +589,48 @@ function StringControl({ param, onChange, isDirty, onReset }: ParameterControlPr
     }
   };
 
-  const control = (
-    <ValueWithUnit
-      unit={param.unit}
-      className={layout === 'inline' ? 'w-40 shrink-0' : undefined}
-      value={
-        <input
-          type="text"
+  const control =
+    param.input === 'textarea' ? (
+      <div
+        className="overflow-hidden rounded-lg border"
+        style={{
+          backgroundColor: 'var(--bg-elevated)',
+          borderColor: 'var(--border-primary)',
+        }}
+      >
+        <textarea
           id={`param-${param.name}`}
           value={localValue}
+          rows={textareaRows}
           onChange={(event) => setLocalValue(event.target.value)}
           onBlur={handleCommit}
-          onKeyDown={(event) => {
-            if (event.key === 'Enter') {
-              handleCommit();
-              event.currentTarget.blur();
-            }
-          }}
-          className="w-full bg-transparent px-3 py-2 text-sm outline-none"
+          className="block min-h-[5.5rem] w-full resize-y bg-transparent px-3 py-2 text-sm leading-relaxed outline-none"
           style={{ color: 'var(--text-primary)' }}
         />
-      }
-    />
-  );
+      </div>
+    ) : (
+      <ValueWithUnit
+        unit={param.unit}
+        className={layout === 'inline' ? 'w-40 shrink-0' : undefined}
+        value={
+          <input
+            type="text"
+            id={`param-${param.name}`}
+            value={localValue}
+            onChange={(event) => setLocalValue(event.target.value)}
+            onBlur={handleCommit}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') {
+                handleCommit();
+                event.currentTarget.blur();
+              }
+            }}
+            className="w-full bg-transparent px-3 py-2 text-sm outline-none"
+            style={{ color: 'var(--text-primary)' }}
+          />
+        }
+      />
+    );
 
   return (
     <ControlShell

--- a/apps/ui/src/services/aiService.ts
+++ b/apps/ui/src/services/aiService.ts
@@ -134,6 +134,8 @@ You are an expert OpenSCAD assistant helping users design and modify 3D models. 
   - \`/* [Options] */\`
 - Add optional OpenSCAD Studio presentation metadata immediately above important user-facing parameters:
   - \`// @studio {"label":"Width","description":"Overall outer width","unit":"mm","group":"Body","prominence":"primary"}\`
+- For longer user-editable text fields, prefer textarea metadata on string params:
+  - \`// @studio {"label":"Engraving","input":"textarea","rows":5}\`
 - Use \`@studio\` metadata only for user-facing controls, not derived/internal variables.
 - Prefer realistic 3D-printing-safe defaults, ranges, and steps.
 `;

--- a/apps/ui/src/utils/__tests__/customizerParser.test.ts
+++ b/apps/ui/src/utils/__tests__/customizerParser.test.ts
@@ -132,4 +132,24 @@ ring_enabled = true; // [true, false]
       source: 'hybrid',
     });
   });
+
+  it('supports textarea metadata and decodes escaped string content', () => {
+    const code = `
+// @studio {"label":"Engraving","input":"textarea","rows":5}
+engraving = "Line 1\\nLine 2 \\"quoted\\"";
+`;
+
+    const tabs = parseCustomizerParams(code);
+    const engraving = tabs[0]?.params[0];
+
+    expect(engraving).toMatchObject({
+      name: 'engraving',
+      type: 'string',
+      label: 'Engraving',
+      input: 'textarea',
+      rows: 5,
+      value: 'Line 1\nLine 2 "quoted"',
+      source: 'hybrid',
+    });
+  });
 });

--- a/apps/ui/src/utils/customizer/parser.ts
+++ b/apps/ui/src/utils/customizer/parser.ts
@@ -13,6 +13,7 @@ import type {
   DropdownOption,
   ParameterProminence,
   CustomizerParamSource,
+  CustomizerStringInput,
 } from './types';
 import type * as TreeSitter from 'web-tree-sitter';
 
@@ -22,6 +23,8 @@ interface StudioMetadata {
   unit?: string;
   group?: string;
   prominence?: ParameterProminence;
+  input?: CustomizerStringInput;
+  rows?: number;
 }
 
 const isDev =
@@ -147,6 +150,17 @@ function parseStudioMetadata(commentText: string): StudioMetadata | null {
     ) {
       metadata.prominence = parsed.prominence;
     }
+    if (parsed.input === 'text' || parsed.input === 'textarea') {
+      metadata.input = parsed.input;
+    }
+    if (
+      typeof parsed.rows === 'number' &&
+      Number.isFinite(parsed.rows) &&
+      Number.isInteger(parsed.rows) &&
+      parsed.rows > 0
+    ) {
+      metadata.rows = parsed.rows;
+    }
 
     return Object.keys(metadata).length > 0 ? metadata : null;
   } catch (error) {
@@ -155,6 +169,97 @@ function parseStudioMetadata(commentText: string): StudioMetadata | null {
     }
     return null;
   }
+}
+
+function decodeStringLiteral(text: string): string {
+  if (text.length < 2) {
+    return text;
+  }
+
+  const quote = text[0];
+  if ((quote !== '"' && quote !== "'") || text[text.length - 1] !== quote) {
+    return text;
+  }
+
+  const inner = text.slice(1, -1);
+  let decoded = '';
+
+  for (let index = 0; index < inner.length; index += 1) {
+    const char = inner[index];
+    if (char !== '\\') {
+      decoded += char;
+      continue;
+    }
+
+    const nextChar = inner[index + 1];
+    if (!nextChar) {
+      decoded += '\\';
+      break;
+    }
+
+    switch (nextChar) {
+      case 'b':
+        decoded += '\b';
+        index += 1;
+        break;
+      case 't':
+        decoded += '\t';
+        index += 1;
+        break;
+      case 'n':
+        decoded += '\n';
+        index += 1;
+        break;
+      case 'r':
+        decoded += '\r';
+        index += 1;
+        break;
+      case 'f':
+        decoded += '\f';
+        index += 1;
+        break;
+      case '\\':
+        decoded += '\\';
+        index += 1;
+        break;
+      case '"':
+        decoded += '"';
+        index += 1;
+        break;
+      case "'":
+        decoded += "'";
+        index += 1;
+        break;
+      case 'x': {
+        const hexMatch = inner.slice(index + 2).match(/^[0-9A-Fa-f]{1,2}/);
+        if (!hexMatch) {
+          decoded += 'x';
+          index += 1;
+          break;
+        }
+        decoded += String.fromCharCode(Number.parseInt(hexMatch[0], 16));
+        index += 1 + hexMatch[0].length;
+        break;
+      }
+      case 'u': {
+        const hex = inner.slice(index + 2, index + 6);
+        if (!/^[0-9A-Fa-f]{4}$/.test(hex)) {
+          decoded += 'u';
+          index += 1;
+          break;
+        }
+        decoded += String.fromCharCode(Number.parseInt(hex, 16));
+        index += 5;
+        break;
+      }
+      default:
+        decoded += nextChar;
+        index += 1;
+        break;
+    }
+  }
+
+  return decoded;
 }
 
 function isValidSliderConfig(
@@ -252,7 +357,7 @@ function extractValue(
   // String
   if (valueNode.type === 'string' || text.startsWith('"') || text.startsWith("'")) {
     return {
-      value: text.replace(/^["']|["']$/g, ''),
+      value: decodeStringLiteral(text),
       rawValue,
       inferredType: 'string',
     };
@@ -420,6 +525,12 @@ export function parseCustomizerParams(sourceCode: string): CustomizerTab[] {
           if (pendingStudioMetadata.group) param.group = pendingStudioMetadata.group;
           if (pendingStudioMetadata.prominence) {
             param.prominence = pendingStudioMetadata.prominence;
+          }
+          if (param.type === 'string' && pendingStudioMetadata.input) {
+            param.input = pendingStudioMetadata.input;
+          }
+          if (param.type === 'string' && pendingStudioMetadata.rows !== undefined) {
+            param.rows = pendingStudioMetadata.rows;
           }
         }
 

--- a/apps/ui/src/utils/customizer/types.ts
+++ b/apps/ui/src/utils/customizer/types.ts
@@ -12,6 +12,7 @@ export type ParameterType =
 
 export type ParameterProminence = 'primary' | 'secondary' | 'advanced';
 export type CustomizerParamSource = 'standard' | 'hybrid';
+export type CustomizerStringInput = 'text' | 'textarea';
 
 export interface DropdownOption {
   value: string | number;
@@ -40,6 +41,8 @@ export interface CustomizerParam {
   unit?: string; // Optional display unit
   prominence?: ParameterProminence; // Primary/secondary/advanced emphasis
   source?: CustomizerParamSource; // Metadata source used for this parameter
+  input?: CustomizerStringInput; // Preferred string control presentation
+  rows?: number; // Preferred textarea row count for large text inputs
 
   // Raw text for replacement
   rawValue: string; // Original value as string (e.g., "10", "true", "[1,2,3]")

--- a/implementation-plans/customizer-textarea-support.md
+++ b/implementation-plans/customizer-textarea-support.md
@@ -1,0 +1,30 @@
+# Customizer Textarea Support
+
+## Goal
+
+Add support for rendering large customizer text parameters as a textarea so makers can comfortably edit longer text content without leaving the customizer.
+
+## Approach
+
+- Extend customizer metadata parsing with an explicit textarea presentation mode for string parameters.
+- Update string parsing and serialization so escaped newlines and quotes round-trip safely through the customizer.
+- Render textarea-backed string controls with sensible sizing while preserving existing single-line string behavior.
+- Add focused parser, replacement, and component tests for the new metadata and string round-tripping behavior.
+
+## Affected Areas
+
+- `apps/ui/src/utils/customizer/types.ts`
+- `apps/ui/src/utils/customizer/parser.ts`
+- `apps/ui/src/utils/customizer/replaceParamValue.ts`
+- `apps/ui/src/components/customizer/ParameterControl.tsx`
+- `apps/ui/src/components/CustomizerPanel.tsx`
+- `apps/ui/src/services/aiService.ts`
+- related unit/component tests
+
+## Checklist
+
+- [x] Add textarea-oriented metadata support to customizer types and parser
+- [x] Update customizer string formatting to safely encode large text content
+- [x] Render textarea controls for flagged string parameters in the customizer UI
+- [x] Add or update parser, replacement, and component tests
+- [x] Run targeted validation and record any intentionally skipped checks


### PR DESCRIPTION
# Summary

## What changed

- Added `@studio` textarea metadata support for customizer string params, including optional `rows` sizing.
- Rendered large-text customizer strings with a textarea control while keeping existing single-line string inputs intact.
- Decoded escaped string content in the parser and now re-encode textarea edits safely when writing OpenSCAD back to source.

## Why

- Large text fields like engravings or generated copy were cramped in the single-line customizer input and could not safely round-trip embedded newlines or quotes.

## Implementation notes

- Added `implementation-plans/customizer-textarea-support.md` and kept its checklist current through validation.
- Updated AI customizer guidance so generated `@studio` metadata can request textarea presentation for long text parameters.

# Testing

## Coverage checklist

- [ ] Backend unit tests added or updated for changed Rust behavior
- [x] Client unit/component tests added or updated for changed frontend behavior
- [ ] E2E tests added or updated for net new user-facing flows
- [ ] No new tests were needed for this change

## Validation performed

- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm test:unit`
- [ ] `pnpm test:formatter:ci`
- [ ] `pnpm test:e2e:web`
- [x] `bash scripts/validate-changes.sh --dry-run ...`
- [ ] `cd apps/ui/src-tauri && cargo fmt --check`
- [ ] `cd apps/ui/src-tauri && cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cd apps/ui/src-tauri && cargo check --all-targets --all-features`

## Test details

- Validated locally with `bash scripts/validate-changes.sh --scope baseline` after installing workspace dependencies via `pnpm install --frozen-lockfile`.
- Skipped formatter-specific CI because no formatter logic changed.
- Skipped Playwright E2E because the behavior is covered by parser and component/unit tests and does not introduce a new multi-step workflow.
- Skipped Rust checks because the change is isolated to shared frontend customizer code.

# Performance

## Performance impact

- [x] Performance was considered for this change
- [x] No meaningful performance impact is expected

## Justification

- The feature only changes string parsing metadata and swaps a single control variant in the customizer UI, so no meaningful render or runtime cost is expected.

# UI changes

## Screenshots or recordings

- N/A

# Issue link

- Closes #
