### PR TITLE
docs: refresh current project documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ openscad-studio/
 │   │   ├── src/                    # Shared React frontend
 │   │   │   ├── components/         # React components
 │   │   │   │   ├── Editor.tsx      # Monaco code editor
-│   │   │   │   ├── Preview.tsx     # Preview pane (STL/SVG)
+│   │   │   │   ├── Preview.tsx     # Preview pane (OFF/SVG)
 │   │   │   │   ├── ThreeViewer.tsx # 3D mesh viewer
 │   │   │   │   ├── AiPromptPanel.tsx # AI chat interface
 │   │   │   │   ├── ErrorBoundary.tsx # Crash recovery UI
@@ -114,7 +114,7 @@ Local MCP client → Tauri MCP server (`mcp.rs`) → active workspace window bri
 2. **Multi-file Projects**: Projects can contain multiple `.scad` files with a designated render target. The desktop app manages project directories and resolves `include`/`use` paths against the project root.
 
 3. **Multi-format Preview**:
-   - Interactive STL/3D mesh for manipulation
+   - Interactive OFF-based 3D mesh for manipulation and model colors
    - SVG for 2D designs
 
 4. **Shared Client-Side AI**: Both web and desktop use the same frontend AI stack for the in-app copilot. Requests are made directly from the React app with Vercel AI SDK's `streamText`, and API keys are currently stored in obfuscated localStorage-backed state inside the browser/webview.
@@ -134,7 +134,7 @@ Local MCP client → Tauri MCP server (`mcp.rs`) → active workspace window bri
 - **`apps/ui/src/hooks/useOpenScad.ts`**: Core rendering logic. Orchestrates both WASM (web) and native binary (desktop) rendering, debouncing, and diagnostics parsing.
 - **`apps/ui/src/hooks/useAiAgent.ts`**: AI agent communication. Handles streaming responses, tool call visualization.
 - **`apps/ui/src/components/Editor.tsx`**: Monaco editor wrapper with OpenSCAD syntax highlighting.
-- **`apps/ui/src/components/Preview.tsx`**: Conditional preview renderer (STL/SVG) with customizer integration.
+- **`apps/ui/src/components/Preview.tsx`**: Conditional preview renderer (OFF/SVG) with customizer integration.
 - **`apps/ui/src/components/CustomizerPanel.tsx`**: Interactive parameter controls panel with collapsible tabs.
 - **`apps/ui/src/components/AiPromptPanel.tsx`**: AI chat transcript and shared composer host.
 - **`apps/ui/src/components/AiComposer.tsx`**: Shared text + image composer used by the welcome screen and main AI panel.
@@ -204,6 +204,7 @@ The desktop app bundles a native OpenSCAD binary for rendering instead of WASM. 
 - **Location**: `apps/ui/src-tauri/binaries/OpenSCAD.app` (gitignored, downloaded at build time)
 
 **Local development**:
+
 ```bash
 # Download the binary (only needed once, re-run to update)
 cd apps/ui/src-tauri
@@ -317,7 +318,7 @@ pnpm validate:changes   # Run the shared validation helper
 ### Current Capabilities (v1.2.2)
 
 ✅ Monaco editor with OpenSCAD syntax highlighting
-✅ Live STL/SVG preview (web: openscad-wasm, desktop: native binary)
+✅ Live OFF/SVG preview (web: openscad-wasm, desktop: native binary)
 ✅ Error diagnostics with inline markers
 ✅ 3D mesh viewer (Three.js) with wireframe/orthographic/shadows
 ✅ Export to STL, OBJ, AMF, 3MF, PNG, SVG, DXF
@@ -405,5 +406,5 @@ pnpm validate:changes   # Run the shared validation helper
 
 ---
 
-**Last Updated**: 2026-04-28
+**Last Updated**: 2026-06-07
 **Current Version**: v1.2.2 — Web + Desktop

--- a/PRE_RELEASE_CHECKLIST.md
+++ b/PRE_RELEASE_CHECKLIST.md
@@ -104,12 +104,12 @@ This checklist captures the initial open-source launch work. It is primarily his
 - [ ] Test on Linux (Ubuntu/Fedora) - not yet tested
 - [ ] Verify desktop-specific filesystem and library workflows on each supported platform
 
-### Known Issues Documentation
+### Historical Known Issues Documentation
 
-- [x] Document known limitations in README:
+- [x] Documented the launch-era limitations in README. Several of these have shipped since the original checklist, so this list is historical rather than current product status:
   - [x] Special operators (`#`, `%`, `*`, `!`) not visually distinguished
-  - [x] No customizer panel for OpenSCAD parameters yet
-  - [x] Preview resolution is fixed at 800x600 (not yet configurable)
+  - [x] No customizer panel for OpenSCAD parameters yet (now shipped)
+  - [x] Preview resolution is fixed at 800x600 (3D preview now uses OFF mesh artifacts and responsive viewer sizing)
   - [x] AI features require API key (no offline mode yet)
   - [x] Only tested on macOS (Windows/Linux pending)
 

--- a/PRODUCT_ROADMAP.md
+++ b/PRODUCT_ROADMAP.md
@@ -4,7 +4,7 @@
 >
 > OpenSCAD is the engine, not the product. The product is: you describe what you want, it makes it, you print it.
 
-**Current version**: v1.2.2 | **Last updated**: 2026-04-28
+**Current version**: v1.2.2 | **Last updated**: 2026-06-07
 
 This roadmap mixes shipped milestones with future planning. Older sections may describe the implementation assumptions that existed when they were written rather than the current client-side `openscad-wasm` architecture.
 
@@ -22,23 +22,23 @@ This roadmap mixes shipped milestones with future planning. Older sections may d
 
 ## What We Have (v1.2.2)
 
-| Area                                                                                  | Status |
-| ------------------------------------------------------------------------------------- | ------ |
-| Monaco editor with OpenSCAD syntax, 27 themes, vim mode, tree-sitter formatting       | ✅     |
-| Live 3D preview (Three.js mesh viewer, orbit controls, wireframe/solid/section tools) | ✅     |
-| 2D SVG mode for laser cutting / engraving                                             | ✅     |
+| Area                                                                                                     | Status |
+| -------------------------------------------------------------------------------------------------------- | ------ |
+| Monaco editor with OpenSCAD syntax, 27 themes, vim mode, tree-sitter formatting                          | ✅     |
+| Live 3D preview (Three.js mesh viewer, orbit controls, wireframe/solid/section tools)                    | ✅     |
+| 2D SVG mode for laser cutting / engraving                                                                | ✅     |
 | AI copilot (Claude + GPT, streaming, tool-calling, diff-based editing, image attachments, auto-rollback) | ✅     |
-| AI can see the 3D preview (screenshot tool returns base64 PNG to vision models)       | ✅     |
-| Customizer panel (tree-sitter parsed parameters → sliders, dropdowns, vectors)        | ✅     |
-| Share links with remixable web entry and thumbnail support                            | ✅     |
-| Product analytics controls and privacy-scrubbed Sentry monitoring                     | ✅     |
-| 2D/3D measurement tools and 3D section plane controls                                 | ✅     |
-| Export (STL, OBJ, AMF, 3MF, PNG, SVG, DXF)                                            | ✅     |
-| Web app via openscad-wasm (zero install, Cloudflare Pages)                            | ✅     |
-| Desktop app (macOS, Homebrew)                                                         | ✅     |
-| Library path management, include/use resolution, BOSL2 support                        | ✅     |
-| Multi-tab editing, undo/redo checkpoints, conversation persistence                    | ✅     |
-| E2E test suite (Playwright, ~2700 lines, CI on every PR)                              | ✅     |
+| AI can see the 3D preview (screenshot tool returns base64 PNG to vision models)                          | ✅     |
+| Customizer panel (tree-sitter parsed parameters → sliders, dropdowns, vectors)                           | ✅     |
+| Share links with remixable web entry and thumbnail support                                               | ✅     |
+| Product analytics controls and privacy-scrubbed Sentry monitoring                                        | ✅     |
+| 2D/3D measurement tools and 3D section plane controls                                                    | ✅     |
+| Export (STL, OBJ, AMF, 3MF, PNG, SVG, DXF)                                                               | ✅     |
+| Web app via openscad-wasm (zero install, Cloudflare Pages)                                               | ✅     |
+| Desktop app (macOS, Homebrew)                                                                            | ✅     |
+| Library path management, include/use resolution, BOSL2 support                                           | ✅     |
+| Multi-tab editing, undo/redo checkpoints, conversation persistence                                       | ✅     |
+| E2E test suite (Playwright, ~2700 lines, CI on every PR)                                                 | ✅     |
 
 ---
 
@@ -208,10 +208,9 @@ Bake domain knowledge into the AI so it produces print-ready designs.
 
 ### 4.4 Configurable Edit Size Limit
 
-- [ ] Move 120-line edit limit to a user setting
-- [ ] Default: 120 lines (current behavior)
-- [ ] Allow increase to 250 or 500 for users who want full-file generation
-- [ ] Setting in Settings → AI tab
+- [ ] Decide whether an edit size setting is still needed now that `apply_edit` is frontend exact-string replacement without the old Rust line cap
+- [ ] If needed, add a Settings → AI control and enforce it in the frontend AI edit path
+- [ ] Keep the product biased toward targeted edits rather than full-file rewrites
 
 **Success criteria**: AI produces print-ready designs. Users can manage conversation history. Multi-file projects work with AI.
 
@@ -223,31 +222,31 @@ Bake domain knowledge into the AI so it produces print-ready designs.
 
 ### 5.1 Adaptive Render Resolution
 
-- [ ] Replace hardcoded 800x600 with actual panel dimensions
-- [ ] `ResizeObserver` on preview panel
-- [ ] Cap at 2x device pixel ratio for retina displays
-- [ ] Debounce resize-triggered re-renders (300ms)
+- [ ] Continue responsive viewer sizing for layout-sensitive overlays
+- [ ] Align screenshot, thumbnail, and export capture dimensions with their target surfaces
+- [ ] Cap capture/render scale for retina displays where raster outputs are generated
+- [ ] Debounce resize-triggered captures or renders when needed
 
 ### 5.2 Measurement Tools
 
 Essential for verifying that dimensions are correct before printing.
 
-- [ ] Bounding box dimensions (toggle X/Y/Z extent labels)
-- [ ] Point-to-point distance measurement (click two points on mesh)
-- [ ] Snap to vertices
-- [ ] Three.js raycasting for point picking
+- [x] Bounding box dimensions (toggle X/Y/Z extent labels)
+- [x] Point-to-point distance measurement (click two points on mesh)
+- [x] Snap to vertices
+- [x] Three.js raycasting for point picking
 
 ### 5.3 Section / Clipping Plane
 
-- [ ] Toggle button: "Section Plane" in 3D viewer toolbar
-- [ ] Draggable clipping plane using `THREE.Plane`
-- [ ] Useful for inspecting hollow objects, internal cavities, fit checks
+- [x] Section tool in the 3D viewer toolbar
+- [x] Clipping plane with axis, invert, offset, nudge, and reset controls
+- [x] Useful for inspecting hollow objects, internal cavities, fit checks
 
 ### 5.4 Color Support
 
-- [ ] Parse `color()` calls from OpenSCAD source
-- [ ] Evaluate AMF/3MF format (supports colors) for preview instead of STL
-- [ ] Minimum viable: single-color override from first `color()` call
+- [x] Preserve OpenSCAD color output in the 3D preview by rendering OFF artifacts
+- [x] Group preview geometry by face color and opacity
+- [x] Viewer preference to toggle model colors
 
 **Success criteria**: Users can verify their designs are dimensionally correct and inspect internal geometry without leaving the app.
 
@@ -328,11 +327,10 @@ Don't schedule these as standalone work items. Fix them when they're in the crit
 
 | Issue                                            | Severity | Trigger to Fix                                                  |
 | ------------------------------------------------ | -------- | --------------------------------------------------------------- |
-| App.tsx is 1189 lines                            | Medium   | When adding a feature that touches App.tsx and it's too painful |
+| App.tsx is ~2600 lines                           | Medium   | When adding a feature that touches App.tsx and it's too painful |
 | Refs-as-state anti-pattern (7+ refs)             | Medium   | When a state bug is traced to this pattern                      |
 | EditorState duplication (frontend + backend)     | Medium   | When AI context or multi-file features need coherent state      |
 | Settings split across localStorage + Tauri store | Low      | When adding new settings gets confusing                         |
-| Error boundary only at top level                 | Low      | When a panel crash takes down the whole app                     |
 | DiffViewer shows same code for old/new           | Low      | When someone actually uses the diff panel                       |
 
 ---
@@ -345,7 +343,7 @@ Don't schedule these as standalone work items. Fix them when they're in the crit
 
 ### Leading Indicators
 
-- Web app weekly active users (Plausible analytics)
+- Web app weekly active users (PostHog product analytics)
 - AI conversations started per session
 - STL exports per session (= user got a result they wanted)
 - Shared design links generated

--- a/engineering-roadmap.md
+++ b/engineering-roadmap.md
@@ -57,7 +57,7 @@
 
 - ✅ Native Rust AI agent exploration (historical)
 - ✅ Current production AI flow uses the shared frontend TypeScript agent and direct provider requests
-- ✅ Diff-based editing: exact string replacement, max 120 lines, validated before apply
+- ✅ Diff-based editing: exact string replacement, validated before apply
 - ✅ Tools: get code, screenshot, apply diff, diagnostics, render
 - ✅ SSE streaming with incremental text deltas
 - ✅ AiPromptPanel, ModelSelector, DiffViewer UI components
@@ -115,7 +115,7 @@
 
 **Goal:** Reduce structural debt so subsequent features don't fight the codebase. No user-visible changes.
 
-### 4B.1: Decompose App.tsx (1189 lines → <300)
+### 4B.1: Decompose App.tsx (~2600 lines → smaller focused modules)
 
 - [ ] Extract `useFileManager` hook:
   - `saveFile`, `checkUnsavedChanges`, `handleOpenFile`, `handleOpenRecent`
@@ -138,7 +138,7 @@
 - [x] Error boundary shows fallback UI with error details
 - [x] Prevents a crash in one area from taking down the entire app
 - [x] Log errors to `console.error` with component stack
-- [ ] Wrap each dockview panel individually (Editor, Preview, AI Chat, Console, Customizer, Diff) — currently only top-level boundary exists
+- [x] Wrap each dockview panel individually (Editor, Preview, AI Chat, Console, Customizer, Diff)
 
 ### 4B.3: Centralized State Management
 
@@ -253,11 +253,9 @@
 
 ### 5.5: Configurable Edit Size Limit
 
-- [ ] Move the 120-line edit limit from hardcoded to a setting
-- [ ] Default: 120 lines (current behavior)
-- [ ] Allow increase to 250 or 500 for users who want full-file generation
-- [ ] Setting in `SettingsDialog.tsx` → AI tab
-- [ ] Update `validate_edit()` in `ai_tools.rs` to read from settings
+- [ ] Decide whether an edit size setting is still needed now that the production AI agent uses frontend `apply_edit` exact-string replacement without the old Rust `validate_edit()` line cap
+- [ ] If needed, add a frontend AI setting and enforce it in `aiService.ts` / `useAiAgent.ts`
+- [ ] Keep the system prompt biased toward targeted edits rather than full-file rewrites
 
 **Success criteria:** AI chat renders beautifully. Users can reference images and past conversations. AI understands multi-file projects. Common operations are one-click.
 
@@ -269,39 +267,33 @@
 
 ### 6.1: Adaptive Render Resolution
 
-- [ ] Replace hardcoded 800x600 with actual panel dimensions
-- [ ] Use `ResizeObserver` on the preview panel to track size
-- [ ] Pass dynamic `{ w, h }` to `renderPreview`
-- [ ] Cap at 2x device pixel ratio for retina displays
-- [ ] Debounce resize-triggered re-renders (300ms)
+- [ ] Continue using `ResizeObserver`-driven viewer sizing for layout-sensitive overlays
+- [ ] Align screenshot, thumbnail, and export capture dimensions with their target surfaces
+- [ ] Cap capture/render scale for retina displays where raster outputs are generated
+- [ ] Debounce resize-triggered captures or renders when needed
 
-### 6.2: Section/Clipping Plane
+### ✅ 6.2: Section/Clipping Plane (COMPLETED)
 
-- [ ] Add a toggle button to the 3D viewer toolbar: "Section Plane"
-- [ ] When enabled: render a draggable clipping plane using `THREE.Plane`
-- [ ] Controls: drag to move plane position, rotate to change orientation
-- [ ] Useful for inspecting hollow objects, internal cavities, fit checks
-- [ ] Three.js `clippingPlanes` on material is the standard approach
+- [x] Added a Section tool in the 3D viewer toolbar
+- [x] Added axis, invert, offset, keyboard nudge, and reset controls
+- [x] Rendered section plane overlay and material clipping for inspecting hollow/internal geometry
 
-### 6.3: Color Support from OpenSCAD
+### ✅ 6.3: Color Support from OpenSCAD (COMPLETED)
 
-- [ ] Parse `color()` calls from OpenSCAD source code
-- [ ] When rendering STL: OpenSCAD doesn't embed colors, so this requires either:
-  - Option A: Use AMF/3MF format (supports colors) for preview instead of STL
-  - Option B: Parse color from source and apply to Three.js materials by geometry group
-- [ ] Evaluate AMF/3MF support in Three.js loaders
-- [ ] Minimum viable: single-color override from first `color()` call in source
+- [x] Switched 3D preview artifacts to OFF output so OpenSCAD-emitted face colors can be preserved
+- [x] Grouped preview geometry by face color and opacity in `preview3dModel.ts`
+- [x] Added a viewer preference to toggle model colors
 
-### 6.4: Measurement Tools
+### ✅ 6.4: Measurement Tools (COMPLETED)
 
-- [ ] Point-to-point distance measurement:
+- [x] Point-to-point distance measurement:
   - Click two points on the mesh surface
   - Display distance with a line and label
   - Snap to vertices
-- [ ] Bounding box dimensions:
+- [x] Bounding box dimensions:
   - Toggle to show X/Y/Z extent labels
   - Display total size in current units
-- [ ] Three.js raycasting for point picking
+- [x] Three.js raycasting for point picking
 
 ### 6.5: Special Operator Preview
 
@@ -515,16 +507,15 @@ These are valuable but not blocking a production release. Prioritize based on us
 
 Items to address opportunistically, not as dedicated phases:
 
-| Issue                                                 | Location                           | Severity | Notes                                                                       |
-| ----------------------------------------------------- | ---------------------------------- | -------- | --------------------------------------------------------------------------- |
-| Refs-as-state anti-pattern                            | `App.tsx` (7+ refs)                | Medium   | Address in 4B.1 decomposition                                               |
-| Settings split across localStorage and Tauri store    | `settingsStore.ts`, `cmd/ai.rs`    | Low      | Consider unifying in platform abstraction                                   |
-| OpenSCAD stderr parsing is regex-based                | `utils/parser.rs`                  | Low      | Works but may miss edge cases. Revisit if OpenSCAD adds JSON output         |
-| `EditorState` duplicated between frontend and backend | `useOpenScad.ts`, `ai_agent.rs`    | Medium   | Backend should be source of truth (4B.3)                                    |
-| No graceful degradation when OpenSCAD is unavailable  | Various                            | Low      | Editor works, just no preview. Could be clearer about what's disabled       |
-| `DiffViewer` panel always shows same code for old/new | `PanelComponents.tsx:58-66`        | Low      | `oldCode={source} newCode={source}` — not actually showing a diff           |
-| Error boundary only at top level                      | `ErrorBoundary.tsx`                | Low      | Per-panel boundaries would improve resilience (see 4B.2 follow-up)          |
-| Parser race condition fixed but fragile               | `CustomizerPanel.tsx`, `parser.ts` | Low      | Parser-ready signaling added; consider a more robust initialization pattern |
+| Issue                                                 | Location                            | Severity | Notes                                                                       |
+| ----------------------------------------------------- | ----------------------------------- | -------- | --------------------------------------------------------------------------- |
+| Refs-as-state anti-pattern                            | `App.tsx` (7+ refs)                 | Medium   | Address in 4B.1 decomposition                                               |
+| Settings split across localStorage and Tauri store    | `settingsStore.ts`, Tauri store     | Low      | Consider unifying in platform abstraction                                   |
+| OpenSCAD stderr parsing is regex-based                | `renderService.ts`                  | Low      | Works but may miss edge cases. Revisit if OpenSCAD adds JSON output         |
+| `EditorState` duplicated between frontend and backend | `useOpenScad.ts`, `cmd/ai_tools.rs` | Medium   | Clarify the current source of truth before deeper state cleanup (4B.3)      |
+| No graceful degradation when OpenSCAD is unavailable  | Various                             | Low      | Editor works, just no preview. Could be clearer about what's disabled       |
+| `DiffViewer` panel always shows same code for old/new | `PanelComponents.tsx:58-66`         | Low      | `oldCode={source} newCode={source}` — not actually showing a diff           |
+| Parser race condition fixed but fragile               | `CustomizerPanel.tsx`, `parser.ts`  | Low      | Parser-ready signaling added; consider a more robust initialization pattern |
 
 ---
 
@@ -545,7 +536,7 @@ Items to address opportunistically, not as dedicated phases:
 3. **Exact string replacement edits**: Agent provides precise changes
    - ✅ Exact match validation (old_string must be unique)
    - ✅ Atomic apply/rollback with validation
-   - ✅ Smaller token usage (max 120 lines)
+   - ✅ Smaller token usage through targeted replacements
    - ✅ Preserves user code structure
    - ✅ Test-compiled before acceptance
 
@@ -583,6 +574,6 @@ Decisions made during roadmap planning that affect ordering:
 
 ---
 
-**Last Updated:** 2026-04-19
-**Current Phase:** v1.2.1 — web + desktop app shipping with sharing, analytics/privacy controls, formatter coverage, advanced viewer tooling, and desktop MCP support for external agents
+**Last Updated:** 2026-06-07
+**Current Phase:** v1.2.2 — web + desktop app shipping with sharing, analytics/privacy controls, formatter coverage, advanced viewer tooling, and desktop MCP support for external agents
 **Next Milestone:** Phase 4B.1/4B.3 (App.tsx decomposition, centralized state) or Phase 5 (AI experience) based on user feedback


### PR DESCRIPTION
# Summary

## What changed

- Refreshed assistant and roadmap docs to describe the current OFF/SVG preview pipeline, model color support, section plane controls, measurement tools, and per-panel error boundaries.
- Updated stale roadmap and technical-debt references for the current frontend AI edit path, App.tsx size, PostHog analytics, and v1.2.2 status.
- Clarified that launch-era pre-release limitations are historical where features have since shipped.

## Why

- The documentation updater found drift between the docs and the current source tree.
- Future contributors and automation should not chase outdated Rust AI validator, STL preview, or top-level-only error boundary assumptions.

## Implementation notes

- Documentation-only change; no product code was edited.
- README.md was intentionally left unchanged because its product-facing content still matches the current app and should not become an engineering index.

# Testing

## Coverage checklist

- [ ] Backend unit tests added or updated for changed Rust behavior
- [ ] Client unit/component tests added or updated for changed frontend behavior
- [ ] E2E tests added or updated for net new user-facing flows
- [x] No new tests were needed for this change

## Validation performed

- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm test:unit`
- [ ] `pnpm test:formatter:ci`
- [ ] `pnpm test:e2e:web`
- [ ] `bash scripts/validate-changes.sh --dry-run ...`
- [ ] `cd apps/ui/src-tauri && cargo fmt --check`
- [ ] `cd apps/ui/src-tauri && cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cd apps/ui/src-tauri && cargo check --all-targets --all-features`

## Test details

- Ran `bash scripts/validate-changes.sh --scope baseline --changed-file CLAUDE.md --changed-file PRODUCT_ROADMAP.md --changed-file engineering-roadmap.md --changed-file PRE_RELEASE_CHECKLIST.md`, which completed `pnpm format:check`, `pnpm lint`, `pnpm type-check`, and `pnpm test:unit` successfully.
- Formatter-specific and E2E checks were skipped because this is a docs-only update.

# Performance

## Performance impact

- [ ] Performance was considered for this change
- [x] No meaningful performance impact is expected

## Justification

- Documentation-only changes do not affect runtime behavior.

# UI changes

## Screenshots or recordings

- N/A

# Issue link

- Closes #
