### PR TITLE
fix: guard against duplicate Monaco model URIs on Editor remount

### DIFF
--- a/apps/ui/src/components/Editor.tsx
+++ b/apps/ui/src/components/Editor.tsx
@@ -132,6 +132,15 @@ export function Editor({
       }
 
       const uri = monaco.Uri.parse(`file:///${fileId}.scad`);
+      // Check Monaco's global registry before creating — a previous Editor
+      // instance may have been unmounted without disposing the model (e.g.
+      // React concurrent mode remounts), which causes createModel to throw
+      // "Cannot add model because it already exists!" (Sentry OPENSCAD-STUDIO-2B).
+      const globalExisting = monaco.editor.getModel(uri);
+      if (globalExisting && !globalExisting.isDisposed()) {
+        modelsRef.current.set(fileId, { model: globalExisting, viewState: null });
+        return globalExisting;
+      }
       const model = monaco.editor.createModel(content, 'openscad', uri);
       modelsRef.current.set(fileId, { model, viewState: null });
       return model;


### PR DESCRIPTION
# Summary

## What changed

- In `getOrCreateModel` (Editor.tsx), added a check against Monaco's global model registry (`monaco.editor.getModel(uri)`) before calling `monaco.editor.createModel`.

## Why

- Sentry issue [OPENSCAD-STUDIO-2B](https://zachary-marion.sentry.io/issues/OPENSCAD-STUDIO-2B): `ModelService: Cannot add model because it already exists!`
- Root cause: when the `Editor` component remounts (e.g. React concurrent mode or a parent re-render), the local `modelsRef` map is fresh, but Monaco's global model registry still holds the previous model under the same URI (`file:///<fileId>.scad`). Calling `monaco.editor.createModel` on an already-registered URI throws the error.
- The fix checks `monaco.editor.getModel(uri)` first and reuses the existing model if found, falling through to `createModel` only when no global model exists.

## Implementation notes

- One-line guard in `getOrCreateModel` — no other code paths affected.
- No implementation plan created (narrow, single-function fix per AGENTS.md guidance).

# Testing

## Coverage checklist

- [ ] Backend unit tests added or updated for changed Rust behavior
- [ ] Client unit/component tests added or updated for changed frontend behavior
- [ ] E2E tests added or updated for net new user-facing flows
- [x] No new tests were needed for this change

## Validation performed

- [x] `pnpm format:check`
- [x] `pnpm lint`
- [ ] `pnpm type-check` — 3 pre-existing errors on `main` in unrelated files (`AgentSetupTabs.tsx`, `Accordion.tsx`, `Tabs.tsx`); confirmed present on `main` before this branch.
- [ ] `pnpm test:unit`
- [ ] `pnpm test:formatter:ci`
- [ ] `pnpm test:e2e:web`
- [ ] `bash scripts/validate-changes.sh --dry-run ...`
- [ ] `cd apps/ui/src-tauri && cargo fmt --check`
- [ ] `cd apps/ui/src-tauri && cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cd apps/ui/src-tauri && cargo check --all-targets --all-features`

## Test details

- Format and lint pass cleanly.
- The race condition is not reliably reproducible in a test environment (requires a specific React remount timing against Monaco's model registry), so no new unit test was added. The fix is a defensive guard that is safe to add regardless.
- Browser preview skipped: this is a crash-path fix with no visual change observable in a happy-path preview.

# Performance

## Performance impact

- [x] No meaningful performance impact is expected

## Justification

- `monaco.editor.getModel()` is a synchronous O(1) map lookup — negligible overhead per tab switch.

# UI changes

## Screenshots or recordings

- N/A

# Issue link

- Closes OPENSCAD-STUDIO-2B