### PR TITLE
docs: refresh roadmap and assistant docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,7 +314,7 @@ pnpm validate:changes   # Run the shared validation helper
 
 ## Current Status
 
-### Current Capabilities (v1.2.1)
+### Current Capabilities (v1.2.2)
 
 ✅ Monaco editor with OpenSCAD syntax highlighting
 ✅ Live STL/SVG preview (web: openscad-wasm, desktop: native binary)
@@ -341,6 +341,7 @@ pnpm validate:changes   # Run the shared validation helper
 ✅ Share links with Cloudflare Pages Functions, KV, and R2-backed thumbnails
 ✅ PostHog analytics controls and Sentry error reporting
 ✅ 2D and 3D measurement tools plus 3D section planes
+✅ Viewer annotation capture for AI screenshot attachments
 ✅ Multi-file project support with file tree, tabs, and include/use resolution
 ✅ Auto-created project directories on desktop
 ✅ Native OpenSCAD binary bundling for desktop (faster rendering, full filesystem access)
@@ -404,5 +405,5 @@ pnpm validate:changes   # Run the shared validation helper
 
 ---
 
-**Last Updated**: 2026-04-19
-**Current Version**: v1.2.1 — Web + Desktop
+**Last Updated**: 2026-04-28
+**Current Version**: v1.2.2 — Web + Desktop

--- a/PRODUCT_ROADMAP.md
+++ b/PRODUCT_ROADMAP.md
@@ -4,7 +4,7 @@
 >
 > OpenSCAD is the engine, not the product. The product is: you describe what you want, it makes it, you print it.
 
-**Current version**: v1.2.1 | **Last updated**: 2026-04-19
+**Current version**: v1.2.2 | **Last updated**: 2026-04-28
 
 This roadmap mixes shipped milestones with future planning. Older sections may describe the implementation assumptions that existed when they were written rather than the current client-side `openscad-wasm` architecture.
 
@@ -20,7 +20,7 @@ This roadmap mixes shipped milestones with future planning. Older sections may d
 
 ---
 
-## What We Have (v1.2.1)
+## What We Have (v1.2.2)
 
 | Area                                                                                  | Status |
 | ------------------------------------------------------------------------------------- | ------ |
@@ -48,14 +48,14 @@ This roadmap mixes shipped milestones with future planning. Older sections may d
 
 ### 1.1 Image Input for AI
 
-Let users paste/drag-drop a photo, sketch, or reference image into the AI chat. "Make something like this" becomes a real workflow.
+This shipped in the current product. Users can paste, drag/drop, or pick an image in chat and ask the AI to work from that reference.
 
-- [ ] Image paste support in AI prompt textarea (clipboard)
-- [ ] Drag-and-drop image files onto the chat
-- [ ] File picker button for image selection
-- [ ] Display image thumbnails in message history
-- [ ] Send as image content blocks to vision models (Anthropic + OpenAI both support this)
-- [ ] Use case: "Here's a photo of the bracket I need — make this in OpenSCAD"
+- [x] Image paste support in AI prompt textarea (clipboard)
+- [x] Drag-and-drop image files onto the chat
+- [x] File picker button for image selection
+- [x] Display image thumbnails in message history
+- [x] Send as image content blocks to vision models (Anthropic + OpenAI both support this)
+- [x] Support prompts like "Here's a photo of the bracket I need — make this in OpenSCAD"
 
 ### 1.2 Prompt Templates & One-Click Generation
 
@@ -106,11 +106,13 @@ The first 60 seconds determine whether someone stays. Optimize this ruthlessly.
 
 ### 2.1 Share Designs via URL
 
-- [ ] "Share" button generates a URL with the source code encoded (gzip + base64 in URL hash, or short-code via paste service)
-- [ ] Opening a shared link loads the design in the web editor with live preview
-- [ ] Shared view shows: rendered preview, source code, "Remix this" button
-- [ ] Social meta tags (OpenGraph) so shared links show a preview image on Twitter/Discord/Reddit
-- [ ] Size limit: designs up to ~50KB source code (covers 99% of use cases)
+This shipped in the current product through the Cloudflare-backed share flow.
+
+- [x] "Share" button creates a hosted share link
+- [x] Opening a shared link loads the design in the web editor with live preview
+- [x] Shared links support remixable entry into the editor
+- [x] Social meta tags (OpenGraph) render preview metadata for shared links
+- [x] Thumbnail-backed sharing is supported for browser-accessible examples
 
 ### 2.2 SEO Landing Pages
 
@@ -127,12 +129,11 @@ Drive organic search traffic to the web app with purpose-built pages.
 
 ### 2.3 Customizer-First Mode
 
-For shared designs and landing pages, the customizer should be primary — not the code editor.
+Customizer-first sharing shipped for share links. SEO landing pages remain future work.
 
-- [ ] "Customizer mode" layout: large preview + customizer panel, code editor collapsed/hidden
-- [ ] Big "Download STL" button
-- [ ] Ideal for non-programmers who just want to tweak dimensions and print
-- [ ] Toggle to switch to full editor mode for power users
+- [x] Shared designs can open in a customizer-first layout
+- [x] The preview/customizer flow is prioritized over the full editor for non-programmer recipients
+- [x] Recipients can still move into the full editor when they want to remix further
 
 **Success criteria**: Shared designs get engagement. Landing pages rank for target queries. Non-programmers can use the customizer to get printable results.
 

--- a/engineering-roadmap.md
+++ b/engineering-roadmap.md
@@ -1,6 +1,6 @@
 # OpenSCAD Studio — Engineering Roadmap
 
-> Current app version: **v1.2.1**. This roadmap mixes historical milestone notes with future planning, so older phase sections may reference the version they originally shipped in rather than the current release.
+> Current app version: **v1.2.2**. This roadmap mixes historical milestone notes with future planning, so older phase sections may reference the version they originally shipped in rather than the current release.
 >
 > A modern OpenSCAD editor with live preview and AI copilot capabilities, available as both a web app and a macOS desktop app. The application uses openscad-wasm for rendering and provides a superior editing experience with real-time feedback and AI-assisted code generation.
 
@@ -211,15 +211,16 @@
 - [ ] Backend already supports `save_conversation`, `load_conversations`, `delete_conversation`
 - [ ] Frontend just needs the UI — `loadConversation` already exists in `useAiAgent`
 
-### 5.2: Image Input for AI
+### ✅ 5.2: Image Input for AI (COMPLETED)
 
-- [ ] Add image paste/drag-drop support to the AI prompt textarea
-- [ ] Support: clipboard paste, file drag-drop, file picker button
-- [ ] Convert images to base64 for API transmission
-- [ ] Display image thumbnails in the message history
-- [ ] Send as `image` content blocks to Anthropic API / OpenAI vision API
-- [ ] Use case: "Make something like this" with a photo/sketch reference
-- [ ] Backend change: extend `send_ai_query` message format to support image content blocks
+> Landed after this roadmap section was first drafted. The shipped implementation stays inside the shared frontend AI stack rather than adding a Rust-side `send_ai_query` backend.
+
+- [x] Add image paste/drag-drop support to the AI prompt textarea
+- [x] Support: clipboard paste, file drag-drop, file picker button
+- [x] Convert images to base64 for API transmission
+- [x] Display image thumbnails in the message history
+- [x] Send as `image` content blocks to Anthropic API / OpenAI vision API
+- [x] Support "make something like this" workflows with photo/sketch references
 
 ### 5.3: Multi-File Project Context for AI
 


### PR DESCRIPTION
# Summary

## What changed

- Updated CLAUDE.md to reflect v1.2.2 and note viewer annotation capture in the current capability list.
- Updated PRODUCT_ROADMAP.md so the current version matches the repo and shipped image/share/customizer-first work is no longer listed as future work.
- Updated engineering-roadmap.md to reflect v1.2.2 and mark AI image input as shipped in the shared frontend AI stack.

## Why

- Several maintainer docs and roadmap sections had drifted from the current product state.
- The biggest inconsistencies were stale version numbers and roadmap items that were already implemented but still presented as planned.

## Implementation notes

- README.md was intentionally left alone so it stays user-facing and avoids maintainership detail.
- This PR is documentation-only and does not change application code.

# Testing

## Coverage checklist

- [ ] Backend unit tests added or updated for changed Rust behavior
- [ ] Client unit/component tests added or updated for changed frontend behavior
- [ ] E2E tests added or updated for net new user-facing flows
- [x] No new tests were needed for this change

## Validation performed

- [x] pnpm format:check
- [x] pnpm lint
- [x] pnpm type-check
- [x] pnpm test:unit
- [ ] pnpm test:formatter:ci
- [ ] pnpm test:e2e:web
- [x] bash scripts/validate-changes.sh --scope baseline
- [ ] cd apps/ui/src-tauri && cargo fmt --check
- [ ] cd apps/ui/src-tauri && cargo clippy --all-targets --all-features -- -D warnings
- [ ] cd apps/ui/src-tauri && cargo check --all-targets --all-features

## Test details

- Ran the shared baseline validation helper after installing workspace dependencies in this worktree.
- Skipped formatter-only, E2E, and Rust-specific validations because the diff only touches Markdown documentation.

# Performance

## Performance impact

- [x] Performance was considered for this change
- [x] No meaningful performance impact is expected

## Justification

- Documentation-only updates do not affect runtime behavior.

# UI changes

## Screenshots or recordings

- N/A

# Issue link

- Closes #
