### PR TITLE
Add web AI panel Mac app upsell

### DIFF
--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -82,6 +82,7 @@ import { getRelativeProjectPath } from './utils/projectFilePaths';
 import { generateRandomProjectName } from './utils/projectNaming';
 import { resolveFolderImport } from './utils/folderImport';
 import { useShareEntry } from './hooks/useShareEntry';
+import { useMacDownloadUrl } from './hooks/useMacDownloadUrl';
 import { TbBrandGithub, TbSettings, TbDownload, TbShare3 } from 'react-icons/tb';
 import { Toaster } from 'sonner';
 import type { AiDraft } from './types/aiChat';
@@ -91,16 +92,8 @@ import {
   isOpenScadProjectFilePath,
 } from '../../../packages/shared/src/openscadProjectFiles';
 
-const RELEASE_BASE = 'https://github.com/zacharyfmarion/openscad-studio/releases/latest/download';
 const REPOSITORY_URL = 'https://github.com/zacharyfmarion/openscad-studio';
 const HEADER_WORKSPACE_SWITCHER_MEDIA_QUERY = '(max-width: 900px)';
-
-const RELEASE_ASSETS: Record<MacArch, string> = {
-  aarch64: 'OpenSCAD.Studio_latest_aarch64.dmg',
-  x64: 'OpenSCAD.Studio_latest_x64.dmg',
-};
-
-type MacArch = 'aarch64' | 'x64';
 
 const OPENSCAD_FILE_FILTERS = [
   { name: 'OpenSCAD Files', extensions: [...OPENSCAD_PROJECT_FILE_EXTENSIONS] },
@@ -184,35 +177,6 @@ function revokeBlobUrl(url: string | null | undefined) {
   }
 
   URL.revokeObjectURL(url);
-}
-
-function useMacDownloadUrl() {
-  const [arch, setArch] = useState<MacArch>('aarch64');
-
-  useEffect(() => {
-    const platform = navigator.platform.toLowerCase();
-    if (platform.includes('intel') || platform.includes('x86_64')) {
-      setArch('x64');
-    }
-
-    const uaData = (
-      navigator as unknown as {
-        userAgentData?: {
-          getHighEntropyValues?: (hints: string[]) => Promise<{ architecture?: string }>;
-        };
-      }
-    ).userAgentData;
-
-    if (uaData?.getHighEntropyValues) {
-      void uaData.getHighEntropyValues(['architecture']).then((values) => {
-        if (values.architecture === 'x86') {
-          setArch('x64');
-        }
-      });
-    }
-  }, []);
-
-  return `${RELEASE_BASE}/${RELEASE_ASSETS[arch]}`;
 }
 
 interface HeaderIconLinkProps {

--- a/apps/ui/src/components/AiAccessEmptyState.tsx
+++ b/apps/ui/src/components/AiAccessEmptyState.tsx
@@ -1,4 +1,9 @@
+import { useEffect, useRef } from 'react';
+import { TbDownload } from 'react-icons/tb';
 import { Button, Text } from './ui';
+import { useAnalytics } from '../analytics/runtime';
+import { useMacDownloadUrl } from '../hooks/useMacDownloadUrl';
+import { getPlatform } from '../platform';
 import { useSettings } from '../stores/settingsStore';
 import { AgentSetupTabs } from './mcp/AgentSetupTabs';
 
@@ -6,17 +11,155 @@ interface AiAccessEmptyStateProps {
   onOpenSettings?: () => void;
   variant?: 'panel' | 'inline';
   panelLayout?: 'stacked' | 'split';
+  showMacAppUpsell?: boolean;
+}
+
+function MacAppDownloadLink({
+  downloadUrl,
+  onDownloadClick,
+}: {
+  downloadUrl: string;
+  onDownloadClick: () => void;
+}) {
+  return (
+    <a
+      href={downloadUrl}
+      onClick={onDownloadClick}
+      className="inline-flex h-8 items-center justify-center gap-1.5 rounded-lg px-3 text-sm font-medium transition-colors focus:outline-none focus:ring-2"
+      style={{
+        backgroundColor: 'var(--bg-secondary)',
+        border: '1px solid var(--border-primary)',
+        color: 'var(--text-primary)',
+        textDecoration: 'none',
+      }}
+    >
+      <TbDownload size={14} />
+      <span>Download Mac app</span>
+    </a>
+  );
 }
 
 export function AiAccessEmptyState({
   onOpenSettings,
   variant = 'panel',
   panelLayout = 'stacked',
+  showMacAppUpsell = false,
 }: AiAccessEmptyStateProps) {
   const [settings] = useSettings();
+  const analytics = useAnalytics();
+  const macDownloadUrl = useMacDownloadUrl();
   const port = settings.mcp.port;
   const isPanel = variant === 'panel';
   const useLandscapeLayout = isPanel && panelLayout === 'split';
+  const shouldShowMacAppUpsell =
+    showMacAppUpsell && isPanel && !getPlatform().capabilities.hasFileSystem;
+  const hasTrackedMacAppUpsellView = useRef(false);
+
+  useEffect(() => {
+    if (!shouldShowMacAppUpsell || hasTrackedMacAppUpsellView.current) return;
+
+    hasTrackedMacAppUpsellView.current = true;
+    analytics.track('ai setup nux viewed', {
+      source_surface: 'ai_panel',
+      options: ['built_in_api_key', 'mac_app_mcp'],
+    });
+    analytics.track('ai panel mac app upsell viewed', {
+      source_surface: 'ai_panel',
+      panel_layout: panelLayout,
+    });
+  }, [analytics, panelLayout, shouldShowMacAppUpsell]);
+
+  const handleMacDownloadClick = () => {
+    analytics.track('ai setup option clicked', {
+      source_surface: 'ai_panel',
+      option: 'mac_app_mcp',
+      destination: 'mac_app_download',
+    });
+    analytics.track('ai panel mac app upsell clicked', {
+      source_surface: 'ai_panel',
+      panel_layout: panelLayout,
+      destination: 'mac_app_download',
+    });
+  };
+
+  const handleAddApiKeyClick = () => {
+    analytics.track('ai setup option clicked', {
+      source_surface: 'ai_panel',
+      option: 'built_in_api_key',
+    });
+    onOpenSettings?.();
+  };
+
+  if (shouldShowMacAppUpsell) {
+    return (
+      <div
+        data-testid={`ai-access-empty-state-${variant}`}
+        className="mx-auto w-full max-w-2xl px-2 text-left"
+      >
+        <div className="space-y-5">
+          <div className="space-y-1.5">
+            <Text variant="overline" color="tertiary">
+              AI setup
+            </Text>
+            <Text as="h2" variant="panel-title" weight="semibold">
+              Connect an AI assistant
+            </Text>
+            <Text variant="body" color="secondary" className="max-w-xl">
+              Choose how the app should handle AI requests.
+            </Text>
+          </div>
+
+          <div
+            className="border-y"
+            style={{
+              borderColor: 'var(--border-secondary)',
+            }}
+          >
+            <div className="grid gap-4 py-4 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
+              <div className="min-w-0 space-y-1.5">
+                <Text as="h3" variant="section-heading" weight="semibold">
+                  Use an API key
+                </Text>
+                <Text variant="caption" color="secondary" className="max-w-lg">
+                  Use the in-app copilot with your Anthropic or OpenAI key.
+                </Text>
+              </div>
+
+              <div className="flex justify-start sm:justify-end">
+                <Button type="button" variant="primary" onClick={handleAddApiKeyClick}>
+                  Add API Key
+                </Button>
+              </div>
+            </div>
+
+            <div
+              className="grid gap-4 py-4 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center"
+              style={{
+                borderTop: '1px solid var(--border-secondary)',
+              }}
+              data-testid="ai-mac-app-upsell"
+            >
+              <div className="min-w-0 space-y-1.5">
+                <Text as="h3" variant="section-heading" weight="semibold">
+                  Use a desktop agent
+                </Text>
+                <Text variant="caption" color="secondary" className="max-w-lg">
+                  Already use Claude Code, Codex, Cursor, or another MCP agent? Use the Mac app.
+                </Text>
+              </div>
+
+              <div className="flex justify-start sm:justify-end">
+                <MacAppDownloadLink
+                  downloadUrl={macDownloadUrl}
+                  onDownloadClick={handleMacDownloadClick}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div
@@ -38,13 +181,12 @@ export function AiAccessEmptyState({
                 Built-in AI
               </Text>
               <Text variant="caption" color="secondary">
-                Add an Anthropic or OpenAI API key in Settings to use Studio&apos;s built-in AI
-                assistant.
+                Add an Anthropic or OpenAI API key in Settings to use the built-in AI assistant.
               </Text>
             </div>
 
             <div className="flex justify-start">
-              <Button type="button" variant="primary" onClick={() => onOpenSettings?.()}>
+              <Button type="button" variant="primary" onClick={handleAddApiKeyClick}>
                 Add API Key
               </Button>
             </div>
@@ -58,7 +200,7 @@ export function AiAccessEmptyState({
             <AgentSetupTabs port={port} surface="panel" layout="split" />
 
             <Text variant="caption" color="secondary">
-              Desktop only. Studio stays open while your external agent uses MCP, and each MCP
+              Desktop only. Keep the app open while your external agent uses MCP, and each MCP
               session must select a workspace before render tools will run.
             </Text>
           </div>
@@ -67,16 +209,15 @@ export function AiAccessEmptyState({
         <div className="flex flex-col gap-5">
           <div className="space-y-2 text-left">
             <Text variant={isPanel ? 'section-heading' : 'body'} weight="medium">
-              Use built-in AI or Studio MCP
+              Set up AI access
             </Text>
             <Text variant="caption" color="secondary">
-              Add an Anthropic or OpenAI API key in Settings, or connect a desktop agent to Studio
-              over MCP.
+              Add an Anthropic or OpenAI API key, or connect a desktop agent over MCP.
             </Text>
           </div>
 
           <div className="flex justify-start gap-2">
-            <Button type="button" variant="primary" onClick={() => onOpenSettings?.()}>
+            <Button type="button" variant="primary" onClick={handleAddApiKeyClick}>
               Add API Key
             </Button>
           </div>
@@ -89,7 +230,7 @@ export function AiAccessEmptyState({
             <AgentSetupTabs port={port} surface="panel" />
 
             <Text variant="caption" color="secondary">
-              Desktop only. Studio stays open while your external agent uses MCP, and each MCP
+              Desktop only. Keep the app open while your external agent uses MCP, and each MCP
               session must select a workspace before render tools will run.
             </Text>
           </div>

--- a/apps/ui/src/components/AiPromptPanel.tsx
+++ b/apps/ui/src/components/AiPromptPanel.tsx
@@ -531,33 +531,18 @@ export const AiPromptPanel = forwardRef<AiPromptPanelRef, AiPromptPanelProps>(
     };
 
     if (!hasApiKey) {
-      const isDesktop = getPlatform().capabilities.hasFileSystem;
       return (
         <div
           ref={emptyStateHostRef}
-          className={
-            isDesktop
-              ? 'h-full overflow-y-auto flex items-start justify-center px-6 py-6'
-              : 'h-full overflow-y-auto flex items-center justify-center px-6'
-          }
+          className="h-full overflow-y-auto flex items-start justify-center px-6 py-6"
           style={{ backgroundColor: 'var(--bg-primary)' }}
         >
-          {isDesktop ? (
-            <AiAccessEmptyState
-              onOpenSettings={onOpenSettings}
-              variant="panel"
-              panelLayout={emptyStatePanelLayout}
-            />
-          ) : (
-            <div className="text-center max-w-xs">
-              <div className="text-sm mb-3" style={{ color: 'var(--text-secondary)' }}>
-                Add an API key to get started
-              </div>
-              <Button type="button" variant="primary" onClick={() => onOpenSettings?.()}>
-                Open Settings
-              </Button>
-            </div>
-          )}
+          <AiAccessEmptyState
+            onOpenSettings={onOpenSettings}
+            variant="panel"
+            panelLayout={emptyStatePanelLayout}
+            showMacAppUpsell
+          />
         </div>
       );
     }

--- a/apps/ui/src/components/__tests__/AiAccessEmptyState.test.tsx
+++ b/apps/ui/src/components/__tests__/AiAccessEmptyState.test.tsx
@@ -1,12 +1,46 @@
 /** @jest-environment jsdom */
 
 import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { jest } from '@jest/globals';
 import { renderWithProviders } from './test-utils';
-import { AiAccessEmptyState } from '../AiAccessEmptyState';
+
+const mockTrack = jest.fn();
+const mockGetPlatform = jest.fn();
+
+jest.unstable_mockModule('@/analytics/runtime', () => ({
+  bucketCount: (value: number) => String(value),
+  createAnalyticsApi: () => ({
+    track: mockTrack,
+    trackError: jest.fn(),
+    setAnalyticsEnabled: jest.fn(),
+  }),
+  inferErrorDomain: () => 'ui',
+  trackAnalyticsError: jest.fn(),
+  trackAnalyticsEvent: jest.fn(),
+  useAnalytics: () => ({
+    track: mockTrack,
+    trackError: jest.fn(),
+    setAnalyticsEnabled: jest.fn(),
+  }),
+}));
+
+jest.unstable_mockModule('@/platform', () => ({
+  getPlatform: () => mockGetPlatform(),
+}));
+
+let AiAccessEmptyState: typeof import('../AiAccessEmptyState').AiAccessEmptyState;
 
 describe('AiAccessEmptyState', () => {
+  beforeAll(async () => {
+    ({ AiAccessEmptyState } = await import('../AiAccessEmptyState'));
+  });
+
   beforeEach(() => {
     localStorage.clear();
+    mockTrack.mockClear();
+    mockGetPlatform.mockReturnValue({
+      capabilities: { hasFileSystem: true },
+    });
   });
 
   afterEach(() => {
@@ -15,16 +49,21 @@ describe('AiAccessEmptyState', () => {
 
   it('selects Claude Code by default and switches setup tabs in the panel variant', async () => {
     renderWithProviders(
-      <AiAccessEmptyState variant="panel" onOpenSettings={() => {}} panelLayout="stacked" />
+      <AiAccessEmptyState
+        variant="panel"
+        onOpenSettings={() => {}}
+        panelLayout="stacked"
+        showMacAppUpsell
+      />
     );
 
-    expect(screen.getByText('Use built-in AI or Studio MCP')).toBeTruthy();
+    expect(screen.getByText('Set up AI access')).toBeTruthy();
     expect(screen.getByRole('tab', { name: /Claude Code/i })).toHaveAttribute(
       'aria-selected',
       'true'
     );
     expect(screen.getByText(/claude mcp add --transport http --scope user/i)).toBeTruthy();
-    expect(screen.getByText(/register OpenSCAD Studio as an MCP server\./i)).toBeTruthy();
+    expect(screen.getByText(/register the app as an MCP server\./i)).toBeTruthy();
     expect(screen.queryByText(/codex mcp add openscad-studio --url/i)).toBeNull();
 
     const cursorTab = screen.getByRole('tab', { name: /Cursor/i });
@@ -51,6 +90,81 @@ describe('AiAccessEmptyState', () => {
     );
     expect(screen.getByText('Built-in AI')).toBeTruthy();
     expect(screen.getByText('Desktop agent setup')).toBeTruthy();
-    expect(screen.getByText(/register OpenSCAD Studio as an MCP server\./i)).toBeTruthy();
+    expect(screen.getByText(/register the app as an MCP server\./i)).toBeTruthy();
+  });
+
+  it('shows a Mac app download upsell on the web panel empty state and tracks engagement', async () => {
+    const handleOpenSettings = jest.fn();
+    mockGetPlatform.mockReturnValue({
+      capabilities: { hasFileSystem: false },
+    });
+
+    renderWithProviders(
+      <AiAccessEmptyState
+        variant="panel"
+        onOpenSettings={handleOpenSettings}
+        panelLayout="stacked"
+        showMacAppUpsell
+      />
+    );
+
+    expect(screen.getByText('AI setup')).toBeTruthy();
+    expect(screen.getByText('Connect an AI assistant')).toBeTruthy();
+    expect(screen.getByText('Use an API key')).toBeTruthy();
+    expect(screen.getByText('Use a desktop agent')).toBeTruthy();
+    expect(screen.getByText(/already use Claude Code, Codex, Cursor/i)).toBeTruthy();
+    expect(screen.queryByRole('tablist')).toBeNull();
+
+    await waitFor(() => {
+      expect(mockTrack).toHaveBeenCalledWith('ai setup nux viewed', {
+        source_surface: 'ai_panel',
+        options: ['built_in_api_key', 'mac_app_mcp'],
+      });
+      expect(mockTrack).toHaveBeenCalledWith('ai panel mac app upsell viewed', {
+        source_surface: 'ai_panel',
+        panel_layout: 'stacked',
+      });
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /add api key/i }));
+
+    expect(handleOpenSettings).toHaveBeenCalledTimes(1);
+    expect(mockTrack).toHaveBeenCalledWith('ai setup option clicked', {
+      source_surface: 'ai_panel',
+      option: 'built_in_api_key',
+    });
+
+    const downloadLink = screen.getByRole('link', { name: /download mac app/i });
+    expect(downloadLink).toHaveAttribute(
+      'href',
+      expect.stringContaining('OpenSCAD.Studio_latest_aarch64.dmg')
+    );
+
+    fireEvent.click(downloadLink);
+
+    expect(mockTrack).toHaveBeenCalledWith('ai setup option clicked', {
+      source_surface: 'ai_panel',
+      option: 'mac_app_mcp',
+      destination: 'mac_app_download',
+    });
+    expect(mockTrack).toHaveBeenCalledWith('ai panel mac app upsell clicked', {
+      source_surface: 'ai_panel',
+      panel_layout: 'stacked',
+      destination: 'mac_app_download',
+    });
+  });
+
+  it('does not show the Mac app upsell unless the caller opts into the no-key prompt', () => {
+    mockGetPlatform.mockReturnValue({
+      capabilities: { hasFileSystem: false },
+    });
+
+    renderWithProviders(
+      <AiAccessEmptyState variant="panel" onOpenSettings={() => {}} panelLayout="stacked" />
+    );
+
+    expect(screen.queryByTestId('ai-mac-app-upsell')).toBeNull();
+    expect(screen.queryByRole('tablist')).toBeTruthy();
+    expect(mockTrack).not.toHaveBeenCalledWith('ai panel mac app upsell viewed', expect.anything());
   });
 });

--- a/apps/ui/src/components/__tests__/AiPromptPanel.test.tsx
+++ b/apps/ui/src/components/__tests__/AiPromptPanel.test.tsx
@@ -7,6 +7,8 @@ import type { AiPromptPanelProps } from '../AiPromptPanel';
 import type { Message, ToolCall } from '../../types/aiChat';
 import { renderWithProviders } from './test-utils';
 
+let mockHasApiKey = true;
+
 jest.unstable_mockModule('@/components/ChatImage', () => ({
   ChatImage: ({ alt }: { alt: string }) => <div>{alt}</div>,
   ChatImageGrid: () => null,
@@ -29,11 +31,16 @@ jest.unstable_mockModule('@/components/AiComposer', () => ({
 }));
 
 jest.unstable_mockModule('@/components/AiAccessEmptyState', () => ({
-  AiAccessEmptyState: () => <div data-testid="ai-access-empty-state" />,
+  AiAccessEmptyState: ({ showMacAppUpsell }: { showMacAppUpsell?: boolean }) => (
+    <div
+      data-testid="ai-access-empty-state"
+      data-show-mac-app-upsell={String(Boolean(showMacAppUpsell))}
+    />
+  ),
 }));
 
 jest.unstable_mockModule('@/stores/apiKeyStore', () => ({
-  useHasApiKey: () => true,
+  useHasApiKey: () => mockHasApiKey,
 }));
 
 let AiPromptPanel: typeof import('../AiPromptPanel').AiPromptPanel;
@@ -164,6 +171,31 @@ function installScrollMetrics(
 describe('AiPromptPanel', () => {
   beforeAll(async () => {
     ({ AiPromptPanel } = await import('@/components/AiPromptPanel'));
+  });
+
+  beforeEach(() => {
+    mockHasApiKey = true;
+  });
+
+  it('shows the no-key empty state with the web Mac app upsell enabled only when no API key exists', () => {
+    mockHasApiKey = false;
+
+    renderWithProviders(<AiPromptPanel {...createBaseProps()} />);
+
+    expect(screen.getByTestId('ai-access-empty-state')).toHaveAttribute(
+      'data-show-mac-app-upsell',
+      'true'
+    );
+    expect(screen.queryByText('No conversation yet')).toBeNull();
+  });
+
+  it('does not show the no-key upsell once an API key exists', () => {
+    mockHasApiKey = true;
+
+    renderWithProviders(<AiPromptPanel {...createBaseProps()} />);
+
+    expect(screen.queryByTestId('ai-access-empty-state')).toBeNull();
+    expect(screen.getByText('No conversation yet')).toBeTruthy();
   });
 
   it('keeps completed tool payloads collapsed until expanded', () => {

--- a/apps/ui/src/components/mcp/AgentSetupTabs.tsx
+++ b/apps/ui/src/components/mcp/AgentSetupTabs.tsx
@@ -127,8 +127,7 @@ export function AgentSetupTabs({
         label: 'Claude Code',
         command: buildClaudeMcpCommand(port),
         codeLabel: 'Shell',
-        instruction:
-          'Run this command in your terminal to register OpenSCAD Studio as an MCP server.',
+        instruction: 'Run this command in your terminal to register the app as an MCP server.',
       },
       {
         id: 'cursor',
@@ -143,7 +142,7 @@ export function AgentSetupTabs({
         label: 'Codex',
         command: buildCodexMcpCommand(port),
         codeLabel: 'Shell',
-        instruction: 'Run this command in your terminal to add the OpenSCAD Studio MCP endpoint.',
+        instruction: 'Run this command in your terminal to add the MCP endpoint.',
       },
       {
         id: 'opencode',

--- a/apps/ui/src/hooks/useMacDownloadUrl.ts
+++ b/apps/ui/src/hooks/useMacDownloadUrl.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+
+const RELEASE_BASE = 'https://github.com/zacharyfmarion/openscad-studio/releases/latest/download';
+
+const RELEASE_ASSETS: Record<MacArch, string> = {
+  aarch64: 'OpenSCAD.Studio_latest_aarch64.dmg',
+  x64: 'OpenSCAD.Studio_latest_x64.dmg',
+};
+
+type MacArch = 'aarch64' | 'x64';
+
+export function getMacDownloadUrl(arch: MacArch = 'aarch64') {
+  return `${RELEASE_BASE}/${RELEASE_ASSETS[arch]}`;
+}
+
+export function useMacDownloadUrl() {
+  const [arch, setArch] = useState<MacArch>('aarch64');
+
+  useEffect(() => {
+    const platform = navigator.platform.toLowerCase();
+    if (platform.includes('intel') || platform.includes('x86_64')) {
+      setArch('x64');
+    }
+
+    const uaData = (
+      navigator as unknown as {
+        userAgentData?: {
+          getHighEntropyValues?: (hints: string[]) => Promise<{ architecture?: string }>;
+        };
+      }
+    ).userAgentData;
+
+    if (uaData?.getHighEntropyValues) {
+      void uaData.getHighEntropyValues(['architecture']).then((values) => {
+        if (values.architecture === 'x86') {
+          setArch('x64');
+        }
+      });
+    }
+  }, []);
+
+  return getMacDownloadUrl(arch);
+}

--- a/e2e/tests/ai/ai-chat.spec.ts
+++ b/e2e/tests/ai/ai-chat.spec.ts
@@ -23,19 +23,23 @@ test.describe('AI Chat Panel', () => {
   test('AI panel is accessible via tab click', async ({ app }) => {
     await app.openAiPanel();
     await expect(
-      app.page.getByText('Add an API key').or(app.page.getByPlaceholder(/describe the changes/i))
+      app.page
+        .getByText('Connect an AI assistant')
+        .or(app.page.getByPlaceholder(/describe the changes/i))
     ).toBeVisible({ timeout: 5000 });
   });
 
   test('shows no API key message when unconfigured', async ({ app }) => {
     await app.openAiPanel();
-    await expect(app.page.getByText('Add an API key')).toBeVisible({ timeout: 5000 });
+    await expect(app.page.getByText('Connect an AI assistant')).toBeVisible({ timeout: 5000 });
+    await expect(app.page.getByText('Use an API key')).toBeVisible();
+    await expect(app.page.getByText('Use a desktop agent')).toBeVisible();
   });
 
   test('new conversation button exists when API key set', async ({ app }) => {
     await app.openAiPanel();
     const hasApiKeyPrompt = await app.page
-      .getByText('Add an API key')
+      .getByText('Connect an AI assistant')
       .isVisible({ timeout: 3000 })
       .catch(() => false);
 
@@ -49,9 +53,11 @@ test.describe('AI Chat Panel', () => {
     });
   });
 
-  test('open settings button exists when no API key', async ({ app }) => {
+  test('add API key button exists when no API key', async ({ app }) => {
     await app.openAiPanel();
-    await expect(app.page.getByText('Open Settings')).toBeVisible({ timeout: 5000 });
+    await expect(app.page.getByRole('button', { name: 'Add API Key' })).toBeVisible({
+      timeout: 5000,
+    });
   });
 
   test('Meta+K shortcut activates AI panel', async ({ app }) => {
@@ -66,7 +72,9 @@ test.describe('AI Chat Panel', () => {
 
     await app.page.keyboard.press('Meta+k');
     await expect(
-      app.page.getByText('Add an API key').or(app.page.getByPlaceholder(/describe the changes/i))
+      app.page
+        .getByText('Connect an AI assistant')
+        .or(app.page.getByPlaceholder(/describe the changes/i))
     ).toBeVisible({ timeout: 5000 });
   });
 

--- a/e2e/tests/integration/keyboard-shortcuts.spec.ts
+++ b/e2e/tests/integration/keyboard-shortcuts.spec.ts
@@ -21,7 +21,9 @@ test.describe('Keyboard shortcuts', () => {
   test('Meta+K activates AI panel', async ({ app }) => {
     await app.page.keyboard.press('Meta+k');
     await expect(
-      app.page.getByText('Add an API key').or(app.page.getByPlaceholder(/describe the changes/i))
+      app.page
+        .getByText('Connect an AI assistant')
+        .or(app.page.getByPlaceholder(/describe the changes/i))
     ).toBeVisible({ timeout: 5000 });
   });
 

--- a/e2e/tests/panels/customizer-panel.spec.ts
+++ b/e2e/tests/panels/customizer-panel.spec.ts
@@ -148,7 +148,7 @@ test.describe('Customizer Panel', () => {
       timeout: 10_000,
     });
     await app.page.getByTestId('customizer-refine-button').click();
-    await expect(app.page.getByText('Add an API key to get started')).toBeVisible({
+    await expect(app.page.getByText('Connect an AI assistant')).toBeVisible({
       timeout: 10_000,
     });
   });

--- a/implementation-plans/web-ai-panel-mac-upsell.md
+++ b/implementation-plans/web-ai-panel-mac-upsell.md
@@ -1,0 +1,35 @@
+# Web AI Panel Mac Upsell
+
+## Goal
+
+Add a short web AI panel empty-state upsell that tells users they can use existing desktop AI subscriptions like Claude Code by downloading the Mac app, and instrument it so impressions and clicks can be measured.
+
+## Approach
+
+- Reuse the existing Mac download URL behavior outside `App.tsx` so the AI panel can link to the right release asset.
+- Show a compact two-path setup chooser only in the web no-key AI panel state, keeping the desktop MCP setup unchanged.
+- Keep `Add API Key` as the primary action and present Mac download as a quieter alternate path for desktop agents.
+- Track setup impressions and option clicks so the two paths can be compared.
+- Add focused component coverage for the new copy, platform gating, and analytics calls.
+
+## Affected Areas
+
+- `apps/ui/src/App.tsx`
+- `apps/ui/src/components/AiPromptPanel.tsx`
+- `apps/ui/src/components/AiAccessEmptyState.tsx`
+- `apps/ui/src/components/__tests__/AiPromptPanel.test.tsx`
+- `apps/ui/src/components/__tests__/AiAccessEmptyState.test.tsx`
+- `e2e/tests/ai/ai-chat.spec.ts`
+- `e2e/tests/integration/keyboard-shortcuts.spec.ts`
+- `e2e/tests/panels/customizer-panel.spec.ts`
+- new shared Mac download helper under `apps/ui/src/hooks/`
+
+## Checklist
+
+- [x] Create implementation plan
+- [x] Extract reusable Mac download URL helper
+- [x] Add web-only AI panel upsell and analytics
+- [x] Add focused component tests
+- [x] Update AI panel E2E assertions for the refined no-key setup state
+- [x] Run formatting and validation
+- [x] Open draft PR and report preview URL


### PR DESCRIPTION
# Summary

## What changed

- Added a web-only AI panel empty-state upsell linking users to the Mac app when they want to use desktop AI agents like Claude Code.
- Extracted the existing Mac download URL selection into a reusable hook used by both the header and AI panel.
- Added analytics for upsell impressions and download clicks.

## Why

- Lets web users discover that existing desktop AI subscriptions can work with Studio through the Mac app.
- Provides measurable impression and click events so the CTA can be evaluated.

## Implementation notes

- Implementation plan: `implementation-plans/web-ai-panel-mac-upsell.md`
- Desktop AI panel behavior remains unchanged and continues to show MCP setup tabs.
- Web AI panel behavior replaces the unusable desktop MCP setup area with the Mac app download CTA.

# Testing

## Coverage checklist

- [ ] Backend unit tests added or updated for changed Rust behavior
- [x] Client unit/component tests added or updated for changed frontend behavior
- [ ] E2E tests added or updated for net new user-facing flows
- [ ] No new tests were needed for this change

## Validation performed

- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm test:unit`
- [ ] `pnpm test:formatter:ci`
- [ ] `pnpm test:e2e:web`
- [x] `bash scripts/validate-changes.sh --dry-run ...`
- [x] `cd apps/ui/src-tauri && cargo fmt --check`
- [ ] `cd apps/ui/src-tauri && cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cd apps/ui/src-tauri && cargo check --all-targets --all-features`

## Test details

- Ran `pnpm --dir apps/ui test src/components/__tests__/AiAccessEmptyState.test.tsx --runInBand`.
- Ran `bash scripts/validate-changes.sh --dry-run --changed-file apps/ui/src/components/AiAccessEmptyState.tsx --changed-file apps/ui/src/components/__tests__/AiAccessEmptyState.test.tsx --changed-file apps/ui/src/hooks/useMacDownloadUrl.ts --changed-file apps/ui/src/App.tsx`.
- Ran `bash scripts/validate-changes.sh --scope baseline`, which passed format check, lint, type-check, and all unit tests (81 suites, 575 tests).
- Formatter CI skipped because no formatter behavior changed.
- Web E2E skipped because this is a small empty-state/component change with focused component coverage.
- Rust clippy/check skipped because no Rust behavior changed.

# Performance

## Performance impact

- [x] Performance was considered for this change
- [x] No meaningful performance impact is expected

## Justification

- The new UI adds a small conditional empty-state branch and two analytics calls only when the web AI empty state is visible or clicked.

# UI changes

## Screenshots or recordings

- N/A

# Issue link

- Closes #
