### PR TITLE
fix(tauri): resolve Linux build and runtime OpenSCAD resolution

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -17,15 +17,18 @@ pnpm web:share:dev
 # Run desktop version in development mode (requires Rust toolchain)
 pnpm tauri:dev
 
-# First-time desktop setup: download the OpenSCAD binary
+# First-time desktop setup:
+# On macOS: download the bundled OpenSCAD binary
 bash apps/ui/src-tauri/scripts/download-openscad.sh
+# On Linux: install the latest nightly AppImage to your PATH (e.g. as /usr/local/bin/openscad) 
+# The app requires OpenSCAD >= 2022.03 to support the `--backend=manifold` flag.
 
 # Build for production
 pnpm web:build    # Web
 pnpm tauri:build  # Desktop
 ```
 
-Desktop development requires the [Rust toolchain](https://rustup.rs/) and the OpenSCAD binary (run `bash apps/ui/src-tauri/scripts/download-openscad.sh` once). Web development only needs Node.js 18+ and pnpm.
+Desktop development requires the [Rust toolchain](https://rustup.rs/) and a recent OpenSCAD binary. Web development only needs Node.js 18+ and pnpm.
 
 ## Share Feature Testing
 

--- a/apps/ui/src-tauri/tauri.conf.json
+++ b/apps/ui/src-tauri/tauri.conf.json
@@ -30,9 +30,7 @@
     "active": true,
     "targets": "all",
     "createUpdaterArtifacts": false,
-    "resources": {
-      "binaries/OpenSCAD.app": "OpenSCAD.app"
-    },
+    "resources": {},
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/apps/ui/src-tauri/tauri.linux.conf.json
+++ b/apps/ui/src-tauri/tauri.linux.conf.json
@@ -1,0 +1,5 @@
+{
+  "bundle": {
+    "resources": {}
+  }
+}

--- a/apps/ui/src-tauri/tauri.macos.conf.json
+++ b/apps/ui/src-tauri/tauri.macos.conf.json
@@ -1,0 +1,7 @@
+{
+  "bundle": {
+    "resources": {
+      "binaries/OpenSCAD.app": "OpenSCAD.app"
+    }
+  }
+}


### PR DESCRIPTION
Extracts the macOS-specific `OpenSCAD.app` bundle requirement from the base `tauri.conf.json` into a platform-specific `tauri.macos.conf.json` override. This prevents Tauri builds from failing on Linux due to missing macOS application bundles.

On Linux, the rendering fallback naturally leverages `which openscad`. Because the application pipeline relies on the `--backend=manifold` flag, Linux developers must ensure an OpenSCAD binary >= 2022.03 (e.g., via nightly AppImages) is accessible on their system PATH.

Developer instructions in DEVELOPMENT.md were updated to reflect this requirement.

# Summary

## What changed

Now there are two Tauri profiles, one for MacOS and one for Linux. DEVELOPMENT.md  was updated to document that Linux developers must provide an OpenSCAD binary >= 2022.03 in their PATH for  --backend=manifold  support.

## Why

Linux is cool, and also:
[-](https://github.com/zacharyfmarion/openscad-studio/issues/92)

## Implementation notes

The Linux ecosystem is much more fragmented than MacOS, so there is no way to have a single download script that works everywhere. Documentation reflects this, most Linux distributions pack outdated versions of OpenSCAD, so the best option is to use an AppImage.

The `which openscad` fallback built into `render.rs` naturally handles the Linux path resolution as long as the binary is available.

# Testing

## Coverage checklist

- [ ] Backend unit tests added or updated for changed Rust behavior
- [ ] Client unit/component tests added or updated for changed frontend behavior
- [ ] E2E tests added or updated for net new user-facing flows
- [X] No new tests were needed for this change

## Validation performed

- [ ] `pnpm format:check`
- [X] `pnpm lint`
- [ ] `pnpm type-check`
- [ ] `pnpm test:unit`
- [ ] `pnpm test:formatter:ci`
- [ ] `pnpm test:e2e:web`
- [ ] `bash scripts/validate-changes.sh --dry-run ...`
- [ ] `cd apps/ui/src-tauri && cargo fmt --check`
- [ ] `cd apps/ui/src-tauri && cargo clippy --all-targets --all-features -- -D warnings`
- [X] `cd apps/ui/src-tauri && cargo check --all-targets --all-features`

## Test details

Validated that the `tauri.conf.json` override pattern parses correctly (`cargo check passed). Verified that  pnpm tauri:dev  now builds successfully on Linux without the macOS  .app bundle. Verified that placing an OpenSCAD AppImage (2026.06.11) in the system PATH allows the Render function to succeed via the  `which openscad`  fallback.

Created a test evidence report (`docs/TAURI_LINUX_TESTS_20260612T204500Z.md`) detailing the manual validations (AppImage fallback and E2E headless execution).

# Performance

## Performance impact

- [X] Performance was considered for this change
- [X] No meaningful performance impact is expected

## Justification

Pretty much only dependency install was changed.

# UI changes

## Screenshots or recordings

- N/A

# Issue link

- Closes #92 
