### PR TITLE
docs: refresh current project documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,15 +256,13 @@ pnpm validate:changes   # Run the shared validation helper
 
 ### Adding or Modifying Themes
 
-**Current Themes (27 total):**
+**Current Themes (22 total):**
 
-- Classic: Solarized Dark/Light
-- Popular Dark: Monokai, Dracula, One Dark Pro, GitHub Dark, Tokyo Night, Ayu Dark, Material Palenight, Night Owl
-- Popular Light: GitHub Light, Atom One Light
-- Pastel & Cozy: Nord, Catppuccin Mocha, Rosé Pine
-- Vibrant & Fun: Synthwave '84, Shades of Purple, Cobalt2, Horizon
-- Nature Inspired: Everforest Dark
-- Retro: Gruvbox Dark/Light
+- Dark: Solarized Dark, Monokai, Dracula, One Dark Pro, GitHub Dark, Tokyo Night
+- Light: Solarized Light, GitHub Light, Gruvbox Light, Atom One Light
+- Cool: Nord, Ayu Dark, Material Palenight, Night Owl, Everforest Dark
+- Warm: Gruvbox Dark, Catppuccin Mocha, Rosé Pine, Horizon
+- Vibrant: Synthwave '84, Shades of Purple, Cobalt2
 
 **To add a new theme:**
 
@@ -329,7 +327,7 @@ pnpm validate:changes   # Run the shared validation helper
 ✅ Multi-turn AI chat with draft and attachment state
 ✅ Customizer panel with interactive parameter controls
 ✅ Tree-sitter based parameter parsing
-✅ 27 editor themes with categorized dropdown
+✅ 22 editor themes with categorized dropdown
 ✅ Vim mode with configurable keybindings
 ✅ Web version (openscad-studio.pages.dev)
 ✅ Platform abstraction (PlatformBridge interface)
@@ -352,7 +350,6 @@ pnpm validate:changes   # Run the shared validation helper
 - Special operators preview (`#`, `%`, `*`, `!`)
 - Additional preview/render polish
 - Cross-platform desktop testing (Windows/Linux)
-- Code signing for macOS
 - Auto-update mechanism
 
 ## Known Issues & Gotchas
@@ -405,5 +402,5 @@ pnpm validate:changes   # Run the shared validation helper
 
 ---
 
-**Last Updated**: 2026-04-28
+**Last Updated**: 2026-05-31
 **Current Version**: v1.2.2 — Web + Desktop

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -113,7 +113,7 @@ openscad-studio/
 │   │   │   │   └── webBridge.ts # Web implementation
 │   │   │   ├── services/        # Render services (WASM + native), AI service, OpenSCAD worker
 │   │   │   ├── stores/          # Zustand state (project files, workspace, settings)
-│   │   │   └── themes/          # 27 editor themes
+│   │   │   └── themes/          # 22 editor themes
 │   │   └── src-tauri/           # Rust backend (desktop only)
 │   └── web/                     # Web app entry point (Vite)
 └── packages/

--- a/PRE_RELEASE_CHECKLIST.md
+++ b/PRE_RELEASE_CHECKLIST.md
@@ -1,6 +1,6 @@
 # Pre-Release Checklist for OpenSCAD Studio
 
-This checklist captures the initial open-source launch work. It is primarily historical context now, not the source of truth for the current app architecture or release workflow. For current behavior, use `README.md`, `DEVELOPMENT.md`, `AGENTS.md`, and `CLAUDE.md`.
+This checklist captures the initial open-source launch work. It is primarily historical context now, not the source of truth for the current app architecture or release workflow. For current behavior, use `README.md`, `DEVELOPMENT.md`, `AGENTS.md`, `CLAUDE.md`, and `scripts/README.md`.
 
 ## ✅ Completed
 
@@ -88,7 +88,7 @@ This checklist captures the initial open-source launch work. It is primarily his
   - [x] Settings dialog saves preferences
   - [x] Theme switching works
   - [x] AI copilot can be configured (with test API key)
-  - [x] AI tools work (get_current_code, apply_edit, etc.)
+  - [x] AI tools work (`get_project_context`, `read_file`, `apply_edit`, etc.)
   - [x] Diagnostics panel shows errors correctly
   - [x] Keyboard shortcuts work (⌘K, ⌘T, ⌘W, etc.)
   - [x] Recent files list works
@@ -108,8 +108,6 @@ This checklist captures the initial open-source launch work. It is primarily his
 
 - [x] Document known limitations in README:
   - [x] Special operators (`#`, `%`, `*`, `!`) not visually distinguished
-  - [x] No customizer panel for OpenSCAD parameters yet
-  - [x] Preview resolution is fixed at 800x600 (not yet configurable)
   - [x] AI features require API key (no offline mode yet)
   - [x] Only tested on macOS (Windows/Linux pending)
 
@@ -127,7 +125,6 @@ This checklist captures the initial open-source launch work. It is primarily his
   rm -rf apps/*/node_modules/
   rm -rf target/
   rm -rf apps/ui/src-tauri/target/
-  rm -rf apps/sidecar/dist/
   ```
 - [ ] Verify fresh build works:
   ```bash
@@ -146,34 +143,16 @@ This checklist captures the initial open-source launch work. It is primarily his
   - [ ] OpenSCAD forums/Discord
   - [ ] Dev.to / Hashnode
 
-## 🚀 Release Process (Fully Automated)
+## 🚀 Release Process
 
-### One-Time Setup (Required First Time Only)
+The old one-command launch flow has been replaced by the protected-branch-friendly process documented in `scripts/README.md`.
 
-1. Create GitHub Personal Access Token (PAT) with repo scope for `homebrew-openscad-studio`
-2. Add `HOMEBREW_TAP_TOKEN` secret to the openscad-studio repository
-3. Create the `zacharyfmarion/homebrew-openscad-studio` repository with initial cask formula
+Current release flow:
 
-### Release a New Version
-
-```bash
-# Run from project root - this does EVERYTHING
-./scripts/release.sh 0.5.0
-```
-
-The script will:
-
-1. Bump version numbers in all files
-2. Update CHANGELOG.md
-3. Commit and push tag
-
-GitHub Actions will then automatically:
-
-1. Build macOS DMGs (ARM + Intel)
-2. Create a published GitHub Release with artifacts
-3. Update the Homebrew cask formula with new version and SHA256 hashes
-
-**No manual steps required after running the release script.**
+1. Prepare a release PR with `./scripts/release.sh prepare <version>`.
+2. Merge that PR into `main`.
+3. Publish the annotated tag with `./scripts/release.sh publish <version>`.
+4. Let GitHub Actions build, sign, notarize, release, and update the Homebrew cask.
 
 ### Post-Release Verification
 
@@ -244,7 +223,7 @@ git log --all --full-history -- "**/.env.local"
 
 - [ ] All TODOs in code removed or documented in issues
 - [ ] No debug console.log statements in production code
-- [ ] All tests pass (when implemented)
+- [ ] Relevant validation checks pass
 - [ ] Fresh clone builds successfully
 - [ ] LICENSE year is correct (2025)
 - [ ] Contact information is correct (GitHub username, etc.)
@@ -252,6 +231,6 @@ git log --all --full-history -- "**/.env.local"
 
 ---
 
-**Last Updated**: 2026-02-19
+**Last Updated**: 2026-05-31
 
 Once all critical items are checked, you're ready to make the repository public! 🎉

--- a/PRODUCT_ROADMAP.md
+++ b/PRODUCT_ROADMAP.md
@@ -4,7 +4,7 @@
 >
 > OpenSCAD is the engine, not the product. The product is: you describe what you want, it makes it, you print it.
 
-**Current version**: v1.2.2 | **Last updated**: 2026-04-28
+**Current version**: v1.2.2 | **Last updated**: 2026-05-31
 
 This roadmap mixes shipped milestones with future planning. Older sections may describe the implementation assumptions that existed when they were written rather than the current client-side `openscad-wasm` architecture.
 
@@ -24,8 +24,8 @@ This roadmap mixes shipped milestones with future planning. Older sections may d
 
 | Area                                                                                  | Status |
 | ------------------------------------------------------------------------------------- | ------ |
-| Monaco editor with OpenSCAD syntax, 27 themes, vim mode, tree-sitter formatting       | ✅     |
-| Live 3D preview (Three.js mesh viewer, orbit controls, wireframe/solid/section tools) | ✅     |
+| Monaco editor with OpenSCAD syntax, 22 themes, vim mode, tree-sitter formatting       | ✅     |
+| Live 3D preview (Three.js mesh viewer, orbit controls, wireframe/solid/section tools, model colors) | ✅     |
 | 2D SVG mode for laser cutting / engraving                                             | ✅     |
 | AI copilot (Claude + GPT, streaming, tool-calling, diff-based editing, image attachments, auto-rollback) | ✅     |
 | AI can see the 3D preview (screenshot tool returns base64 PNG to vision models)       | ✅     |
@@ -38,7 +38,7 @@ This roadmap mixes shipped milestones with future planning. Older sections may d
 | Desktop app (macOS, Homebrew)                                                         | ✅     |
 | Library path management, include/use resolution, BOSL2 support                        | ✅     |
 | Multi-tab editing, undo/redo checkpoints, conversation persistence                    | ✅     |
-| E2E test suite (Playwright, ~2700 lines, CI on every PR)                              | ✅     |
+| E2E test suite (Playwright, ~3100 lines, CI on every PR)                              | ✅     |
 
 ---
 
@@ -230,24 +230,24 @@ Bake domain knowledge into the AI so it produces print-ready designs.
 
 ### 5.2 Measurement Tools
 
-Essential for verifying that dimensions are correct before printing.
+This shipped in the current product for both 2D and 3D inspection.
 
-- [ ] Bounding box dimensions (toggle X/Y/Z extent labels)
-- [ ] Point-to-point distance measurement (click two points on mesh)
-- [ ] Snap to vertices
-- [ ] Three.js raycasting for point picking
+- [x] Bounding box dimensions with X/Y/Z extent labels
+- [x] Point-to-point distance measurement
+- [x] Snap-assisted measurement placement
+- [x] Three.js raycasting for 3D point picking
 
 ### 5.3 Section / Clipping Plane
 
-- [ ] Toggle button: "Section Plane" in 3D viewer toolbar
-- [ ] Draggable clipping plane using `THREE.Plane`
-- [ ] Useful for inspecting hollow objects, internal cavities, fit checks
+- [x] Section tool in the 3D viewer toolbar
+- [x] Adjustable clipping plane using Three.js clipping
+- [x] Useful for inspecting hollow objects, internal cavities, fit checks
 
 ### 5.4 Color Support
 
-- [ ] Parse `color()` calls from OpenSCAD source
-- [ ] Evaluate AMF/3MF format (supports colors) for preview instead of STL
-- [ ] Minimum viable: single-color override from first `color()` call
+- [x] Render 3D previews through OFF output so OpenSCAD face colors can be preserved
+- [x] Parse OFF face colors into Three.js material groups
+- [x] Add a viewer preference to show model colors or fall back to the theme preview material
 
 **Success criteria**: Users can verify their designs are dimensionally correct and inspect internal geometry without leaving the app.
 

--- a/apps/docs/formatter-architecture.md
+++ b/apps/docs/formatter-architecture.md
@@ -134,7 +134,7 @@ The OpenSCAD language grammar compiled to WASM.
 
 4. **Copy to Project**:
    ```bash
-   cp tree-sitter-openscad.wasm /path/to/openscad-tauri/apps/ui/public/
+   cp tree-sitter-openscad.wasm /path/to/openscad-studio/apps/ui/public/
    ```
 
 **Alternative Method** (without cloning):
@@ -212,197 +212,38 @@ interface FormatOptions {
 - Preserved between comment sections and code
 - Added between top-level module/function declarations
 
-## Known Issues
+## Current Validation
 
-This section documents bugs and issues discovered during comprehensive testing with the official OpenSCAD examples (113 test cases from 48 example files).
+The critical formatter bugs previously documented here are now covered by the fixture suite in `apps/ui/src/utils/formatter/__tests__`.
 
-### Critical Bugs (Break Code - Must Fix)
+- Every file-based formatter test checks idempotence with `format(format(input)) === format(input)`.
+- The fixture set includes regressions for comment newlines, brace-less `if` statements, brace-less module bodies, blank lines in blocks, numeric-prefixed module calls, and inline comments inside keyboard-layout lists.
+- Official OpenSCAD example fixtures live under `fixtures/openscad-examples/`.
+- The integration test compiles a curated subset before and after formatting to catch syntax-breaking output.
 
-#### 1. Non-Idempotent Formatting - Statement Merging
-**Severity**: Critical
-**Status**: Open
-**Affected Files**: `basics/logo.scad`
+Run the dedicated formatter suite with:
 
-**Description**: Formatting the same code multiple times produces different results. In some cases, separate statements on adjacent lines get merged into a single line.
-
-**Example**:
-```openscad
-// Original (formatted once)
-cylinder(d=hole, h=cylinderHeight, center=true);
-#rotate([90, 0, 0]) cylinder(d=hole, h=cylinderHeight, center=true);
-
-// After formatting again (non-idempotent!)
-cylinder(d=hole, h=cylinderHeight, center=true);#rotate([90, 0, 0]) cylinder(d=hole, h=cylinderHeight, center=true);
+```bash
+pnpm test:formatter:ci
 ```
-
-**Root Cause**: Likely missing hardline after statements in certain contexts.
-
-#### 2. Non-Idempotent Formatting - File Truncation
-**Severity**: Critical
-**Status**: Open
-**Affected Files**: `basics/logo_and_text.scad`, `basics/CSG-modules.scad`
-
-**Description**: On repeated formatting, portions of the file get truncated, causing progressive data loss.
-
-**Root Cause**: Unknown - possibly related to EOF handling or tree traversal terminating early.
-
-#### 3. If Statement Bodies Dropped (No Braces)
-**Severity**: Critical
-**Status**: Open
-**Affected Files**: `old/example001.scad`, `old/example021.scad`, `old/example022.scad`, `old/example024.scad`
-
-**Description**: When an if statement doesn't have braces, the child statement is lost during formatting.
-
-**Example**:
-```openscad
-// Original
-if (type == 1) rotate(i*360/n) polygon([...]);
-
-// Formatted (BROKEN!)
-if (type == 1)  // polygon call is lost!
-```
-
-**Root Cause**: `printIfStatement()` in printer.ts:351 doesn't handle brace-less if statements properly.
-
-#### 4. Single-Line Module Definitions Lose Child Calls
-**Severity**: Critical
-**Status**: Open
-**Affected Files**: `advanced/GEB.scad`
-
-**Description**: Module declarations without braces that have child transform chains lose their body.
-
-**Example**:
-```openscad
-// Original
-module G() offset(0.3) text("G", font = "Bitstream Vera Sans:style=Bold", halign = "center", valign = "center", size = 10);
-
-// Formatted (BROKEN!)
-module G()  // body is lost!
-```
-
-**Root Cause**: `printModuleDeclaration()` in printer.ts:186 only handles blocks, not brace-less module bodies.
-
-#### 5. Missing Newlines Before Comments
-**Severity**: Critical
-**Status**: Open
-**Affected Files**: Multiple files in `old/` directory
-
-**Description**: Comments that should be on their own line get concatenated to the previous statement, causing progressive syntax errors on each format pass.
-
-**Example**:
-```openscad
-// Original
-cube(10);
-// This is a comment
-
-// Formatted (BROKEN!)
-cube(10);// This is a comment
-```
-
-**Root Cause**: `printSourceFile()` in printer.ts:143 doesn't ensure hardline before comments.
-
-### Major Issues (Affect Readability)
-
-#### 6. Line Offset Issue
-**Severity**: Major
-**Status**: Open
-**Affected Files**: All files in `advanced/` directory, many in `old/`
-
-**Description**: All content is shifted up by 1-2 lines in the output. Line 2 content appears on line 1, line 3 on line 2, etc.
-
-**Example**:
-```
-Expected Line 2: ""
-Actual Line 2:   "// Size of edge"
-
-Expected Line 3: "// Size of edge"
-Actual Line 3:   "D = 100;"
-```
-
-**Root Cause**: Likely incorrect hardline handling at the start of `printSourceFile()` or missing initial newline.
-
-#### 7. Multi-Line Transformation Chains Collapsed
-**Severity**: Major
-**Status**: Open
-**Affected Files**: `basics/projection.scad`, multiple `old/` files
-
-**Description**: Deeply nested transformation chains that were intentionally formatted across multiple lines get collapsed to single lines, hurting readability.
-
-**Example**:
-```openscad
-// Original (readable)
-color("red")
-    translate([0, 0, -20])
-        linear_extrude(height = 2, center = true)
-            difference() { ... }
-
-// Formatted (hard to read)
-color("red") translate([0, 0, -20]) linear_extrude(height = 2, center = true) difference() { ... }
-```
-
-**Root Cause**: `printTransformChain()` in printer.ts:445 doesn't preserve original multi-line formatting.
-
-### Style Differences (May Update Expected Files)
-
-These are consistent formatting differences that may be acceptable - we need to decide whether to:
-1. Update expected test files to match formatter output, OR
-2. Add configuration options for style preferences
-
-#### 8. Brace Style
-- **Expected**: K&R style (opening brace on next line)
-- **Actual**: One True Brace style (opening brace on same line)
-
-```openscad
-// Expected (K&R)
-module foo()
-{
-  ...
-}
-
-// Actual (1TBS)
-module foo() {
-  ...
-}
-```
-
-#### 9. Indentation Width
-- **Expected**: 2 spaces (many `old/` examples)
-- **Actual**: 4 spaces (default setting)
-
-#### 10. Operator Spacing
-- **Expected**: No spaces in some contexts (`360*i/6`, `center=true`)
-- **Actual**: Spaces around all binary operators (`360 * i / 6`, `center = true`)
-
-#### 11. Named Parameter Spacing
-- **Expected**: No space around `=` (`center=true`)
-- **Actual**: Spaces around `=` (`center = true`)
-
-#### 12. Child Statement Placement
-- **Expected**: Sometimes on same line as parent
-- **Actual**: New line after opening brace
 
 ## Known Limitations
 
-1. **Blank lines within blocks**: Currently not preserved. The formatter doesn't track original line spacing within function bodies.
+1. **Blank-line fidelity**: Common blank-line cases are covered by fixtures, but the formatter still does not attempt full trivia-preserving reconstruction for every possible layout.
 
 2. **Complex expressions**: Very long expressions might not wrap optimally.
 
-3. **Comments**: Inline comments are preserved but not reformatted.
+3. **Comments**: Inline comments are preserved but not reflowed or aligned.
 
 4. **Print width**: The `printWidth` option exists but line breaking based on width is not yet implemented.
 
 ## Debugging
 
-Enable debug logs by checking the browser console. The formatter logs:
-- Unknown node types encountered
-- Module/function declaration processing
-- Array/list formatting decisions
+Enable debug logs by checking the browser console. The formatter logs unknown node types and parser initialization or error state.
 
 Example log output:
 ```
 [Formatter] Unknown node type: "foo", text: "..."
-[Formatter] Unary expression: operator="-", operand="1"
-[Formatter] List has 3 items
 ```
 
 ## Performance Considerations

--- a/engineering-roadmap.md
+++ b/engineering-roadmap.md
@@ -257,7 +257,7 @@
 - [ ] Default: 120 lines (current behavior)
 - [ ] Allow increase to 250 or 500 for users who want full-file generation
 - [ ] Setting in `SettingsDialog.tsx` → AI tab
-- [ ] Update `validate_edit()` in `ai_tools.rs` to read from settings
+- [ ] Add frontend settings plumbing for the AI edit size policy and make `apply_edit` validation read from it
 
 **Success criteria:** AI chat renders beautifully. Users can reference images and past conversations. AI understands multi-file projects. Common operations are one-click.
 
@@ -275,33 +275,26 @@
 - [ ] Cap at 2x device pixel ratio for retina displays
 - [ ] Debounce resize-triggered re-renders (300ms)
 
-### 6.2: Section/Clipping Plane
+### ✅ 6.2: Section/Clipping Plane (COMPLETED)
 
-- [ ] Add a toggle button to the 3D viewer toolbar: "Section Plane"
-- [ ] When enabled: render a draggable clipping plane using `THREE.Plane`
-- [ ] Controls: drag to move plane position, rotate to change orientation
-- [ ] Useful for inspecting hollow objects, internal cavities, fit checks
-- [ ] Three.js `clippingPlanes` on material is the standard approach
+- [x] Add a section tool to the 3D viewer toolbar
+- [x] Render an adjustable clipping plane using Three.js clipping
+- [x] Provide axis, offset, invert, keyboard, and reset controls
+- [x] Useful for inspecting hollow objects, internal cavities, fit checks
 
-### 6.3: Color Support from OpenSCAD
+### ✅ 6.3: Color Support from OpenSCAD (COMPLETED)
 
-- [ ] Parse `color()` calls from OpenSCAD source code
-- [ ] When rendering STL: OpenSCAD doesn't embed colors, so this requires either:
-  - Option A: Use AMF/3MF format (supports colors) for preview instead of STL
-  - Option B: Parse color from source and apply to Three.js materials by geometry group
-- [ ] Evaluate AMF/3MF support in Three.js loaders
-- [ ] Minimum viable: single-color override from first `color()` call in source
+- [x] Render 3D previews as OFF rather than STL so OpenSCAD face colors can be carried into the viewer
+- [x] Parse OFF face colors into material groups, including alpha
+- [x] Provide a viewer preference for model colors versus theme fallback material
 
-### 6.4: Measurement Tools
+### ✅ 6.4: Measurement Tools (COMPLETED)
 
-- [ ] Point-to-point distance measurement:
-  - Click two points on the mesh surface
-  - Display distance with a line and label
-  - Snap to vertices
-- [ ] Bounding box dimensions:
-  - Toggle to show X/Y/Z extent labels
-  - Display total size in current units
-- [ ] Three.js raycasting for point picking
+- [x] Point-to-point distance measurement in 3D
+- [x] 2D SVG distance measurement workflow
+- [x] Measurement overlays with labels and selected-measurement controls
+- [x] Bounding box dimensions displayed in current units
+- [x] Snap-assisted placement and Three.js raycasting for point picking
 
 ### 6.5: Special Operator Preview
 
@@ -577,12 +570,12 @@ Decisions made during roadmap planning that affect ordering:
 
 5. **No collaborative editing before 1.0.** CRDT/Yjs is a massive undertaking. It's not what users are asking for first. Save it for post-1.0 when there's a user base that wants to share.
 
-6. **E2E tests before more features.** Investing in a comprehensive Playwright test suite before building new features ensures regressions are caught early. The ~2700-line test suite covers all critical paths.
+6. **E2E tests before more features.** Investing in a comprehensive Playwright test suite before building new features ensures regressions are caught early. The ~3100-line test suite covers all critical paths.
 
 7. **Library management before AI multi-file context.** Building `include`/`use` resolution at the render pipeline level first means the AI can later leverage the same infrastructure for project context, rather than duplicating resolution logic.
 
 ---
 
-**Last Updated:** 2026-04-19
-**Current Phase:** v1.2.1 — web + desktop app shipping with sharing, analytics/privacy controls, formatter coverage, advanced viewer tooling, and desktop MCP support for external agents
+**Last Updated:** 2026-05-31
+**Current Phase:** v1.2.2 — web + desktop app shipping with sharing, analytics/privacy controls, formatter coverage, advanced viewer tooling, model colors, and desktop MCP support for external agents
 **Next Milestone:** Phase 4B.1/4B.3 (App.tsx decomposition, centralized state) or Phase 5 (AI experience) based on user feedback


### PR DESCRIPTION
# Summary

## What changed

- Refreshed maintained assistant/developer docs to match current v1.2.2 status.
- Updated roadmap entries for shipped model colors, section planes, and 2D/3D measurement tooling.
- Replaced stale formatter critical-bug notes with the current fixture and integration validation coverage.
- Pointed the historical pre-release checklist at the current protected-branch release flow.

## Why

- The documentation updater audit found stale counts, shipped features still listed as future work, and old release/formatter notes.

## Implementation notes

- README.md was intentionally left unchanged to keep it user-facing and avoid adding maintainer-only details.
- No code changes were made.

# Testing

## Coverage checklist

- [ ] Backend unit tests added or updated for changed Rust behavior
- [ ] Client unit/component tests added or updated for changed frontend behavior
- [ ] E2E tests added or updated for net new user-facing flows
- [x] No new tests were needed for this change

## Validation performed

- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm test:unit`
- [x] `pnpm test:formatter:ci`
- [ ] `pnpm test:e2e:web`
- [ ] `bash scripts/validate-changes.sh --dry-run ...`
- [ ] `cd apps/ui/src-tauri && cargo fmt --check`
- [ ] `cd apps/ui/src-tauri && cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cd apps/ui/src-tauri && cargo check --all-targets --all-features`

## Test details

- Ran `bash scripts/validate-changes.sh --changed-file CLAUDE.md --changed-file DEVELOPMENT.md --changed-file PRE_RELEASE_CHECKLIST.md --changed-file PRODUCT_ROADMAP.md --changed-file apps/docs/formatter-architecture.md --changed-file engineering-roadmap.md`, which completed format, lint, type-check, and unit tests.
- Ran `pnpm test:formatter:ci` because the formatter architecture documentation now references the current formatter validation coverage.
- Skipped E2E because this is documentation-only.

# Performance

## Performance impact

- [x] Performance was considered for this change
- [x] No meaningful performance impact is expected

## Justification

- Documentation-only changes do not affect runtime behavior.

# UI changes

## Screenshots or recordings

- N/A

# Issue link

- Closes #
