### PR TITLE
Add OpenSCAD Studio agent skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ OpenSCAD Studio is a professional editor for OpenSCAD — the programmable solid
 
 ### AI Copilot
 - **In-app chat** — Stream responses from Claude or GPT to generate, explain, and fix OpenSCAD code (bring your own API key)
-- **MCP support (desktop)** — Exposes a localhost MCP server so external agents like [Claude Code](https://claude.ai/code) can render models, read diagnostics, capture screenshots, and edit files in your active workspace
+- **MCP support (desktop)** — Exposes a localhost MCP server so external agents like [Claude Code](https://claude.ai/code) can edit files in your repo, then use Studio for render-target selection, diagnostics, render refreshes, screenshots, and exports
 
 ### Platform
-- **Runs everywhere** — Web app at [openscad-studio.pages.dev](https://openscad-studio.pages.dev) and macOS desktop app 
+- **Runs everywhere** — Web app at [openscad-studio.pages.dev](https://openscad-studio.pages.dev) and macOS desktop app
 - **Share links** — Publish browser-based share links with thumbnail previews for remixable examples
 
 **Known limitation:** Special operators (`!`, `#`, `%`, `*`) are not yet reflected in the preview.

--- a/apps/ui/src/components/WelcomeScreen.tsx
+++ b/apps/ui/src/components/WelcomeScreen.tsx
@@ -3,10 +3,17 @@ import type { ModelSelectionSurface } from '../analytics/runtime';
 import { Button, Text } from './ui';
 import { AiComposer } from './AiComposer';
 import { ModelSelector } from './ModelSelector';
-import { TbFileText, TbFolder, TbFolderOpen } from 'react-icons/tb';
+import {
+  TbExternalLink,
+  TbFileText,
+  TbFolder,
+  TbFolderOpen,
+  TbPlugConnected,
+} from 'react-icons/tb';
 import { getPlatform } from '../platform';
 import { useHasApiKey } from '../stores/apiKeyStore';
 import type { AiDraft, AttachmentStore } from '../types/aiChat';
+import { buildSkillInstallCommand, OPENSCAD_STUDIO_SKILL_URL } from '../services/desktopMcp';
 import {
   loadRecentFiles,
   removeRecentFile,
@@ -82,6 +89,8 @@ export function WelcomeScreen({
   const [recentFiles, setRecentFiles] = useState<RecentFile[]>([]);
   const [recentFilesReady, setRecentFilesReady] = useState(!showRecentFiles);
   const hasApiKey = useHasApiKey();
+  const isDesktop = getPlatform().capabilities.hasFileSystem;
+  const skillInstallCommand = buildSkillInstallCommand();
 
   // Shorten home directory to ~/ for display
   const displayPath = useMemo(() => {
@@ -267,6 +276,65 @@ export function WelcomeScreen({
               </a>{' '}
               to configure (⌘,)
             </Text>
+          </div>
+        ) : null}
+
+        {isDesktop ? (
+          <div
+            className="rounded-lg border p-4 ph-no-capture"
+            style={{
+              backgroundColor: 'var(--bg-secondary)',
+              borderColor: 'var(--border-secondary)',
+            }}
+            data-testid="welcome-mcp-skill"
+          >
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex min-w-0 items-start gap-3">
+                <div
+                  className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-lg"
+                  style={{
+                    backgroundColor: 'var(--bg-tertiary)',
+                    color: 'var(--accent-primary)',
+                  }}
+                  aria-hidden="true"
+                >
+                  <TbPlugConnected size={18} />
+                </div>
+                <div className="min-w-0 space-y-1">
+                  <Text variant="body" weight="medium">
+                    Work with external agents
+                  </Text>
+                  <Text variant="caption" color="tertiary">
+                    Install the Studio skill, connect MCP in settings, then bind an agent to this
+                    workspace.
+                  </Text>
+                  <Text as="code" variant="caption" className="block truncate font-mono">
+                    {skillInstallCommand}
+                  </Text>
+                </div>
+              </div>
+
+              <div className="flex shrink-0 flex-wrap gap-2">
+                <a
+                  href={OPENSCAD_STUDIO_SKILL_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 rounded-lg px-3 py-2 text-sm underline hover:no-underline"
+                  style={{ color: 'var(--accent-primary)' }}
+                >
+                  Install skill
+                  <TbExternalLink size={14} />
+                </a>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  onClick={() => onOpenSettings?.()}
+                  className="text-sm"
+                >
+                  Open MCP setup
+                </Button>
+              </div>
+            </div>
           </div>
         ) : null}
 

--- a/apps/ui/src/components/__tests__/SettingsDialog.test.tsx
+++ b/apps/ui/src/components/__tests__/SettingsDialog.test.tsx
@@ -47,6 +47,8 @@ jest.unstable_mockModule('@/stores/layoutStore', () => ({
 }));
 
 jest.unstable_mockModule('@/services/desktopMcp', () => ({
+  buildSkillInstallCommand: () =>
+    'npx skills add https://github.com/zacharyfmarion/openscad-studio --skill openscad-studio',
   buildClaudeMcpCommand: (port: number) =>
     `claude mcp add --transport http --scope user openscad-studio http://127.0.0.1:${port}/mcp`,
   buildCodexMcpCommand: (port: number) =>
@@ -68,6 +70,7 @@ jest.unstable_mockModule('@/services/desktopMcp', () => ({
     }
   }
 }`,
+  OPENSCAD_STUDIO_SKILL_URL: 'https://skills.sh/zacharyfmarion/openscad-studio/openscad-studio',
   getDesktopMcpStatus: (...args: unknown[]) => mockGetDesktopMcpStatus(...args),
   syncDesktopMcpConfig: (...args: unknown[]) => mockSyncDesktopMcpConfig(...args),
 }));
@@ -233,6 +236,12 @@ describe('SettingsDialog privacy copy', () => {
     expect(screen.getByRole('tab', { name: /Codex/i })).toBeTruthy();
     expect(screen.getByRole('tab', { name: /Cursor/i })).toBeTruthy();
     expect(screen.getByRole('tab', { name: /OpenCode/i })).toBeTruthy();
+    expect(screen.getByTestId('studio-skill-install')).toBeTruthy();
+    expect(screen.getByText(/npx skills add https:\/\/github\.com\/zacharyfmarion/i)).toBeTruthy();
+    expect(screen.getByRole('link', { name: /Open on skills\.sh/i })).toHaveAttribute(
+      'href',
+      'https://skills.sh/zacharyfmarion/openscad-studio/openscad-studio'
+    );
     expect(screen.getByText(/claude mcp add --transport http --scope user/i)).toBeTruthy();
     expect(screen.getAllByText(/get_or_create_workspace/i).length).toBeGreaterThan(0);
     expect(screen.getAllByRole('button', { name: 'Copy' }).length).toBeGreaterThanOrEqual(2);

--- a/apps/ui/src/components/__tests__/WelcomeScreen.test.tsx
+++ b/apps/ui/src/components/__tests__/WelcomeScreen.test.tsx
@@ -1,6 +1,6 @@
 /** @jest-environment jsdom */
 
-import { screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { jest } from '@jest/globals';
 import { clearApiKey, storeApiKey } from '../../stores/apiKeyStore';
 import { renderWithProviders } from './test-utils';
@@ -79,6 +79,7 @@ describe('WelcomeScreen', () => {
     );
 
     expect(screen.getByTestId('welcome-ai-entry').className).toContain('ph-no-capture');
+    expect(screen.queryByTestId('welcome-mcp-skill')).toBeNull();
     const combobox = await screen.findByRole('combobox');
     expect(combobox).toBeTruthy();
     await waitFor(() => {
@@ -123,9 +124,10 @@ describe('WelcomeScreen', () => {
     ]);
   });
 
-  it('keeps the desktop no-key welcome state focused on API key setup only', async () => {
+  it('shows compact desktop MCP skill setup in the no-key welcome state', async () => {
     clearApiKey('openai');
     clearApiKey('anthropic');
+    const onOpenSettings = jest.fn();
     mockGetPlatform.mockReturnValue({
       capabilities: { hasFileSystem: true },
       fileExists: jest.fn(async () => false),
@@ -144,12 +146,23 @@ describe('WelcomeScreen', () => {
         onStartWithDraft={() => {}}
         onStartManually={() => {}}
         onOpenRecent={async () => 'opened'}
-        onOpenSettings={() => {}}
+        onOpenSettings={onOpenSettings}
         showRecentFiles={false}
       />
     );
 
     expect(screen.getByText('Set up an API key to use the AI assistant')).toBeTruthy();
     expect(screen.queryByText('Claude Code')).toBeNull();
+    expect(screen.getByTestId('welcome-mcp-skill')).toBeTruthy();
+    expect(screen.getByText(/npx skills add https:\/\/github\.com\/zacharyfmarion/i)).toBeTruthy();
+
+    const skillLink = screen.getByRole('link', { name: /Install skill/i });
+    expect(skillLink).toHaveAttribute(
+      'href',
+      'https://skills.sh/zacharyfmarion/openscad-studio/openscad-studio'
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Open MCP setup/i }));
+    expect(onOpenSettings).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/ui/src/components/settings/ExternalAgentsCard.tsx
+++ b/apps/ui/src/components/settings/ExternalAgentsCard.tsx
@@ -3,7 +3,9 @@ import { Button, Input, Text, Toggle } from '../ui';
 import type { Settings } from '../../stores/settingsStore';
 import { updateSetting } from '../../stores/settingsStore';
 import {
+  buildSkillInstallCommand,
   getDesktopMcpStatus,
+  OPENSCAD_STUDIO_SKILL_URL,
   syncDesktopMcpConfig,
   type McpServerStatus,
 } from '../../services/desktopMcp';
@@ -92,6 +94,7 @@ export function ExternalAgentsCard({ settings, isOpen }: ExternalAgentsCardProps
   }, [isOpen, refreshStatus]);
 
   const endpoint = status.endpoint ?? `http://127.0.0.1:${status.port}/mcp`;
+  const skillInstallCommand = buildSkillInstallCommand();
 
   const copyText = useCallback(async (label: string, value: string) => {
     try {
@@ -257,6 +260,56 @@ export function ExternalAgentsCard({ settings, isOpen }: ExternalAgentsCardProps
               size="sm"
               variant="ghost"
               onClick={() => void copyText('Endpoint', endpoint)}
+            >
+              Copy
+            </Button>
+          </div>
+        </SettingsSupportBlock>
+
+        <SettingsSupportBlock
+          className="flex flex-col"
+          style={{ gap: 'var(--space-helper-gap)' }}
+          data-testid="studio-skill-install"
+        >
+          <div
+            className="flex items-start justify-between"
+            style={{ gap: 'var(--space-control-gap)' }}
+          >
+            <div className="flex min-w-0 flex-col" style={{ gap: 'var(--space-1)' }}>
+              <Text variant="caption" weight="semibold">
+                Studio Skill
+              </Text>
+              <Text variant="caption" color="tertiary">
+                Install the agent skill, connect this MCP endpoint, then have the agent call{' '}
+                <Text as="code" variant="caption" className="font-mono">
+                  get_or_create_workspace
+                </Text>{' '}
+                before render tools.
+              </Text>
+            </div>
+            <a
+              href={OPENSCAD_STUDIO_SKILL_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="shrink-0 text-xs underline hover:no-underline"
+              style={{ color: 'var(--accent-primary)' }}
+            >
+              Open on skills.sh
+            </a>
+          </div>
+
+          <div
+            className="flex items-center justify-between"
+            style={{ gap: 'var(--space-control-gap)' }}
+          >
+            <Text as="code" variant="caption" className="font-mono break-all">
+              {skillInstallCommand}
+            </Text>
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              onClick={() => void copyText('Skill install command', skillInstallCommand)}
             >
               Copy
             </Button>

--- a/apps/ui/src/services/desktopMcp.ts
+++ b/apps/ui/src/services/desktopMcp.ts
@@ -150,6 +150,9 @@ const DEFAULT_STATUS: McpServerStatus = {
   message: null,
 };
 
+export const OPENSCAD_STUDIO_SKILL_URL =
+  'https://skills.sh/zacharyfmarion/openscad-studio/openscad-studio';
+
 function isDesktopTauri(): boolean {
   return typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
 }
@@ -1163,6 +1166,10 @@ export function buildOpenCodeMcpConfig(port: number): string {
     }
   }
 }`;
+}
+
+export function buildSkillInstallCommand(): string {
+  return 'npx skills add https://github.com/zacharyfmarion/openscad-studio --skill openscad-studio';
 }
 
 export function buildAgentSnippet(port: number): string {

--- a/implementation-plans/openscad-studio-agent-skill.md
+++ b/implementation-plans/openscad-studio-agent-skill.md
@@ -1,0 +1,35 @@
+# OpenSCAD Studio Agent Skill
+
+## Goal
+
+Publish an installable `openscad-studio` Agent Skill from this repository and surface skill installation alongside the desktop MCP onboarding UI.
+
+## Approach
+
+- Add a standalone skill package under `skills/openscad-studio/` with metadata, license, and guidance aligned with the current Studio MCP tools and in-app AI prompt.
+- Add skills.sh repository metadata so the skill can be discovered and installed from the public repo.
+- Add shared install helper constants/functions and show the skill install command/link in desktop MCP onboarding surfaces.
+- Update README copy so MCP is described as render-oriented feedback while external agents keep file edits in the repo.
+- Update component tests and run targeted validation, followed by the shared repo validation script when feasible.
+
+## Affected Areas
+
+- `skills/openscad-studio/`
+- `skills.sh.json`
+- `apps/ui/src/services/desktopMcp.ts`
+- `apps/ui/src/components/settings/ExternalAgentsCard.tsx`
+- `apps/ui/src/components/WelcomeScreen.tsx`
+- `apps/ui/src/components/__tests__/SettingsDialog.test.tsx`
+- `apps/ui/src/components/__tests__/WelcomeScreen.test.tsx`
+- `README.md`
+
+## Checklist
+
+- [x] Add the skill package and skills.sh metadata
+- [x] Add shared skill install helpers
+- [x] Surface skill installation in settings MCP onboarding
+- [x] Surface skill installation on the desktop welcome screen
+- [x] Update README MCP copy
+- [x] Update tests for new onboarding copy
+- [x] Validate skill installation listing
+- [x] Run formatting, linting, type checking, and targeted tests

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -1,0 +1,8 @@
+{
+  "groups": [
+    {
+      "name": "OpenSCAD Studio",
+      "skills": ["openscad-studio"]
+    }
+  ]
+}

--- a/skills/openscad-studio/LICENSE.txt
+++ b/skills/openscad-studio/LICENSE.txt
@@ -1,0 +1,338 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Moe Ghoul>, 1 April 1989
+  Moe Ghoul, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/skills/openscad-studio/SKILL.md
+++ b/skills/openscad-studio/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: openscad-studio
+description: Use this skill when working on OpenSCAD models in a repository that can be opened in OpenSCAD Studio, especially when the user wants external-agent help with rendering, diagnostics, screenshots, exports, or validation through the Studio desktop MCP server. This skill teaches the agent to edit files directly in the repo, then use OpenSCAD Studio MCP for render-oriented feedback.
+license: GPL-2.0-only
+metadata:
+  short-description: Work with OpenSCAD Studio over MCP
+---
+
+# OpenSCAD Studio
+
+OpenSCAD Studio is a desktop editor with a loopback-only MCP server for external agents. Use normal filesystem tools to inspect and edit project files. Use Studio MCP for workspace binding, render-target selection, diagnostics, render refreshes, 3D screenshots, and exports.
+
+## Requirements
+
+- OpenSCAD Studio desktop must be running.
+- The local MCP server must be enabled in Studio settings. The default endpoint is `http://127.0.0.1:32123/mcp`; users can change the port in Settings > AI Assistant > External Agents.
+- The MCP server is render-oriented. It does not expose file-reading or file-editing tools. Read and edit files directly in the repository with your normal agent tools.
+
+## MCP Tools
+
+- `get_or_create_workspace({ "folder_path": "/absolute/project/path" })`: bind this MCP session to the exact project folder. Call this before other Studio tools.
+- `get_project_context()`: check the bound Studio window, workspace root, render target, window mode, and startup status.
+- `set_render_target({ "file_path": "relative/path.scad" })`: choose the workspace-relative file Studio compiles and previews.
+- `get_diagnostics()`: render the current target and report errors or warnings without treating compile errors as MCP transport failures.
+- `trigger_render()`: render the current target, refresh the preview, and fail the tool call when render errors remain.
+- `get_preview_screenshot({ "view": "isometric" })`: capture a PNG from the latest settled 3D render. Valid views are `front`, `back`, `top`, `bottom`, `left`, `right`, and `isometric`. 2D SVG previews are not supported by this screenshot tool.
+- `export_file({ "format": "stl", "file_path": "exports/part.stl" })`: export the current render target to `stl`, `obj`, `amf`, `3mf`, `svg`, or `dxf`. Use an absolute output path, or a workspace-relative path when a workspace root is open.
+
+## Workflow
+
+1. Bind the session with `get_or_create_workspace` using the absolute repo or project folder path.
+2. Use `get_project_context` to confirm the workspace and active render target.
+3. Inspect and edit `.scad` files directly in the repo. Keep changes focused and preserve unrelated user edits.
+4. If the wrong entry point is active, call `set_render_target` with the desired workspace-relative `.scad` path.
+5. After edits, call `get_diagnostics`. Fix errors before claiming success.
+6. Call `trigger_render` for final validation. For visual checks on 3D models, call `get_preview_screenshot` after a successful render.
+7. Use `export_file` only after diagnostics and render validation are clean, unless the user explicitly asks to export the current failing state.
+
+If a Studio tool reports that no workspace is bound or no render target is active, call `get_or_create_workspace` again and then set the render target.
+
+## OpenSCAD Editing Guidance
+
+- Prefer small, reviewable edits over full rewrites.
+- Keep precise fabrication intent intact: dimensions, tolerances, coordinate systems, module boundaries, and `include`/`use` paths matter.
+- Multi-file projects compile only the active render target. Supporting files are available through `include` and `use`; validate the entry point the user cares about.
+- If the user provides an annotated screenshot, treat drawn circles, boxes, arrows, or marks as intentional guidance about what to inspect or change. Do not treat annotation marks as model geometry.
+- When creating or refactoring user-customizable designs, place user-facing parameters as top-level literal assignments before modules/functions.
+- For numeric parameters, prefer OpenSCAD customizer ranges such as `width = 60; // [40:120]` or `wall = 2.4; // [1.2:0.2:4]`.
+- For option parameters, prefer dropdown syntax such as `lid_style = "snap"; // [snap, friction, screw]`.
+- Group related controls with customizer tabs such as `/* [Dimensions] */` and add `// @studio {...}` metadata only for important user-facing controls.
+- Prefer realistic, printable defaults and ranges.
+
+## Reporting Back
+
+Summarize:
+
+- Files changed and why.
+- Active render target.
+- Diagnostics/render outcome.
+- Screenshot or export paths when produced.
+- Any remaining manual checks or Studio/MCP limitations.

--- a/skills/openscad-studio/agents/openai.yaml
+++ b/skills/openscad-studio/agents/openai.yaml
@@ -1,0 +1,16 @@
+interface:
+  display_name: 'OpenSCAD Studio'
+  short_description: 'Render and validate OpenSCAD models'
+  brand_color: '#2AA198'
+  default_prompt: 'Use $openscad-studio to edit this OpenSCAD project and validate it in OpenSCAD Studio.'
+
+dependencies:
+  tools:
+    - type: 'mcp'
+      value: 'openscad-studio'
+      description: 'OpenSCAD Studio desktop MCP server'
+      transport: 'streamable_http'
+      url: 'http://127.0.0.1:32123/mcp'
+
+policy:
+  allow_implicit_invocation: true


### PR DESCRIPTION
# Summary

## What changed

- Added a public `openscad-studio` Agent Skill package under `skills/openscad-studio/` with MCP workflow guidance, OpenAI metadata, and standalone GPL license.
- Added skills.sh metadata and shared install helpers for the skills.sh URL and `npx skills add ... --skill openscad-studio` command.
- Surfaced Studio Skill install/setup guidance in the desktop welcome screen and AI settings External Agents card.
- Corrected README MCP copy to clarify that agents edit repo files directly and use Studio MCP for render-oriented feedback.

## Why

- Users should be able to install a dedicated OpenSCAD Studio skill from skills.sh and connect external agents to the app's existing MCP endpoint without reverse-engineering the setup.

## Implementation notes

- Implementation plan: `implementation-plans/openscad-studio-agent-skill.md`
- The skill intentionally does not claim MCP exposes file-read or file-edit tools; it directs agents to use normal repo file access and Studio MCP for render target, diagnostics, render, screenshot, and export operations.

# Testing

## Coverage checklist

- [ ] Backend unit tests added or updated for changed Rust behavior
- [x] Client unit/component tests added or updated for changed frontend behavior
- [ ] E2E tests added or updated for net new user-facing flows
- [ ] No new tests were needed for this change

## Validation performed

- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm test:unit`
- [ ] `pnpm test:formatter:ci`
- [ ] `pnpm test:e2e:web`
- [ ] `bash scripts/validate-changes.sh --dry-run ...`
- [ ] `cd apps/ui/src-tauri && cargo fmt --check`
- [ ] `cd apps/ui/src-tauri && cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cd apps/ui/src-tauri && cargo check --all-targets --all-features`

## Test details

- Ran `npx skills add . --list` and verified `openscad-studio` appears.
- Ran a temp install with `HOME=/tmp/openscad-skills-home npx skills add . --skill openscad-studio -g -a universal -y --copy` and verified only the `openscad-studio` skill was installed.
- Ran targeted component tests for `WelcomeScreen` and `SettingsDialog`.
- Ran `bash scripts/validate-changes.sh --scope baseline`, which completed `pnpm format:check`, `pnpm lint`, `pnpm type-check`, and `pnpm test:unit` successfully.
- Formatter, E2E, and Rust-specific validation were skipped because this change does not touch formatter logic, E2E-only flows, or Rust behavior.

# Performance

## Performance impact

- [x] Performance was considered for this change
- [ ] No meaningful performance impact is expected

## Justification

- No runtime-heavy paths were changed. The new UI work adds static copy, links, and shared string helpers only.

# UI changes

## Screenshots or recordings

- N/A

# Issue link

- Closes #
