### PR TITLE
Use browser downloads for web exports

### DIFF
--- a/apps/ui/src/platform/__tests__/webBridge.test.ts
+++ b/apps/ui/src/platform/__tests__/webBridge.test.ts
@@ -1,9 +1,6 @@
 import { jest } from '@jest/globals';
 
 const mockShowSaveFilePicker = jest.fn();
-const mockCreateWritable = jest.fn();
-const mockWrite = jest.fn();
-const mockClose = jest.fn();
 const mockAnchorClick = jest.fn();
 const mockAppendChild = jest.fn();
 const mockRemoveChild = jest.fn();
@@ -45,46 +42,20 @@ describe('WebBridge.fileExport', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockCreateWritable.mockResolvedValue({ write: mockWrite, close: mockClose });
-    mockWrite.mockResolvedValue(undefined);
-    mockClose.mockResolvedValue(undefined);
     mockCreateObjectURL.mockReturnValue('blob:mock-url');
   });
 
-  it('shows the save picker and writes the file on success', async () => {
-    mockShowSaveFilePicker.mockResolvedValue({ createWritable: mockCreateWritable });
-
+  it('uses the browser download flow even when File System Access API is available', async () => {
     await new WebBridge().fileExport(data, filename, filters);
 
-    expect(mockShowSaveFilePicker).toHaveBeenCalledTimes(1);
-    expect(mockWrite).toHaveBeenCalledWith(data);
-    expect(mockClose).toHaveBeenCalledTimes(1);
-    expect(mockAnchorClick).not.toHaveBeenCalled();
+    expect(mockShowSaveFilePicker).not.toHaveBeenCalled();
+    expect(mockAnchorClick).toHaveBeenCalledTimes(1);
+    expect(mockAppendChild).toHaveBeenCalledTimes(1);
+    expect(mockRemoveChild).toHaveBeenCalledTimes(1);
+    expect(mockRevokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
   });
 
-  it('does not trigger a fallback download when the user cancels (AbortError)', async () => {
-    const abortError = Object.assign(new Error('The user aborted a request.'), {
-      name: 'AbortError',
-    });
-    mockShowSaveFilePicker.mockRejectedValue(abortError);
-
-    await expect(new WebBridge().fileExport(data, filename, filters)).resolves.toBeUndefined();
-
-    expect(mockShowSaveFilePicker).toHaveBeenCalledTimes(1);
-    // Regression guard: cancelling the picker must NOT silently trigger a second download
-    expect(mockAnchorClick).not.toHaveBeenCalled();
-  });
-
-  it('propagates non-abort errors without triggering a fallback download', async () => {
-    mockShowSaveFilePicker.mockResolvedValue({ createWritable: mockCreateWritable });
-    mockWrite.mockRejectedValue(new Error('Disk full'));
-
-    await expect(new WebBridge().fileExport(data, filename, filters)).rejects.toThrow('Disk full');
-
-    expect(mockAnchorClick).not.toHaveBeenCalled();
-  });
-
-  it('uses the anchor fallback when File System Access API is unavailable', async () => {
+  it('uses the same browser download flow when File System Access API is unavailable', async () => {
     // Temporarily remove showOpenFilePicker to simulate an unsupported browser
     const originalWindow = global.window;
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -96,7 +67,6 @@ describe('WebBridge.fileExport', () => {
 
     await new WebBridge().fileExport(data, filename, filters);
 
-    expect(mockShowSaveFilePicker).not.toHaveBeenCalled();
     expect(mockAnchorClick).toHaveBeenCalledTimes(1);
 
     Object.defineProperty(global, 'window', { value: originalWindow, writable: true });

--- a/apps/ui/src/platform/webBridge.ts
+++ b/apps/ui/src/platform/webBridge.ts
@@ -224,33 +224,7 @@ export class WebBridge implements PlatformBridge {
     defaultFilename: string,
     filters?: FileFilter[]
   ): Promise<void> {
-    if (hasFileSystemAccess()) {
-      const types: PickerAcceptType[] = filters?.length
-        ? filters.map((f) => ({
-            description: f.name,
-            accept: {
-              'application/octet-stream': f.extensions.map((ext) => `.${ext}`),
-            },
-          }))
-        : [];
-
-      try {
-        const handle = await window.showSaveFilePicker({
-          types: types.length ? types : undefined,
-          suggestedName: defaultFilename,
-        });
-
-        const writable = await handle.createWritable();
-        await writable.write(data);
-        await writable.close();
-      } catch (err) {
-        // User cancelled the picker — silently return without triggering the fallback download
-        if (err instanceof Error && err.name === 'AbortError') return;
-        throw err;
-      }
-      return;
-    }
-
+    void filters;
     const blob = new Blob([data], { type: 'application/octet-stream' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');

--- a/implementation-plans/web-export-save-picker-gesture.md
+++ b/implementation-plans/web-export-save-picker-gesture.md
@@ -1,0 +1,27 @@
+# Web Export Save Picker Gesture
+
+## Goal
+
+Fix web export failures caused by `showSaveFilePicker()` and make exports behave like normal browser downloads that appear in Chrome's download UI.
+
+## Approach
+
+1. Replace the web export path with the existing blob-download flow instead of `showSaveFilePicker()`.
+2. Keep desktop export behavior unchanged so native save dialogs still work in Tauri.
+3. Add regression tests that assert web exports trigger the browser download path and never open the save picker.
+4. Run targeted validation and record the results in this plan and the PR handoff.
+
+## Affected Areas
+
+- `apps/ui/src/platform/webBridge.ts`
+- `apps/ui/src/platform/__tests__/webBridge.test.ts`
+- `implementation-plans/web-export-save-picker-gesture.md`
+
+## Checklist
+
+- [x] Confirm the Sentry failure mode and identify the async gap before `showSaveFilePicker()`
+- [x] Replace the web export picker path with browser-download behavior
+- [x] Add regression coverage for the web download behavior
+- [x] Run targeted tests and shared validation
+- [ ] Create a draft PR against `main` with validation notes
+- [ ] Wait for preview status and report the PR plus preview URL

--- a/implementation-plans/web-export-save-picker-gesture.md
+++ b/implementation-plans/web-export-save-picker-gesture.md
@@ -23,5 +23,5 @@ Fix web export failures caused by `showSaveFilePicker()` and make exports behave
 - [x] Replace the web export picker path with browser-download behavior
 - [x] Add regression coverage for the web download behavior
 - [x] Run targeted tests and shared validation
-- [ ] Create a draft PR against `main` with validation notes
-- [ ] Wait for preview status and report the PR plus preview URL
+- [x] Create a draft PR against `main` with validation notes
+- [x] Wait for preview status and report the PR plus preview URL


### PR DESCRIPTION
# Summary

## What changed

- switched web export downloads to always use the browser download flow instead of `showSaveFilePicker()`
- added regression coverage to verify web exports do not try to open the save picker, even when the File System Access API is available
- documented the investigation and validation steps in `implementation-plans/web-export-save-picker-gesture.md`

## Why

- Sentry issue `7427849443` showed production export failures from `SecurityError: Failed to execute 'showSaveFilePicker' on 'Window': Must be handling a user gesture to show a file picker.`
- export generation happens asynchronously before the picker is shown, so the browser rejects the save dialog once the original click gesture has unwound
- using the normal browser download flow matches the desired web UX and makes exports appear in Chrome downloads

## Implementation notes

- desktop export behavior is unchanged; this only updates the web bridge `fileExport()` path
- implementation plan: `implementation-plans/web-export-save-picker-gesture.md`

# Testing

## Coverage checklist

- [ ] Backend unit tests added or updated for changed Rust behavior
- [x] Client unit/component tests added or updated for changed frontend behavior
- [ ] E2E tests added or updated for net new user-facing flows
- [ ] No new tests were needed for this change

## Validation performed

- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm test:unit`
- [ ] `pnpm test:formatter:ci`
- [ ] `pnpm test:e2e:web`
- [x] `bash scripts/validate-changes.sh --dry-run --changed-file apps/ui/src/platform/webBridge.ts --changed-file apps/ui/src/platform/__tests__/webBridge.test.ts --changed-file implementation-plans/web-export-save-picker-gesture.md`
- [ ] `cd apps/ui/src-tauri && cargo fmt --check`
- [ ] `cd apps/ui/src-tauri && cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cd apps/ui/src-tauri && cargo check --all-targets --all-features`

## Test details

- Ran focused Jest coverage for `src/platform/__tests__/webBridge.test.ts`, `src/platform/__tests__/index.test.tsx`, and `src/components/__tests__/ExportDialog.test.tsx`
- Ran `bash scripts/validate-changes.sh --scope baseline`, which completed `pnpm format:check`, `pnpm lint`, `pnpm type-check`, and the full `pnpm test:unit` suite successfully
- Skipped formatter CI because formatter behavior did not change
- Skipped Playwright because this is a targeted browser export transport fix with existing unit coverage and no new end-to-end flow
- Skipped Rust validation because the change is frontend-only and does not touch `apps/ui/src-tauri`

# Performance

## Performance impact

- [x] Performance was considered for this change
- [x] No meaningful performance impact is expected

## Justification

- The web export path still creates a blob and triggers a download, which is already the existing fallback behavior. This removes picker overhead without changing export generation cost.

# UI changes

## Screenshots or recordings

- N/A

# Issue link

- Sentry issue: https://zachary-marion.sentry.io/issues/7427849443/
