### PR TITLE
fix: fall back to CGAL when manifold export crashes in WASM

### DIFF
--- a/apps/ui/src/services/__tests__/exportService.test.ts
+++ b/apps/ui/src/services/__tests__/exportService.test.ts
@@ -74,4 +74,62 @@ describe('exportService', () => {
       }
     );
   });
+
+  it('falls back to CGAL when manifold export crashes with indirect call signature mismatch', async () => {
+    const crashError = new Error(
+      'OpenSCAD crashed: RuntimeError: indirect call signature mismatch'
+    );
+    const exportCgal = jest.fn(async () => new Uint8Array([4, 5, 6]));
+    const exportModel = jest
+      .fn()
+      .mockRejectedValueOnce(crashError)
+      .mockImplementationOnce(exportCgal);
+
+    const result = await exportModelWithContext({
+      format: 'stl',
+      library: { autoDiscoverSystem: false, customPaths: [] },
+      state: createState(),
+      renderService: { exportModel } as never,
+      platform: {
+        getLibraryPaths: jest.fn(async () => []),
+        readDirectoryFiles: jest.fn(async () => ({})),
+        readTextFile: jest.fn(async () => null),
+      } as never,
+    });
+
+    expect(result).toEqual(new Uint8Array([4, 5, 6]));
+    expect(exportModel).toHaveBeenNthCalledWith(
+      1,
+      'use <shared/utils.scad>\ninclude <BOSL2/std.scad>\ncube(size);',
+      'stl',
+      expect.objectContaining({ backend: 'manifold' })
+    );
+    expect(exportModel).toHaveBeenNthCalledWith(
+      2,
+      'use <shared/utils.scad>\ninclude <BOSL2/std.scad>\ncube(size);',
+      'stl',
+      expect.objectContaining({ backend: 'cgal' })
+    );
+  });
+
+  it('re-throws when manifold export crashes with a different error', async () => {
+    const otherError = new Error('Some other crash');
+    const exportModel = jest.fn().mockRejectedValueOnce(otherError);
+
+    await expect(
+      exportModelWithContext({
+        format: 'stl',
+        library: { autoDiscoverSystem: false, customPaths: [] },
+        state: createState(),
+        renderService: { exportModel } as never,
+        platform: {
+          getLibraryPaths: jest.fn(async () => []),
+          readDirectoryFiles: jest.fn(async () => ({})),
+          readTextFile: jest.fn(async () => null),
+        } as never,
+      })
+    ).rejects.toThrow('Some other crash');
+
+    expect(exportModel).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/ui/src/services/exportService.ts
+++ b/apps/ui/src/services/exportService.ts
@@ -36,8 +36,18 @@ export async function exportModelWithContext(
     platform: workingDir ? platform : undefined,
   });
 
-  return renderService.exportModel(renderInputs.code, options.format, {
-    backend: 'manifold',
-    ...renderInputs.renderOptions,
-  });
+  try {
+    return await renderService.exportModel(renderInputs.code, options.format, {
+      backend: 'manifold',
+      ...renderInputs.renderOptions,
+    });
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('indirect call signature mismatch')) {
+      return await renderService.exportModel(renderInputs.code, options.format, {
+        backend: 'cgal',
+        ...renderInputs.renderOptions,
+      });
+    }
+    throw err;
+  }
 }

--- a/implementation-plans/wasm-export-manifold-fallback.md
+++ b/implementation-plans/wasm-export-manifold-fallback.md
@@ -1,0 +1,23 @@
+# WASM Export Manifold → CGAL Fallback
+
+## Goal
+
+Mitigate `RuntimeError: indirect call signature mismatch` crashes during export by adding a silent manifold→CGAL fallback in `exportService.ts`.
+
+## Approach
+
+The manifold backend in openscad-wasm@0.0.4 can crash the WASM runtime with `indirect call signature mismatch` for certain geometry + format combinations. This is a known Emscripten/WASM compilation artifact — it's a function table type mismatch inside the WASM module, not something we can fix client-side without updating the WASM binary (which isn't available).
+
+The fix catches this specific error and retries the export with the CGAL backend, which uses a more stable code path. The fallback is transparent to the user.
+
+## Affected Areas
+
+- `apps/ui/src/services/exportService.ts` — add try/catch with CGAL fallback
+- `apps/ui/src/services/__tests__/exportService.test.ts` — add test for fallback path
+
+## Checklist
+
+- [x] Add manifold→CGAL fallback in `exportModelWithContext`
+- [x] Add unit test covering the fallback path
+- [x] Run validation (baseline scope)
+- [x] Open draft PR against main


### PR DESCRIPTION
## Summary

Mitigates `RuntimeError: indirect call signature mismatch` crashes during export by adding a silent manifold→CGAL fallback in the export service.

## What changed

- `apps/ui/src/services/exportService.ts` — catch `indirect call signature mismatch` errors from manifold exports and retry with CGAL backend
- `apps/ui/src/services/__tests__/exportService.test.ts` — add tests for the fallback path and re-throw path

## Why

The manifold backend in `openscad-wasm@0.0.4` can crash the WASM runtime with `RuntimeError: indirect call signature mismatch` for certain geometry + format combinations. This is a known Emscripten/WASM compilation artifact inside the WASM binary — upgrading isn't an option (we're on latest).

The CGAL backend uses a more stable code path and avoids the problematic WASM table entries. The fallback is transparent to the user — no error dialog appears, the export just succeeds via CGAL.

## Implementation notes

- Implementation plan: `implementation-plans/wasm-export-manifold-fallback.md`
- Uses string matching on `err.message.includes('indirect call signature mismatch')` rather than checking error name/constructor, since the error is re-wrapped as an `Error` by the worker
- Non-matching errors are re-thrown normally

## Testing

- [x] Client unit/component tests added or updated for changed frontend behavior
- [ ] No new tests were needed for this change

## Validation performed

- [x] `pnpm format:check` (passes)
- [x] `pnpm lint` (passes)
- [ ] `pnpm type-check` (pre-existing @radix-ui failures, unrelated to this change)
- [x] `pnpm test:unit` (pre-existing failures, exportService tests pass: 3/3)
- [ ] `pnpm test:formatter:ci` (skipped — no formatter changes)
- [ ] `pnpm test:e2e:web` (skipped — no UI changes)
- [x] `bash scripts/validate-changes.sh --scope baseline`

## Performance impact

- [x] No meaningful performance impact is expected
- The fallback path only executes on the rare WASM crash; the vast majority of exports proceed through manifold at full speed.

## Issue link

- Closes #N/A