### PR TITLE
Add OpenAI-compatible local provider support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ OpenSCAD Studio runs the AI copilot entirely on the client side.
 
 - The same React/TypeScript AI stack is used in both the standalone web app and the Tauri desktop app.
 - Model requests are still made directly from the frontend with the Vercel AI SDK.
+- Hosted providers use Anthropic/OpenAI endpoints; local and self-hosted models use a configurable OpenAI-compatible endpoint such as Ollama, llama.cpp, or LM Studio.
 - Tauri provides desktop shell features such as native file dialogs, filesystem access, native rendering, and a desktop-only localhost MCP bridge for external agents.
 - OpenSCAD rendering is client-side: web uses `openscad-wasm` in a Web Worker, while the desktop app uses a bundled native OpenSCAD binary invoked via Tauri IPC commands.
 
@@ -48,7 +49,7 @@ Preserve and tighten the current aesthetic instead of replacing it. The existing
 │ └── useOpenScad.ts         (rendering + diagnostics)       │
 └─────────────────────────────────────────────────────────────┘
                  │
-                 │ HTTPS from the client
+                 │ HTTPS / localhost from the client
                  ▼
         ┌───────────────────┐
         │ Anthropic API     │
@@ -57,6 +58,12 @@ Preserve and tighten the current aesthetic instead of replacing it. The existing
                  ▼
         ┌───────────────────┐
         │ OpenAI API        │
+        └───────────────────┘
+                 │
+                 ▼
+        ┌───────────────────┐
+        │ OpenAI-compatible │
+        │ local endpoint    │
         └───────────────────┘
 
 Desktop-only shell services:
@@ -73,13 +80,14 @@ Desktop-only shell services:
 
 ## Security Model
 
-### API keys
+### API keys and local provider settings
 
-AI API keys are currently stored client-side in obfuscated localStorage-backed state, including when the app runs inside the Tauri webview.
+Hosted AI API keys are currently stored client-side in obfuscated localStorage-backed state, including when the app runs inside the Tauri webview. OpenAI-compatible provider settings, including base URL, model id, and optional API key, are also stored locally.
 
 - This is a convenience tradeoff for a shared web + desktop AI implementation.
 - It is not equivalent to backend-only secret storage.
 - The current architecture intentionally prioritizes one shared AI stack across web and desktop over secret isolation.
+- Local provider API keys are optional; Ollama and LM Studio typically work without one.
 
 Relevant code:
 
@@ -117,9 +125,10 @@ The in-app copilot still has no Rust-side model transport or backend conversatio
 
 ### Provider selection
 
-- The current model is stored in local storage.
-- The provider is inferred from the selected model id.
-- Available models are fetched from provider APIs on the client when keys exist.
+- The current provider and model id are stored together in local storage.
+- Legacy bare model ids are migrated to provider-aware selections.
+- Available hosted models are fetched from provider APIs on the client when keys exist.
+- The OpenAI-compatible provider is available when a base URL and model id are configured; `/models` is used when the local server supports it.
 
 Relevant code:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ Local MCP client → Tauri MCP server (`mcp.rs`) → active workspace window bri
    - Interactive STL/3D mesh for manipulation
    - SVG for 2D designs
 
-4. **Shared Client-Side AI**: Both web and desktop use the same frontend AI stack for the in-app copilot. Requests are made directly from the React app with Vercel AI SDK's `streamText`, and API keys are currently stored in obfuscated localStorage-backed state inside the browser/webview.
+4. **Shared Client-Side AI**: Both web and desktop use the same frontend AI stack for the in-app copilot. Requests are made directly from the React app with Vercel AI SDK's `streamText`; hosted API keys and OpenAI-compatible local provider settings are stored in localStorage-backed state inside the browser/webview.
 
 5. **Diff-based AI Editing**: AI returns exact string replacements, not full file rewrites.
 
@@ -204,6 +204,7 @@ The desktop app bundles a native OpenSCAD binary for rendering instead of WASM. 
 - **Location**: `apps/ui/src-tauri/binaries/OpenSCAD.app` (gitignored, downloaded at build time)
 
 **Local development**:
+
 ```bash
 # Download the binary (only needed once, re-run to update)
 cd apps/ui/src-tauri
@@ -279,7 +280,7 @@ pnpm validate:changes   # Run the shared validation helper
 ### Platform Abstraction
 
 - **PlatformBridge**: Components should use the `PlatformBridge` interface (`apps/ui/src/platform/types.ts`), never import Tauri or web APIs directly.
-- **API keys**: Stored client-side in obfuscated localStorage-backed state today, including in the Tauri webview. This is a convenience tradeoff, not hardened secret isolation.
+- **API keys and local provider settings**: Hosted API keys are stored client-side in obfuscated localStorage-backed state today, including in the Tauri webview. OpenAI-compatible base URLs, model ids, and optional local provider keys are also stored locally. This is a convenience tradeoff, not hardened secret isolation.
 - **File I/O**: Desktop uses native file dialogs via Tauri. Web uses File System Access API with fallbacks.
 
 ### WASM Rendering (Web)

--- a/README.md
+++ b/README.md
@@ -33,22 +33,26 @@ OpenSCAD Studio is a professional editor for OpenSCAD — the programmable solid
 ## ✨ Features
 
 ### Editor
+
 - **Multi-file projects** — File tree, multiple tabs, and `include`/`use` path resolution against the project root (desktop)
 - **Real-time diagnostics** — Inline error and warning markers with line/column precision parsed directly from the OpenSCAD compiler
 - **Monaco-based editing** — OpenSCAD syntax highlighting, multi-tab support, formatter, and vim mode with configurable keybindings
 
 ### Preview
+
 - **Live 3D preview** — Interactive mesh viewer with orbit controls, orthographic mode, wireframe, shadows, and section planes
 - **2D mode** — Dedicated SVG viewer for laser cutting and engraving workflows
 - **Measurement tools** — In-canvas 2D and 3D measurement overlays
 - **Customizer panel** — Interactive parameter controls auto-generated from your OpenSCAD file, with live re-rendering on change
 
 ### AI Copilot
-- **In-app chat** — Stream responses from Claude or GPT to generate, explain, and fix OpenSCAD code (bring your own API key)
+
+- **In-app chat** — Stream responses from Claude, GPT, or local OpenAI-compatible models such as Ollama, llama.cpp, and LM Studio to generate, explain, and fix OpenSCAD code
 - **MCP support (desktop)** — Exposes a localhost MCP server so external agents like [Claude Code](https://claude.ai/code) can render models, read diagnostics, capture screenshots, and edit files in your active workspace
 
 ### Platform
-- **Runs everywhere** — Web app at [openscad-studio.pages.dev](https://openscad-studio.pages.dev) and macOS desktop app 
+
+- **Runs everywhere** — Web app at [openscad-studio.pages.dev](https://openscad-studio.pages.dev) and macOS desktop app
 - **Share links** — Publish browser-based share links with thumbnail previews for remixable examples
 
 **Known limitation:** Special operators (`!`, `#`, `%`, `*`) are not yet reflected in the preview.

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -55,7 +55,7 @@ import { getPreviewSceneStyle } from './services/previewSceneConfig';
 import { isShareEnabled } from './services/shareService';
 import { openFileInWindow, openWorkspaceFolderInWindow } from './services/windowOpenService';
 import { useSettings, loadSettings, updateSetting } from './stores/settingsStore';
-import { getApiKey, getProviderFromModel } from './stores/apiKeyStore';
+import { getApiKey, getOpenAiCompatibleConfig } from './stores/apiKeyStore';
 import {
   selectActiveRender,
   selectActiveTab,
@@ -615,6 +615,7 @@ function App() {
     canSubmitDraft,
     isProcessingAttachments,
     currentToolCalls,
+    currentProvider,
     currentModel,
     currentModelVisionSupport,
     availableProviders,
@@ -1495,7 +1496,10 @@ function App() {
     }, 0);
   }, []);
 
-  const hasCurrentModelApiKey = Boolean(getApiKey(getProviderFromModel(currentModel)));
+  const hasCurrentModelApiKey =
+    currentProvider === 'openai-compatible'
+      ? Boolean(getOpenAiCompatibleConfig().baseUrl && currentModel.trim())
+      : Boolean(getApiKey(currentProvider));
   const canAttachViewerAnnotation = !isStreaming && !isProcessingAttachments;
 
   const attachViewerAnnotationFile = useCallback<WorkspaceState['attachViewerAnnotationFile']>(
@@ -2149,6 +2153,7 @@ function App() {
       canSubmitDraft,
       isProcessingAttachments,
       currentToolCalls,
+      currentProvider,
       currentModel,
       currentModelVisionSupport,
       availableProviders,
@@ -2212,6 +2217,7 @@ function App() {
       canSubmitDraft,
       isProcessingAttachments,
       currentToolCalls,
+      currentProvider,
       currentModel,
       currentModelVisionSupport,
       availableProviders,
@@ -2332,6 +2338,7 @@ function App() {
           );
         }}
         showRecentFiles={capabilities.hasFileSystem}
+        currentProvider={currentProvider}
         currentModel={currentModel}
         availableProviders={availableProviders}
         onModelChange={setCurrentModel}

--- a/apps/ui/src/components/AiAccessEmptyState.tsx
+++ b/apps/ui/src/components/AiAccessEmptyState.tsx
@@ -38,14 +38,14 @@ export function AiAccessEmptyState({
                 Built-in AI
               </Text>
               <Text variant="caption" color="secondary">
-                Add an Anthropic or OpenAI API key in Settings to use Studio&apos;s built-in AI
-                assistant.
+                Configure Anthropic, OpenAI, or a local OpenAI-compatible provider in Settings to
+                use Studio&apos;s built-in AI assistant.
               </Text>
             </div>
 
             <div className="flex justify-start">
               <Button type="button" variant="primary" onClick={() => onOpenSettings?.()}>
-                Add API Key
+                Configure AI
               </Button>
             </div>
           </div>
@@ -70,14 +70,14 @@ export function AiAccessEmptyState({
               Use built-in AI or Studio MCP
             </Text>
             <Text variant="caption" color="secondary">
-              Add an Anthropic or OpenAI API key in Settings, or connect a desktop agent to Studio
-              over MCP.
+              Configure Anthropic, OpenAI, or a local OpenAI-compatible provider in Settings, or
+              connect a desktop agent to Studio over MCP.
             </Text>
           </div>
 
           <div className="flex justify-start gap-2">
             <Button type="button" variant="primary" onClick={() => onOpenSettings?.()}>
-              Add API Key
+              Configure AI
             </Button>
           </div>
 

--- a/apps/ui/src/components/AiPromptPanel.tsx
+++ b/apps/ui/src/components/AiPromptPanel.tsx
@@ -9,6 +9,7 @@ import { useAnalytics, type ModelSelectionSurface } from '../analytics/runtime';
 import { useHistory } from '../hooks/useHistory';
 import { getPlatform } from '../platform';
 import { useHasApiKey } from '../stores/apiKeyStore';
+import type { AiProvider } from '../stores/apiKeyStore';
 import { notifyError, notifySuccess } from '../utils/notifications';
 import type {
   AiDraft,
@@ -348,9 +349,14 @@ export interface AiPromptPanelProps {
   messages?: Message[];
   onNewConversation?: () => void;
   currentToolCalls?: ToolCall[];
+  currentProvider?: AiProvider;
   currentModel?: string;
-  availableProviders?: string[];
-  onModelChange?: (model: string, sourceSurface?: ModelSelectionSurface) => void;
+  availableProviders?: AiProvider[];
+  onModelChange?: (
+    model: string,
+    sourceSurface?: ModelSelectionSurface,
+    provider?: AiProvider
+  ) => void;
   onRestoreCheckpoint?: (checkpointId: string, truncatedMessages: Message[]) => void;
   onOpenSettings?: () => void;
 }
@@ -379,6 +385,7 @@ export const AiPromptPanel = forwardRef<AiPromptPanelRef, AiPromptPanelProps>(
       messages = [],
       onNewConversation,
       currentToolCalls = [],
+      currentProvider,
       currentModel = 'claude-sonnet-4-5',
       availableProviders = [],
       onModelChange,
@@ -551,7 +558,7 @@ export const AiPromptPanel = forwardRef<AiPromptPanelRef, AiPromptPanelProps>(
           ) : (
             <div className="text-center max-w-xs">
               <div className="text-sm mb-3" style={{ color: 'var(--text-secondary)' }}>
-                Add an API key to get started
+                Configure an AI provider to get started
               </div>
               <Button type="button" variant="primary" onClick={() => onOpenSettings?.()}>
                 Open Settings
@@ -826,8 +833,9 @@ export const AiPromptPanel = forwardRef<AiPromptPanelRef, AiPromptPanelProps>(
             trailingControls={
               <ModelSelector
                 currentModel={currentModel}
+                currentProvider={currentProvider}
                 availableProviders={availableProviders}
-                onChange={(model) => onModelChange?.(model, 'ai_panel')}
+                onChange={(model, provider) => onModelChange?.(model, 'ai_panel', provider)}
                 disabled={isStreaming}
                 compact
               />

--- a/apps/ui/src/components/ModelSelector.tsx
+++ b/apps/ui/src/components/ModelSelector.tsx
@@ -74,6 +74,20 @@ export function ModelSelector({
     });
   }, [error]);
 
+  useEffect(() => {
+    if (
+      disabled ||
+      isLoading ||
+      selectedProvider !== 'openai-compatible' ||
+      openAiCompatibleModels.length === 0 ||
+      openAiCompatibleModels.some((model) => model.id === currentModel)
+    ) {
+      return;
+    }
+
+    onChange(openAiCompatibleModels[0].id, 'openai-compatible');
+  }, [currentModel, disabled, isLoading, onChange, openAiCompatibleModels, selectedProvider]);
+
   if (!hasModels && !isLoading) {
     return (
       <span className="text-xs" style={{ color: 'var(--text-tertiary)', opacity: 0.5 }}>

--- a/apps/ui/src/components/ModelSelector.tsx
+++ b/apps/ui/src/components/ModelSelector.tsx
@@ -11,17 +11,40 @@ import {
   SelectLabel,
 } from './ui';
 import { notifyError } from '../utils/notifications';
+import { getProviderFromModel, type AiProvider } from '../stores/apiKeyStore';
 
 interface ModelSelectorProps {
   currentModel: string;
-  availableProviders: string[];
-  onChange: (model: string) => void;
+  currentProvider?: AiProvider;
+  availableProviders: AiProvider[];
+  onChange: (model: string, provider: AiProvider) => void;
   disabled?: boolean;
   compact?: boolean;
 }
 
+function encodeModelValue(provider: AiProvider, modelId: string): string {
+  return JSON.stringify([provider, modelId]);
+}
+
+function decodeModelValue(value: string): { provider: AiProvider; modelId: string } {
+  try {
+    const parsed = JSON.parse(value);
+    if (
+      Array.isArray(parsed) &&
+      (parsed[0] === 'anthropic' || parsed[0] === 'openai' || parsed[0] === 'openai-compatible') &&
+      typeof parsed[1] === 'string'
+    ) {
+      return { provider: parsed[0], modelId: parsed[1] };
+    }
+  } catch {
+    // Legacy select values were bare model ids.
+  }
+  return { provider: getProviderFromModel(value), modelId: value };
+}
+
 export function ModelSelector({
   currentModel,
+  currentProvider,
   availableProviders,
   onChange,
   disabled,
@@ -30,8 +53,15 @@ export function ModelSelector({
   const { groupedByProvider, isLoading, error, fromCache, refreshModels } =
     useModels(availableProviders);
 
-  const { anthropic: anthropicModels, openai: openaiModels } = groupedByProvider;
-  const hasModels = anthropicModels.length > 0 || openaiModels.length > 0;
+  const {
+    anthropic: anthropicModels,
+    openai: openaiModels,
+    openaiCompatible: openAiCompatibleModels,
+  } = groupedByProvider;
+  const hasModels =
+    anthropicModels.length > 0 || openaiModels.length > 0 || openAiCompatibleModels.length > 0;
+  const selectedProvider = currentProvider ?? getProviderFromModel(currentModel);
+  const selectedValue = encodeModelValue(selectedProvider, currentModel);
 
   useEffect(() => {
     if (!error) return;
@@ -47,7 +77,7 @@ export function ModelSelector({
   if (!hasModels && !isLoading) {
     return (
       <span className="text-xs" style={{ color: 'var(--text-tertiary)', opacity: 0.5 }}>
-        No API keys
+        No AI provider configured
       </span>
     );
   }
@@ -61,7 +91,14 @@ export function ModelSelector({
         minHeight: compact ? '32px' : undefined,
       }}
     >
-      <Select value={currentModel} onValueChange={onChange} disabled={disabled || isLoading}>
+      <Select
+        value={selectedValue}
+        onValueChange={(value) => {
+          const selection = decodeModelValue(value);
+          onChange(selection.modelId, selection.provider);
+        }}
+        disabled={disabled || isLoading}
+      >
         <SelectTrigger
           size="sm"
           style={{
@@ -76,20 +113,46 @@ export function ModelSelector({
             <SelectGroup>
               <SelectLabel>Anthropic</SelectLabel>
               {anthropicModels.map((model) => (
-                <SelectItem key={model.id} value={model.id}>
+                <SelectItem
+                  key={`${model.provider}:${model.id}`}
+                  value={encodeModelValue(model.provider, model.id)}
+                >
                   {model.display_name}
                 </SelectItem>
               ))}
             </SelectGroup>
           )}
-          {anthropicModels.length > 0 && openaiModels.length > 0 && (
-            <div className="my-1 mx-2 h-px" style={{ backgroundColor: 'var(--border-primary)' }} />
-          )}
+          {anthropicModels.length > 0 &&
+            (openaiModels.length > 0 || openAiCompatibleModels.length > 0) && (
+              <div
+                className="my-1 mx-2 h-px"
+                style={{ backgroundColor: 'var(--border-primary)' }}
+              />
+            )}
           {openaiModels.length > 0 && (
             <SelectGroup>
               <SelectLabel>OpenAI</SelectLabel>
               {openaiModels.map((model) => (
-                <SelectItem key={model.id} value={model.id}>
+                <SelectItem
+                  key={`${model.provider}:${model.id}`}
+                  value={encodeModelValue(model.provider, model.id)}
+                >
+                  {model.display_name}
+                </SelectItem>
+              ))}
+            </SelectGroup>
+          )}
+          {openaiModels.length > 0 && openAiCompatibleModels.length > 0 && (
+            <div className="my-1 mx-2 h-px" style={{ backgroundColor: 'var(--border-primary)' }} />
+          )}
+          {openAiCompatibleModels.length > 0 && (
+            <SelectGroup>
+              <SelectLabel>OpenAI-compatible</SelectLabel>
+              {openAiCompatibleModels.map((model) => (
+                <SelectItem
+                  key={`${model.provider}:${model.id}`}
+                  value={encodeModelValue(model.provider, model.id)}
+                >
                   {model.display_name}
                 </SelectItem>
               ))}

--- a/apps/ui/src/components/SettingsDialog.tsx
+++ b/apps/ui/src/components/SettingsDialog.tsx
@@ -394,7 +394,7 @@ export function SettingsDialog({ isOpen, onClose, initialTab }: SettingsDialogPr
           >
             {activeSection === 'ai' && (
               <Button variant="primary" onClick={() => aiRef.current?.save()} disabled={!aiCanSave}>
-                Save Key
+                Save AI Settings
               </Button>
             )}
             <Button variant="ghost" onClick={handleClose}>

--- a/apps/ui/src/components/WelcomeScreen.tsx
+++ b/apps/ui/src/components/WelcomeScreen.tsx
@@ -5,7 +5,7 @@ import { AiComposer } from './AiComposer';
 import { ModelSelector } from './ModelSelector';
 import { TbFileText, TbFolder, TbFolderOpen } from 'react-icons/tb';
 import { getPlatform } from '../platform';
-import { useHasApiKey } from '../stores/apiKeyStore';
+import { useHasApiKey, type AiProvider } from '../stores/apiKeyStore';
 import type { AiDraft, AttachmentStore } from '../types/aiChat';
 import {
   loadRecentFiles,
@@ -35,9 +35,14 @@ interface WelcomeScreenProps {
   onOpenFolder?: () => void;
   onOpenSettings?: () => void;
   showRecentFiles?: boolean;
+  currentProvider?: AiProvider;
   currentModel?: string;
-  availableProviders?: string[];
-  onModelChange?: (model: string, sourceSurface?: ModelSelectionSurface) => void;
+  availableProviders?: AiProvider[];
+  onModelChange?: (
+    model: string,
+    sourceSurface?: ModelSelectionSurface,
+    provider?: AiProvider
+  ) => void;
   /** Resolved default project directory path (null on web → hidden) */
   projectDirectory?: string | null;
   /** Called when user clicks "Change" to pick a different default project directory */
@@ -72,6 +77,7 @@ export function WelcomeScreen({
   onOpenFolder,
   onOpenSettings,
   showRecentFiles = true,
+  currentProvider,
   currentModel = 'claude-sonnet-4-5',
   availableProviders = [],
   onModelChange,
@@ -177,8 +183,9 @@ export function WelcomeScreen({
                 trailingControls={
                   <ModelSelector
                     currentModel={currentModel}
+                    currentProvider={currentProvider}
                     availableProviders={availableProviders}
-                    onChange={(model) => onModelChange?.(model, 'welcome')}
+                    onChange={(model, provider) => onModelChange?.(model, 'welcome', provider)}
                     compact
                   />
                 }
@@ -234,7 +241,7 @@ export function WelcomeScreen({
                       onStartWithDraft({ text: example, attachmentIds: [] });
                     }}
                     disabled={!hasApiKey}
-                    title={!hasApiKey ? 'Configure an API key in Settings to use AI' : example}
+                    title={!hasApiKey ? 'Configure an AI provider in Settings to use AI' : example}
                   >
                     {example}
                   </Button>
@@ -251,7 +258,7 @@ export function WelcomeScreen({
             }}
           >
             <Text variant="body" className="mb-2">
-              Set up an API key to use the AI assistant
+              Configure an AI provider to use the AI assistant
             </Text>
             <Text variant="caption" color="tertiary">
               <a

--- a/apps/ui/src/components/__tests__/ModelSelector.test.tsx
+++ b/apps/ui/src/components/__tests__/ModelSelector.test.tsx
@@ -3,7 +3,12 @@
 import { TransformStream } from 'node:stream/web';
 import { act, screen, waitFor } from '@testing-library/react';
 import { jest } from '@jest/globals';
-import { clearApiKey, storeApiKey } from '../../stores/apiKeyStore';
+import {
+  clearApiKey,
+  clearOpenAiCompatibleConfig,
+  storeApiKey,
+  storeOpenAiCompatibleConfig,
+} from '../../stores/apiKeyStore';
 import { renderWithProviders } from './test-utils';
 
 if (!globalThis.TransformStream) {
@@ -54,6 +59,12 @@ function createFetchMock() {
       });
     }
 
+    if (url === 'http://127.0.0.1:11434/v1/models') {
+      return createJsonResponse({
+        data: [{ id: 'gemma4:12b' }],
+      });
+    }
+
     return {
       ok: false,
       status: 404,
@@ -64,15 +75,16 @@ function createFetchMock() {
 }
 
 function ModelSelectorHarness() {
-  const { currentModel, availableProviders, setCurrentModel } = useAiAgent();
+  const { currentProvider, currentModel, availableProviders, setCurrentModel } = useAiAgent();
 
   // Wrap in <form> so Radix Select renders its hidden native <select> for option assertions
   return (
     <form>
       <ModelSelector
         currentModel={currentModel}
+        currentProvider={currentProvider}
         availableProviders={availableProviders}
-        onChange={setCurrentModel}
+        onChange={(model, provider) => setCurrentModel(model, 'unknown', provider)}
       />
     </form>
   );
@@ -88,6 +100,7 @@ describe('ModelSelector provider refresh', () => {
     localStorage.clear();
     clearApiKey('anthropic');
     clearApiKey('openai');
+    clearOpenAiCompatibleConfig();
 
     Object.defineProperty(globalThis, 'fetch', {
       configurable: true,
@@ -108,7 +121,7 @@ describe('ModelSelector provider refresh', () => {
   it('refreshes a mounted selector when an OpenAI key is added after mount', async () => {
     renderWithProviders(<ModelSelectorHarness />);
 
-    expect(screen.getByText('No API keys')).toBeTruthy();
+    expect(screen.getByText('No AI provider configured')).toBeTruthy();
 
     act(() => {
       storeApiKey('openai', 'openai-test-key');
@@ -120,7 +133,7 @@ describe('ModelSelector provider refresh', () => {
       expect(getNativeSelectOptionLabels()).toContain('GPT-5.4');
     });
     await waitFor(() => {
-      expect(screen.queryByText('No API keys')).toBeNull();
+      expect(screen.queryByText('No AI provider configured')).toBeNull();
     });
   });
 
@@ -172,7 +185,25 @@ describe('ModelSelector provider refresh', () => {
 
     const nativeSelect = document.querySelector('select') as HTMLSelectElement | null;
     await waitFor(() => {
-      expect(nativeSelect?.value).toBe('gpt-5.4');
+      expect(nativeSelect?.value).toContain('gpt-5.4');
+      expect(nativeSelect?.value).toContain('openai');
+    });
+  });
+
+  it('shows OpenAI-compatible models when a local provider is configured without an API key', async () => {
+    act(() => {
+      storeOpenAiCompatibleConfig({
+        baseUrl: 'http://127.0.0.1:11434/v1',
+        modelId: 'gemma4:12b',
+        apiKey: null,
+      });
+    });
+
+    renderWithProviders(<ModelSelectorHarness />);
+
+    await screen.findByRole('combobox');
+    await waitFor(() => {
+      expect(getNativeSelectOptionLabels()).toContain('gemma4:12b');
     });
   });
 });

--- a/apps/ui/src/components/__tests__/ModelSelector.test.tsx
+++ b/apps/ui/src/components/__tests__/ModelSelector.test.tsx
@@ -6,6 +6,7 @@ import { jest } from '@jest/globals';
 import {
   clearApiKey,
   clearOpenAiCompatibleConfig,
+  setStoredModelSelection,
   storeApiKey,
   storeOpenAiCompatibleConfig,
 } from '../../stores/apiKeyStore';
@@ -62,6 +63,12 @@ function createFetchMock() {
     if (url === 'http://127.0.0.1:11434/v1/models') {
       return createJsonResponse({
         data: [{ id: 'gemma4:12b' }],
+      });
+    }
+
+    if (url === 'http://localhost:1234/v1/models') {
+      return createJsonResponse({
+        data: [{ id: 'lm-studio-model' }],
       });
     }
 
@@ -194,7 +201,7 @@ describe('ModelSelector provider refresh', () => {
     act(() => {
       storeOpenAiCompatibleConfig({
         baseUrl: 'http://127.0.0.1:11434/v1',
-        modelId: 'gemma4:12b',
+        modelId: '',
         apiKey: null,
       });
     });
@@ -204,6 +211,30 @@ describe('ModelSelector provider refresh', () => {
     await screen.findByRole('combobox');
     await waitFor(() => {
       expect(getNativeSelectOptionLabels()).toContain('gemma4:12b');
+    });
+  });
+
+  it('selects the first discovered local model when the saved local selection is stale', async () => {
+    act(() => {
+      storeOpenAiCompatibleConfig({
+        baseUrl: 'http://localhost:1234/v1',
+        modelId: '',
+        apiKey: null,
+      });
+      setStoredModelSelection({ provider: 'openai-compatible', modelId: 'gemma4:12b' });
+    });
+
+    renderWithProviders(<ModelSelectorHarness />);
+
+    await screen.findByRole('combobox');
+    await waitFor(() => {
+      expect(getNativeSelectOptionLabels()).toContain('lm-studio-model');
+    });
+
+    const nativeSelect = document.querySelector('select') as HTMLSelectElement | null;
+    await waitFor(() => {
+      expect(nativeSelect?.value).toContain('lm-studio-model');
+      expect(nativeSelect?.value).toContain('openai-compatible');
     });
   });
 });

--- a/apps/ui/src/components/__tests__/SettingsDialog.test.tsx
+++ b/apps/ui/src/components/__tests__/SettingsDialog.test.tsx
@@ -3,6 +3,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { jest } from '@jest/globals';
 import { ThemeProvider } from '../../contexts/ThemeContext';
+import { getAvailableProviders, getOpenAiCompatibleConfig } from '../../stores/apiKeyStore';
 
 const mockGetPlatform = jest.fn();
 const mockTrack = jest.fn();
@@ -238,6 +239,41 @@ describe('SettingsDialog privacy copy', () => {
     expect(screen.getAllByRole('button', { name: 'Copy' }).length).toBeGreaterThanOrEqual(2);
     expect(screen.getAllByText(/http:\/\/127\.0\.0\.1:32123\/mcp/i).length).toBeGreaterThan(0);
     expect(mockGetDesktopMcpStatus).toHaveBeenCalled();
+  });
+
+  it('saves an OpenAI-compatible provider without requiring an API key', async () => {
+    render(
+      <ThemeProvider>
+        <SettingsDialog isOpen onClose={() => {}} initialTab="ai" />
+      </ThemeProvider>
+    );
+
+    expect(await screen.findByText('OpenAI-compatible Provider')).toBeTruthy();
+
+    const baseUrlInput = screen.getByPlaceholderText('http://127.0.0.1:11434/v1');
+    const modelInput = screen.getByPlaceholderText('gemma4:12b');
+
+    fireEvent.focus(baseUrlInput);
+    fireEvent.change(baseUrlInput, { target: { value: ' http://localhost:1234/v1/ ' } });
+    fireEvent.change(modelInput, { target: { value: 'lm-studio-model' } });
+
+    const saveButton = screen.getByRole('button', { name: 'Save AI Settings' });
+    await waitFor(() => {
+      expect(saveButton).not.toBeDisabled();
+    });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(getAvailableProviders()).toContain('openai-compatible');
+    });
+    expect(getOpenAiCompatibleConfig()).toEqual({
+      baseUrl: 'http://localhost:1234/v1',
+      modelId: 'lm-studio-model',
+      apiKey: null,
+    });
+    expect(mockTrack).toHaveBeenCalledWith('api key saved', {
+      provider: 'openai-compatible',
+    });
   });
 
   it('tracks layout selection sources and viewer preference changes', async () => {

--- a/apps/ui/src/components/__tests__/SettingsDialog.test.tsx
+++ b/apps/ui/src/components/__tests__/SettingsDialog.test.tsx
@@ -241,6 +241,25 @@ describe('SettingsDialog privacy copy', () => {
     expect(mockGetDesktopMcpStatus).toHaveBeenCalled();
   });
 
+  it('orders hosted API key cards before the OpenAI-compatible provider', async () => {
+    render(
+      <ThemeProvider>
+        <SettingsDialog isOpen onClose={() => {}} initialTab="ai" />
+      </ThemeProvider>
+    );
+
+    const anthropicHeading = await screen.findByText('Anthropic API Key');
+    const openAiHeading = screen.getByText('OpenAI API Key');
+    const compatibleHeading = screen.getByText('OpenAI-compatible Provider');
+
+    expect(
+      anthropicHeading.compareDocumentPosition(openAiHeading) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+    expect(
+      openAiHeading.compareDocumentPosition(compatibleHeading) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
   it('saves an OpenAI-compatible provider without requiring an API key', async () => {
     render(
       <ThemeProvider>

--- a/apps/ui/src/components/__tests__/SettingsDialog.test.tsx
+++ b/apps/ui/src/components/__tests__/SettingsDialog.test.tsx
@@ -3,7 +3,11 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { jest } from '@jest/globals';
 import { ThemeProvider } from '../../contexts/ThemeContext';
-import { getAvailableProviders, getOpenAiCompatibleConfig } from '../../stores/apiKeyStore';
+import {
+  getAvailableProviders,
+  getOpenAiCompatibleConfig,
+  storeOpenAiCompatibleConfig,
+} from '../../stores/apiKeyStore';
 
 const mockGetPlatform = jest.fn();
 const mockTrack = jest.fn();
@@ -276,11 +280,9 @@ describe('SettingsDialog privacy copy', () => {
     expect(await screen.findByText('OpenAI-compatible Provider')).toBeTruthy();
 
     const baseUrlInput = screen.getByPlaceholderText('http://127.0.0.1:11434/v1');
-    const modelInput = screen.getByPlaceholderText('gemma4:12b');
 
     fireEvent.focus(baseUrlInput);
     fireEvent.change(baseUrlInput, { target: { value: ' http://localhost:1234/v1/ ' } });
-    fireEvent.change(modelInput, { target: { value: 'lm-studio-model' } });
 
     const saveButton = screen.getByRole('button', { name: 'Save AI Settings' });
     await waitFor(() => {
@@ -293,12 +295,31 @@ describe('SettingsDialog privacy copy', () => {
     });
     expect(getOpenAiCompatibleConfig()).toEqual({
       baseUrl: 'http://localhost:1234/v1',
-      modelId: 'lm-studio-model',
+      modelId: '',
       apiKey: null,
     });
     expect(mockTrack).toHaveBeenCalledWith('api key saved', {
       provider: 'openai-compatible',
     });
+  });
+
+  it('shows saved OpenAI-compatible settings before the local card is focused', async () => {
+    storeOpenAiCompatibleConfig({
+      baseUrl: 'http://localhost:1234/v1',
+      modelId: '',
+      apiKey: null,
+    });
+
+    render(
+      <ThemeProvider>
+        <SettingsDialog isOpen onClose={() => {}} initialTab="ai" />
+      </ThemeProvider>
+    );
+
+    const baseUrlInput = (await screen.findByPlaceholderText(
+      'http://127.0.0.1:11434/v1'
+    )) as HTMLInputElement;
+    expect(baseUrlInput.value).toBe('http://localhost:1234/v1');
   });
 
   it('tracks layout selection sources and viewer preference changes', async () => {

--- a/apps/ui/src/components/__tests__/SettingsDialog.test.tsx
+++ b/apps/ui/src/components/__tests__/SettingsDialog.test.tsx
@@ -248,6 +248,12 @@ describe('SettingsDialog privacy copy', () => {
       </ThemeProvider>
     );
 
+    expect(
+      await screen.findByText(
+        'Connect hosted API keys or a local OpenAI-compatible server, then choose the model from the chat composer.'
+      )
+    ).toBeTruthy();
+
     const anthropicHeading = await screen.findByText('Anthropic API Key');
     const openAiHeading = screen.getByText('OpenAI API Key');
     const compatibleHeading = screen.getByText('OpenAI-compatible Provider');

--- a/apps/ui/src/components/__tests__/SettingsDialog.test.tsx
+++ b/apps/ui/src/components/__tests__/SettingsDialog.test.tsx
@@ -322,6 +322,20 @@ describe('SettingsDialog privacy copy', () => {
     expect(baseUrlInput.value).toBe('http://localhost:1234/v1');
   });
 
+  it('notes that web users must enable CORS on local LLM servers', async () => {
+    platformMock.capabilities.hasFileSystem = false;
+
+    render(
+      <ThemeProvider>
+        <SettingsDialog isOpen onClose={() => {}} initialTab="ai" />
+      </ThemeProvider>
+    );
+
+    expect(
+      await screen.findByText('On the web, your local LLM server must allow browser CORS requests.')
+    ).toBeTruthy();
+  });
+
   it('tracks layout selection sources and viewer preference changes', async () => {
     const { unmount } = render(
       <ThemeProvider>

--- a/apps/ui/src/components/__tests__/WelcomeScreen.test.tsx
+++ b/apps/ui/src/components/__tests__/WelcomeScreen.test.tsx
@@ -123,7 +123,7 @@ describe('WelcomeScreen', () => {
     ]);
   });
 
-  it('keeps the desktop no-key welcome state focused on API key setup only', async () => {
+  it('keeps the desktop no-provider welcome state focused on built-in AI setup only', async () => {
     clearApiKey('openai');
     clearApiKey('anthropic');
     mockGetPlatform.mockReturnValue({
@@ -149,7 +149,7 @@ describe('WelcomeScreen', () => {
       />
     );
 
-    expect(screen.getByText('Set up an API key to use the AI assistant')).toBeTruthy();
+    expect(screen.getByText('Configure an AI provider to use the AI assistant')).toBeTruthy();
     expect(screen.queryByText('Claude Code')).toBeNull();
   });
 });

--- a/apps/ui/src/components/panels/PanelComponents.tsx
+++ b/apps/ui/src/components/panels/PanelComponents.tsx
@@ -110,6 +110,7 @@ const AiChatPanel: React.FC<IDockviewPanelProps> = () => {
         messages={ws.messages}
         onNewConversation={ws.newConversation}
         currentToolCalls={ws.currentToolCalls}
+        currentProvider={ws.currentProvider}
         currentModel={ws.currentModel}
         availableProviders={ws.availableProviders}
         onModelChange={ws.setCurrentModel}

--- a/apps/ui/src/components/settings/AiSettings.tsx
+++ b/apps/ui/src/components/settings/AiSettings.tsx
@@ -1,16 +1,29 @@
 import { useState, useEffect, useCallback, forwardRef, useImperativeHandle } from 'react';
-import { Text } from '../ui';
+import { Button, Input, Text } from '../ui';
 import { useAnalytics } from '../../analytics/runtime';
 import {
+  DEFAULT_OPENAI_COMPATIBLE_BASE_URL,
+  clearOpenAiCompatibleConfig,
   storeApiKey as storeApiKeyToStorage,
   clearApiKey as clearApiKeyFromStorage,
+  getApiKey,
+  getOpenAiCompatibleConfig,
   hasApiKeyForProvider,
+  hasOpenAiCompatibleConfig,
+  normalizeOpenAiCompatibleBaseUrl,
+  storeOpenAiCompatibleConfig,
   getAvailableProviders as getAvailableProvidersFromStore,
+  type AiProvider,
 } from '../../stores/apiKeyStore';
 import { useSettings } from '../../stores/settingsStore';
 import { getPlatform } from '../../platform';
 import { notifyError, notifySuccess } from '../../utils/notifications';
-import { SettingsSupportBlock } from './SettingsPrimitives';
+import {
+  SettingsCard,
+  SettingsCardHeader,
+  SettingsCardSection,
+  SettingsSupportBlock,
+} from './SettingsPrimitives';
 import { ApiProviderCard } from './ApiProviderCard';
 import { ExternalAgentsCard } from './ExternalAgentsCard';
 
@@ -29,20 +42,29 @@ interface AiSettingsProps {
 
 export const AiSettings = forwardRef<AiSettingsHandle, AiSettingsProps>(
   ({ isOpen, onCanSaveChange }, ref) => {
-    const [provider, setProvider] = useState<'anthropic' | 'openai'>('anthropic');
+    const [provider, setProvider] = useState<AiProvider>('anthropic');
     const [apiKey, setApiKey] = useState('');
     const [hasAnthropicKey, setHasAnthropicKey] = useState(false);
     const [hasOpenAIKey, setHasOpenAIKey] = useState(false);
-    const [isLoading] = useState(false);
+    const [hasOpenAiCompatibleProvider, setHasOpenAiCompatibleProvider] = useState(false);
+    const [customBaseUrl, setCustomBaseUrl] = useState(DEFAULT_OPENAI_COMPATIBLE_BASE_URL);
+    const [customModel, setCustomModel] = useState('');
+    const [isTestingCompatible, setIsTestingCompatible] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [showKey, setShowKey] = useState(false);
     const analytics = useAnalytics();
     const [settings] = useSettings();
+    const isLoading = isTestingCompatible;
 
     const loadKeys = useCallback(() => {
       const availableProviders = getAvailableProvidersFromStore();
       setHasAnthropicKey(availableProviders.includes('anthropic'));
       setHasOpenAIKey(availableProviders.includes('openai'));
+      setHasOpenAiCompatibleProvider(hasOpenAiCompatibleConfig());
+
+      const customConfig = getOpenAiCompatibleConfig();
+      setCustomBaseUrl(customConfig.baseUrl || DEFAULT_OPENAI_COMPATIBLE_BASE_URL);
+      setCustomModel(customConfig.modelId);
 
       if (hasApiKeyForProvider(provider)) {
         setApiKey(MASKED_KEY);
@@ -58,10 +80,55 @@ export const AiSettings = forwardRef<AiSettingsHandle, AiSettingsProps>(
     }, [isOpen, loadKeys]);
 
     useEffect(() => {
+      if (provider === 'openai-compatible') {
+        onCanSaveChange(
+          !isLoading && !!normalizeOpenAiCompatibleBaseUrl(customBaseUrl) && !!customModel.trim()
+        );
+        return;
+      }
       onCanSaveChange(!isLoading && !!apiKey.trim() && !apiKey.startsWith('•'));
-    }, [apiKey, isLoading, onCanSaveChange]);
+    }, [apiKey, customBaseUrl, customModel, isLoading, onCanSaveChange, provider]);
 
     const handleSave = useCallback(() => {
+      if (provider === 'openai-compatible') {
+        const baseUrl = normalizeOpenAiCompatibleBaseUrl(customBaseUrl);
+        const modelId = customModel.trim();
+        if (!baseUrl || !modelId) {
+          setError('Enter a base URL and model for the OpenAI-compatible provider');
+          return;
+        }
+
+        setError(null);
+
+        try {
+          const existingKey = getApiKey('openai-compatible');
+          const keyToStore = apiKey.startsWith('•') ? existingKey : apiKey.trim() || null;
+          storeOpenAiCompatibleConfig({
+            baseUrl,
+            modelId,
+            apiKey: keyToStore,
+          });
+          analytics.track('api key saved', { provider });
+          notifySuccess('OpenAI-compatible provider saved', {
+            toastId: 'save-api-key-openai-compatible',
+          });
+          setHasOpenAiCompatibleProvider(true);
+          setCustomBaseUrl(baseUrl);
+          setCustomModel(modelId);
+          setApiKey(keyToStore ? MASKED_KEY : '');
+          setShowKey(false);
+        } catch (err) {
+          notifyError({
+            operation: 'save-openai-compatible-provider',
+            error: err,
+            fallbackMessage: 'Failed to save OpenAI-compatible provider',
+            toastId: 'save-api-key-error-openai-compatible',
+            logLabel: '[AiSettings] Failed to save OpenAI-compatible provider',
+          });
+        }
+        return;
+      }
+
       if (!apiKey.trim() || apiKey.startsWith('•')) {
         setError('Please enter a valid API key');
         return;
@@ -93,28 +160,42 @@ export const AiSettings = forwardRef<AiSettingsHandle, AiSettingsProps>(
           logLabel: '[AiSettings] Failed to save API key',
         });
       }
-    }, [apiKey, provider, analytics]);
+    }, [apiKey, customBaseUrl, customModel, provider, analytics]);
 
     useImperativeHandle(ref, () => ({ save: handleSave }), [handleSave]);
 
-    const handleClear = async (targetProvider: 'anthropic' | 'openai') => {
+    const handleClear = async (targetProvider: AiProvider) => {
+      const providerLabel =
+        targetProvider === 'anthropic'
+          ? 'Anthropic'
+          : targetProvider === 'openai'
+            ? 'OpenAI'
+            : 'OpenAI-compatible';
       const confirmed = await getPlatform().confirm(
-        `Are you sure you want to remove your ${targetProvider === 'anthropic' ? 'Anthropic' : 'OpenAI'} API key?`,
-        { title: 'Remove API Key', kind: 'warning', okLabel: 'Remove', cancelLabel: 'Cancel' }
+        `Are you sure you want to remove your ${providerLabel} AI settings?`,
+        { title: 'Remove AI Settings', kind: 'warning', okLabel: 'Remove', cancelLabel: 'Cancel' }
       );
       if (!confirmed) return;
 
       setError(null);
 
       try {
-        clearApiKeyFromStorage(targetProvider);
+        if (targetProvider === 'openai-compatible') {
+          clearOpenAiCompatibleConfig();
+        } else {
+          clearApiKeyFromStorage(targetProvider);
+        }
         analytics.track('api key cleared', { provider: targetProvider });
-        notifySuccess('API key cleared', { toastId: `clear-api-key-${targetProvider}` });
+        notifySuccess('AI settings cleared', { toastId: `clear-api-key-${targetProvider}` });
 
         if (targetProvider === 'anthropic') {
           setHasAnthropicKey(false);
-        } else {
+        } else if (targetProvider === 'openai') {
           setHasOpenAIKey(false);
+        } else {
+          setHasOpenAiCompatibleProvider(false);
+          setCustomBaseUrl(DEFAULT_OPENAI_COMPATIBLE_BASE_URL);
+          setCustomModel('');
         }
 
         if (provider === targetProvider) {
@@ -131,12 +212,62 @@ export const AiSettings = forwardRef<AiSettingsHandle, AiSettingsProps>(
       }
     };
 
+    const handleTestOpenAiCompatible = async () => {
+      const baseUrl = normalizeOpenAiCompatibleBaseUrl(customBaseUrl);
+      if (!baseUrl) {
+        setError('Enter a base URL before testing the provider');
+        return;
+      }
+
+      setProvider('openai-compatible');
+      setError(null);
+      setIsTestingCompatible(true);
+
+      try {
+        const key = apiKey.startsWith('•') ? getApiKey('openai-compatible') : apiKey.trim();
+        const headers: Record<string, string> = {};
+        if (key) {
+          headers.Authorization = `Bearer ${key}`;
+        }
+        const response = await fetch(`${baseUrl}/models`, { headers });
+        if (!response.ok) {
+          throw new Error(
+            `OpenAI-compatible API error (${response.status}): ${await response.text()}`
+          );
+        }
+        const body = (await response.json()) as { data?: Array<{ id?: string }> };
+        const models = Array.isArray(body.data) ? body.data : [];
+        const firstModel = models.find((model) => typeof model.id === 'string')?.id;
+        if (!customModel.trim() && firstModel) {
+          setCustomModel(firstModel);
+        }
+        notifySuccess(
+          models.length > 0
+            ? `Connected to OpenAI-compatible provider (${models.length} model${models.length === 1 ? '' : 's'})`
+            : 'Connected to OpenAI-compatible provider',
+          { toastId: 'test-openai-compatible-provider' }
+        );
+      } catch (err) {
+        notifyError({
+          operation: 'test-openai-compatible-provider',
+          error: err,
+          fallbackMessage:
+            'Could not reach the OpenAI-compatible provider. Check that the local server is running and allows browser requests.',
+          toastId: 'test-openai-compatible-provider-error',
+          logLabel: '[AiSettings] Failed to test OpenAI-compatible provider',
+        });
+      } finally {
+        setIsTestingCompatible(false);
+      }
+    };
+
     return (
       <div className="flex flex-col ph-no-capture" style={{ gap: 'var(--space-section-gap)' }}>
         <Text variant="body">
           Add your API keys to enable AI assistant features. Model selection is available in the
-          chat interface. Your key is stored locally on this device/browser profile and used for
-          direct requests to the AI provider from the app. It is not sent to our analytics.
+          chat interface. Hosted keys and local provider settings are stored locally on this
+          device/browser profile and used for direct requests from the app. They are not sent to our
+          analytics.
         </Text>
 
         <ApiProviderCard
@@ -171,6 +302,139 @@ export const AiSettings = forwardRef<AiSettingsHandle, AiSettingsProps>(
             handleClear('anthropic');
           }}
         />
+
+        <SettingsCard className="ph-no-capture">
+          <SettingsCardHeader
+            title="OpenAI-compatible Provider"
+            description="For local servers such as Ollama, llama.cpp, and LM Studio."
+            action={
+              <span
+                className="text-xs px-2 py-0.5 rounded-full font-medium"
+                style={{
+                  backgroundColor: hasOpenAiCompatibleProvider
+                    ? 'rgba(133, 153, 0, 0.15)'
+                    : 'rgba(128, 128, 128, 0.1)',
+                  color: hasOpenAiCompatibleProvider
+                    ? 'var(--color-success)'
+                    : 'var(--text-tertiary)',
+                }}
+              >
+                {hasOpenAiCompatibleProvider ? 'Configured' : 'Not configured'}
+              </span>
+            }
+          />
+          <SettingsCardSection className="flex flex-col" style={{ gap: 'var(--space-field-gap)' }}>
+            <label className="flex flex-col" style={{ gap: 'var(--space-helper-gap)' }}>
+              <Text variant="caption" color="secondary">
+                Base URL
+              </Text>
+              <Input
+                value={provider === 'openai-compatible' ? customBaseUrl : ''}
+                onFocus={() => {
+                  setProvider('openai-compatible');
+                  setApiKey(hasApiKeyForProvider('openai-compatible') ? MASKED_KEY : '');
+                  setShowKey(false);
+                }}
+                onChange={(event) => {
+                  setProvider('openai-compatible');
+                  setCustomBaseUrl(event.target.value);
+                }}
+                placeholder="http://127.0.0.1:11434/v1"
+                className="font-mono text-sm ph-no-capture"
+                disabled={isLoading}
+              />
+            </label>
+
+            <label className="flex flex-col" style={{ gap: 'var(--space-helper-gap)' }}>
+              <Text variant="caption" color="secondary">
+                Model
+              </Text>
+              <Input
+                value={provider === 'openai-compatible' ? customModel : ''}
+                onFocus={() => {
+                  setProvider('openai-compatible');
+                  setApiKey(hasApiKeyForProvider('openai-compatible') ? MASKED_KEY : '');
+                  setShowKey(false);
+                }}
+                onChange={(event) => {
+                  setProvider('openai-compatible');
+                  setCustomModel(event.target.value);
+                }}
+                placeholder="gemma4:12b"
+                className="font-mono text-sm ph-no-capture"
+                disabled={isLoading}
+              />
+            </label>
+
+            <label className="flex flex-col" style={{ gap: 'var(--space-helper-gap)' }}>
+              <Text variant="caption" color="secondary">
+                API key (optional)
+              </Text>
+              <div className="relative">
+                <Input
+                  type={showKey && provider === 'openai-compatible' ? 'text' : 'password'}
+                  value={provider === 'openai-compatible' ? apiKey : ''}
+                  onFocus={() => {
+                    setProvider('openai-compatible');
+                    setApiKey(hasApiKeyForProvider('openai-compatible') ? MASKED_KEY : '');
+                  }}
+                  onChange={(event) => {
+                    setProvider('openai-compatible');
+                    setApiKey(event.target.value);
+                  }}
+                  placeholder="Leave blank for Ollama or LM Studio"
+                  className="pr-20 font-mono text-sm ph-no-capture"
+                  disabled={isLoading}
+                />
+                {provider === 'openai-compatible' && apiKey && !apiKey.startsWith('•') ? (
+                  // eslint-disable-next-line no-restricted-syntax -- absolute-positioned inline toggle overlay on a password input; matches API key cards above
+                  <button
+                    type="button"
+                    onClick={() => setShowKey((prev) => !prev)}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 text-xs px-2 py-1 rounded-lg transition-colors"
+                    style={{ color: 'var(--text-secondary)' }}
+                  >
+                    {showKey ? 'Hide' : 'Show'}
+                  </button>
+                ) : null}
+              </div>
+            </label>
+
+            <Text variant="caption" color="tertiary">
+              Examples: Ollama `http://127.0.0.1:11434/v1`, llama.cpp `http://127.0.0.1:8080/v1`, LM
+              Studio `http://localhost:1234/v1`.
+            </Text>
+
+            <div
+              className="flex items-center justify-between"
+              style={{ gap: 'var(--space-control-gap)' }}
+            >
+              <Button
+                type="button"
+                size="sm"
+                variant="secondary"
+                onClick={() => {
+                  void handleTestOpenAiCompatible();
+                }}
+                disabled={isLoading}
+              >
+                {isTestingCompatible ? 'Testing...' : 'Test Connection'}
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                onClick={() => {
+                  setProvider('openai-compatible');
+                  void handleClear('openai-compatible');
+                }}
+                disabled={isLoading || !hasOpenAiCompatibleProvider}
+              >
+                Clear
+              </Button>
+            </div>
+          </SettingsCardSection>
+        </SettingsCard>
 
         <ApiProviderCard
           title="OpenAI API Key"

--- a/apps/ui/src/components/settings/AiSettings.tsx
+++ b/apps/ui/src/components/settings/AiSettings.tsx
@@ -263,13 +263,6 @@ export const AiSettings = forwardRef<AiSettingsHandle, AiSettingsProps>(
 
     return (
       <div className="flex flex-col ph-no-capture" style={{ gap: 'var(--space-section-gap)' }}>
-        <Text variant="body">
-          Add your API keys to enable AI assistant features. Model selection is available in the
-          chat interface. Hosted keys and local provider settings are stored locally on this
-          device/browser profile and used for direct requests from the app. They are not sent to our
-          analytics.
-        </Text>
-
         <ApiProviderCard
           title="Anthropic API Key"
           description="Required for Claude models."

--- a/apps/ui/src/components/settings/AiSettings.tsx
+++ b/apps/ui/src/components/settings/AiSettings.tsx
@@ -263,6 +263,11 @@ export const AiSettings = forwardRef<AiSettingsHandle, AiSettingsProps>(
 
     return (
       <div className="flex flex-col ph-no-capture" style={{ gap: 'var(--space-section-gap)' }}>
+        <Text variant="body" color="secondary">
+          Connect hosted API keys or a local OpenAI-compatible server, then choose the model from
+          the chat composer.
+        </Text>
+
         <ApiProviderCard
           title="Anthropic API Key"
           description="Required for Claude models."

--- a/apps/ui/src/components/settings/AiSettings.tsx
+++ b/apps/ui/src/components/settings/AiSettings.tsx
@@ -57,6 +57,7 @@ export const AiSettings = forwardRef<AiSettingsHandle, AiSettingsProps>(
     const analytics = useAnalytics();
     const [settings] = useSettings();
     const isLoading = isTestingCompatible;
+    const isWeb = !getPlatform().capabilities.hasFileSystem;
 
     const loadKeys = useCallback(() => {
       const availableProviders = getAvailableProvidersFromStore();
@@ -407,6 +408,12 @@ export const AiSettings = forwardRef<AiSettingsHandle, AiSettingsProps>(
               Examples: Ollama `http://127.0.0.1:11434/v1`, llama.cpp `http://127.0.0.1:8080/v1`, LM
               Studio `http://localhost:1234/v1`.
             </Text>
+
+            {isWeb ? (
+              <Text variant="caption" color="tertiary">
+                On the web, your local LLM server must allow browser CORS requests.
+              </Text>
+            ) : null}
 
             <div
               className="flex items-center justify-between"

--- a/apps/ui/src/components/settings/AiSettings.tsx
+++ b/apps/ui/src/components/settings/AiSettings.tsx
@@ -3,6 +3,7 @@ import { Button, Input, Text } from '../ui';
 import { useAnalytics } from '../../analytics/runtime';
 import {
   DEFAULT_OPENAI_COMPATIBLE_BASE_URL,
+  clearStoredModelSelectionForProvider,
   clearOpenAiCompatibleConfig,
   storeApiKey as storeApiKeyToStorage,
   clearApiKey as clearApiKeyFromStorage,
@@ -47,8 +48,9 @@ export const AiSettings = forwardRef<AiSettingsHandle, AiSettingsProps>(
     const [hasAnthropicKey, setHasAnthropicKey] = useState(false);
     const [hasOpenAIKey, setHasOpenAIKey] = useState(false);
     const [hasOpenAiCompatibleProvider, setHasOpenAiCompatibleProvider] = useState(false);
-    const [customBaseUrl, setCustomBaseUrl] = useState(DEFAULT_OPENAI_COMPATIBLE_BASE_URL);
-    const [customModel, setCustomModel] = useState('');
+    const [customBaseUrl, setCustomBaseUrl] = useState(
+      () => getOpenAiCompatibleConfig().baseUrl || DEFAULT_OPENAI_COMPATIBLE_BASE_URL
+    );
     const [isTestingCompatible, setIsTestingCompatible] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [showKey, setShowKey] = useState(false);
@@ -64,7 +66,6 @@ export const AiSettings = forwardRef<AiSettingsHandle, AiSettingsProps>(
 
       const customConfig = getOpenAiCompatibleConfig();
       setCustomBaseUrl(customConfig.baseUrl || DEFAULT_OPENAI_COMPATIBLE_BASE_URL);
-      setCustomModel(customConfig.modelId);
 
       if (hasApiKeyForProvider(provider)) {
         setApiKey(MASKED_KEY);
@@ -81,40 +82,40 @@ export const AiSettings = forwardRef<AiSettingsHandle, AiSettingsProps>(
 
     useEffect(() => {
       if (provider === 'openai-compatible') {
-        onCanSaveChange(
-          !isLoading && !!normalizeOpenAiCompatibleBaseUrl(customBaseUrl) && !!customModel.trim()
-        );
+        onCanSaveChange(!isLoading && !!normalizeOpenAiCompatibleBaseUrl(customBaseUrl));
         return;
       }
       onCanSaveChange(!isLoading && !!apiKey.trim() && !apiKey.startsWith('•'));
-    }, [apiKey, customBaseUrl, customModel, isLoading, onCanSaveChange, provider]);
+    }, [apiKey, customBaseUrl, isLoading, onCanSaveChange, provider]);
 
     const handleSave = useCallback(() => {
       if (provider === 'openai-compatible') {
         const baseUrl = normalizeOpenAiCompatibleBaseUrl(customBaseUrl);
-        const modelId = customModel.trim();
-        if (!baseUrl || !modelId) {
-          setError('Enter a base URL and model for the OpenAI-compatible provider');
+        if (!baseUrl) {
+          setError('Enter a base URL for the OpenAI-compatible provider');
           return;
         }
 
         setError(null);
 
         try {
+          const previousConfig = getOpenAiCompatibleConfig();
           const existingKey = getApiKey('openai-compatible');
           const keyToStore = apiKey.startsWith('•') ? existingKey : apiKey.trim() || null;
           storeOpenAiCompatibleConfig({
             baseUrl,
-            modelId,
+            modelId: '',
             apiKey: keyToStore,
           });
+          if (previousConfig.baseUrl !== baseUrl) {
+            clearStoredModelSelectionForProvider('openai-compatible');
+          }
           analytics.track('api key saved', { provider });
           notifySuccess('OpenAI-compatible provider saved', {
             toastId: 'save-api-key-openai-compatible',
           });
           setHasOpenAiCompatibleProvider(true);
           setCustomBaseUrl(baseUrl);
-          setCustomModel(modelId);
           setApiKey(keyToStore ? MASKED_KEY : '');
           setShowKey(false);
         } catch (err) {
@@ -160,7 +161,7 @@ export const AiSettings = forwardRef<AiSettingsHandle, AiSettingsProps>(
           logLabel: '[AiSettings] Failed to save API key',
         });
       }
-    }, [apiKey, customBaseUrl, customModel, provider, analytics]);
+    }, [apiKey, customBaseUrl, provider, analytics]);
 
     useImperativeHandle(ref, () => ({ save: handleSave }), [handleSave]);
 
@@ -195,7 +196,6 @@ export const AiSettings = forwardRef<AiSettingsHandle, AiSettingsProps>(
         } else {
           setHasOpenAiCompatibleProvider(false);
           setCustomBaseUrl(DEFAULT_OPENAI_COMPATIBLE_BASE_URL);
-          setCustomModel('');
         }
 
         if (provider === targetProvider) {
@@ -237,10 +237,6 @@ export const AiSettings = forwardRef<AiSettingsHandle, AiSettingsProps>(
         }
         const body = (await response.json()) as { data?: Array<{ id?: string }> };
         const models = Array.isArray(body.data) ? body.data : [];
-        const firstModel = models.find((model) => typeof model.id === 'string')?.id;
-        if (!customModel.trim() && firstModel) {
-          setCustomModel(firstModel);
-        }
         notifySuccess(
           models.length > 0
             ? `Connected to OpenAI-compatible provider (${models.length} model${models.length === 1 ? '' : 's'})`
@@ -357,7 +353,7 @@ export const AiSettings = forwardRef<AiSettingsHandle, AiSettingsProps>(
                 Base URL
               </Text>
               <Input
-                value={provider === 'openai-compatible' ? customBaseUrl : ''}
+                value={customBaseUrl}
                 onFocus={() => {
                   setProvider('openai-compatible');
                   setApiKey(hasApiKeyForProvider('openai-compatible') ? MASKED_KEY : '');
@@ -368,27 +364,6 @@ export const AiSettings = forwardRef<AiSettingsHandle, AiSettingsProps>(
                   setCustomBaseUrl(event.target.value);
                 }}
                 placeholder="http://127.0.0.1:11434/v1"
-                className="font-mono text-sm ph-no-capture"
-                disabled={isLoading}
-              />
-            </label>
-
-            <label className="flex flex-col" style={{ gap: 'var(--space-helper-gap)' }}>
-              <Text variant="caption" color="secondary">
-                Model
-              </Text>
-              <Input
-                value={provider === 'openai-compatible' ? customModel : ''}
-                onFocus={() => {
-                  setProvider('openai-compatible');
-                  setApiKey(hasApiKeyForProvider('openai-compatible') ? MASKED_KEY : '');
-                  setShowKey(false);
-                }}
-                onChange={(event) => {
-                  setProvider('openai-compatible');
-                  setCustomModel(event.target.value);
-                }}
-                placeholder="gemma4:12b"
                 className="font-mono text-sm ph-no-capture"
                 disabled={isLoading}
               />

--- a/apps/ui/src/components/settings/AiSettings.tsx
+++ b/apps/ui/src/components/settings/AiSettings.tsx
@@ -303,6 +303,36 @@ export const AiSettings = forwardRef<AiSettingsHandle, AiSettingsProps>(
           }}
         />
 
+        <ApiProviderCard
+          title="OpenAI API Key"
+          description="Required for OpenAI models."
+          placeholder="sk-..."
+          keyLink={{ label: 'Get one from OpenAI', href: 'https://platform.openai.com/api-keys' }}
+          isActive={provider === 'openai'}
+          hasKey={hasOpenAIKey}
+          apiKey={apiKey}
+          showKey={showKey}
+          isLoading={isLoading}
+          onFocus={() => {
+            if (provider !== 'openai') {
+              setProvider('openai');
+              setApiKey('');
+              setShowKey(false);
+            } else {
+              setProvider('openai');
+            }
+          }}
+          onChange={(value) => {
+            setProvider('openai');
+            setApiKey(value);
+          }}
+          onToggleShow={() => setShowKey((prev) => !prev)}
+          onClear={() => {
+            setProvider('openai');
+            handleClear('openai');
+          }}
+        />
+
         <SettingsCard className="ph-no-capture">
           <SettingsCardHeader
             title="OpenAI-compatible Provider"
@@ -435,36 +465,6 @@ export const AiSettings = forwardRef<AiSettingsHandle, AiSettingsProps>(
             </div>
           </SettingsCardSection>
         </SettingsCard>
-
-        <ApiProviderCard
-          title="OpenAI API Key"
-          description="Required for OpenAI models."
-          placeholder="sk-..."
-          keyLink={{ label: 'Get one from OpenAI', href: 'https://platform.openai.com/api-keys' }}
-          isActive={provider === 'openai'}
-          hasKey={hasOpenAIKey}
-          apiKey={apiKey}
-          showKey={showKey}
-          isLoading={isLoading}
-          onFocus={() => {
-            if (provider !== 'openai') {
-              setProvider('openai');
-              setApiKey('');
-              setShowKey(false);
-            } else {
-              setProvider('openai');
-            }
-          }}
-          onChange={(value) => {
-            setProvider('openai');
-            setApiKey(value);
-          }}
-          onToggleShow={() => setShowKey((prev) => !prev)}
-          onClear={() => {
-            setProvider('openai');
-            handleClear('openai');
-          }}
-        />
 
         {error && (
           <SettingsSupportBlock

--- a/apps/ui/src/contexts/WorkspaceContext.tsx
+++ b/apps/ui/src/contexts/WorkspaceContext.tsx
@@ -5,6 +5,7 @@ import type { RenderKind } from '../hooks/useOpenScad';
 import type { AddDraftFilesResult } from '../hooks/useAiAgent';
 import type { AiPromptPanelRef } from '../components/AiPromptPanel';
 import type { ViewerAnnotationAttachResult } from '../components/viewer-annotation';
+import type { AiProvider } from '../stores/apiKeyStore';
 import type { Settings } from '../stores/settingsStore';
 import type { WorkspaceTab } from '../stores/workspaceTypes';
 import type { AiDraft, AttachmentStore, Message, ToolCall, VisionSupport } from '../types/aiChat';
@@ -49,9 +50,10 @@ export interface WorkspaceState {
   canSubmitDraft: boolean;
   isProcessingAttachments: boolean;
   currentToolCalls: ToolCall[];
+  currentProvider: AiProvider;
   currentModel: string;
   currentModelVisionSupport: VisionSupport;
-  availableProviders: string[];
+  availableProviders: AiProvider[];
   submitDraft: () => void;
   setDraftText: (text: string) => void;
   addDraftFiles: (
@@ -67,7 +69,11 @@ export interface WorkspaceState {
   rejectDiff: () => void;
   clearAiError: () => void;
   newConversation: () => void;
-  setCurrentModel: (model: string, sourceSurface?: ModelSelectionSurface) => void;
+  setCurrentModel: (
+    model: string,
+    sourceSurface?: ModelSelectionSurface,
+    provider?: AiProvider
+  ) => void;
   handleRestoreCheckpoint: (checkpointId: string, truncatedMessages: Message[]) => void;
   aiPromptPanelRef: React.RefObject<AiPromptPanelRef | null>;
 

--- a/apps/ui/src/hooks/__tests__/useAiAgent.test.tsx
+++ b/apps/ui/src/hooks/__tests__/useAiAgent.test.tsx
@@ -298,6 +298,40 @@ describe('useAiAgent', () => {
     );
   });
 
+  it('shows a local-provider reachability message when OpenAI-compatible fetch fails', async () => {
+    storeOpenAiCompatibleConfig({
+      baseUrl: 'http://127.0.0.1:11434/v1',
+      modelId: 'gemma4:12b',
+      apiKey: null,
+    });
+    setStoredModelSelection({ provider: 'openai-compatible', modelId: 'gemma4:12b' });
+
+    const hook = createHarness({
+      testOverrides: {
+        availableProviders: ['openai-compatible'],
+        createModel: (() => ({ id: 'local-model' })) as never,
+        buildTools: (() => ({})) as never,
+        messagesToModelMessages: (() => []) as never,
+        startAiStream: (async () => {
+          throw new Error('Failed to fetch');
+        }) as never,
+      },
+    });
+
+    await act(async () => {
+      await hook.current().submitPrompt('Try local model');
+    });
+
+    await waitFor(() => {
+      expect(hook.current().isStreaming).toBe(false);
+    });
+
+    expect(hook.current().error).toBe(
+      'Could not reach the OpenAI-compatible provider — check that the local server is running and allows browser requests.'
+    );
+    expect(hook.current().draft.text).toBe('Try local model');
+  });
+
   it('adds attachments, exposes unknown-vision warnings, and cleans up previews when removing or clearing', async () => {
     const analytics = createAnalyticsSpy();
     const processAttachmentFiles = jest

--- a/apps/ui/src/hooks/__tests__/useAiAgent.test.tsx
+++ b/apps/ui/src/hooks/__tests__/useAiAgent.test.tsx
@@ -6,7 +6,10 @@ import {
   storeApiKey,
   invalidateApiKeyStatus,
   setStoredModel,
+  storeOpenAiCompatibleConfig,
+  setStoredModelSelection,
   getStoredModel,
+  getStoredModelSelection,
 } from '../../stores/apiKeyStore';
 import {
   getUserMessageText,
@@ -69,12 +72,10 @@ describe('useAiAgent', () => {
 
   it('falls back to a preferred provider model when the stored provider is unavailable', async () => {
     setStoredModel('gpt-5.4');
-    const getPreferredDefaultModel = jest.fn(() => 'claude-sonnet-4-5');
 
     const hook = createHarness({
       testOverrides: {
         availableProviders: ['anthropic'],
-        getPreferredDefaultModel: getPreferredDefaultModel as never,
         getVisionSupportForModelId: ((model: string) =>
           model === 'claude-sonnet-4-5' ? 'yes' : 'no') as never,
       },
@@ -85,8 +86,12 @@ describe('useAiAgent', () => {
     });
 
     expect(hook.current().currentModelVisionSupport).toBe('yes');
-    expect(getPreferredDefaultModel).toHaveBeenCalledWith(['anthropic']);
+    expect(hook.current().currentProvider).toBe('anthropic');
     expect(getStoredModel()).toBe('claude-sonnet-4-5');
+    expect(getStoredModelSelection()).toEqual({
+      provider: 'anthropic',
+      modelId: 'claude-sonnet-4-5',
+    });
   });
 
   it('exposes project-aware tool callbacks that read from projectStore', async () => {
@@ -233,6 +238,64 @@ describe('useAiAgent', () => {
     expect(startAiStream).not.toHaveBeenCalled();
     expect(hook.current().messages).toEqual([]);
     expect(hook.current().error).toBe('Please set your API key in Settings first');
+  });
+
+  it('submits to an OpenAI-compatible provider without requiring an API key', async () => {
+    storeOpenAiCompatibleConfig({
+      baseUrl: 'http://127.0.0.1:11434/v1',
+      modelId: 'gemma4:12b',
+      apiKey: null,
+    });
+    setStoredModelSelection({ provider: 'openai-compatible', modelId: 'gemma4:12b' });
+    const analytics = createAnalyticsSpy();
+    const createModel = jest.fn(() => ({ id: 'local-model' }));
+    const startAiStream = jest.fn(async () =>
+      createStreamResult([
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', text: 'Local done.' },
+        { type: 'text-end', id: 'text-1' },
+        {
+          type: 'finish',
+          finishReason: 'stop',
+          rawFinishReason: 'stop',
+          totalUsage: {} as never,
+        },
+      ] satisfies StreamChunk[])
+    );
+
+    const hook = createHarness({
+      testOverrides: {
+        analytics: analytics as never,
+        availableProviders: ['openai-compatible'],
+        createModel: createModel as never,
+        buildTools: (() => ({})) as never,
+        messagesToModelMessages: (() => []) as never,
+        startAiStream: startAiStream as never,
+      },
+    });
+
+    await act(async () => {
+      await hook.current().submitPrompt('Use local model');
+    });
+
+    await waitFor(() => {
+      expect(hook.current().isStreaming).toBe(false);
+    });
+
+    expect(createModel).toHaveBeenCalledWith('openai-compatible', 'local', 'gemma4:12b', {
+      baseUrl: 'http://127.0.0.1:11434/v1',
+    });
+    expect(hook.current().messages[1]).toMatchObject({
+      type: 'assistant',
+      content: 'Local done.',
+    });
+    expect(analytics.track).toHaveBeenCalledWith(
+      'ai request submitted',
+      expect.objectContaining({
+        provider: 'openai-compatible',
+        model_id: 'gemma4:12b',
+      })
+    );
   });
 
   it('adds attachments, exposes unknown-vision warnings, and cleans up previews when removing or clearing', async () => {

--- a/apps/ui/src/hooks/__tests__/useAiAgent.test.tsx
+++ b/apps/ui/src/hooks/__tests__/useAiAgent.test.tsx
@@ -94,6 +94,115 @@ describe('useAiAgent', () => {
     });
   });
 
+  it('routes legacy bare OpenAI model storage through the OpenAI provider', async () => {
+    localStorage.setItem('openscad_studio_openai_api_key', 'plain-openai-key');
+    localStorage.setItem('openscad_studio_ai_model', 'gpt-4o');
+    const createModel = jest.fn(() => ({ id: 'openai-model' }));
+    const startAiStream = jest.fn(async () =>
+      createStreamResult([
+        {
+          type: 'finish',
+          finishReason: 'stop',
+          rawFinishReason: 'stop',
+          totalUsage: {} as never,
+        },
+      ] satisfies StreamChunk[])
+    );
+
+    const hook = createHarness({
+      testOverrides: {
+        availableProviders: ['openai'],
+        createModel: createModel as never,
+        buildTools: (() => ({})) as never,
+        messagesToModelMessages: (() => []) as never,
+        startAiStream: startAiStream as never,
+      },
+    });
+
+    await waitFor(() => {
+      expect(hook.current().currentProvider).toBe('openai');
+      expect(hook.current().currentModel).toBe('gpt-4o');
+    });
+
+    await act(async () => {
+      await hook.current().submitPrompt('Use my existing OpenAI model');
+    });
+
+    await waitFor(() => {
+      expect(hook.current().isStreaming).toBe(false);
+    });
+
+    expect(createModel).toHaveBeenCalledWith('openai', 'plain-openai-key', 'gpt-4o');
+    expect(localStorage.getItem('openscad_studio_openai_api_key')).toMatch(/^obf1:/);
+  });
+
+  it('routes legacy bare Anthropic model storage through the Anthropic provider', async () => {
+    localStorage.setItem('openscad_studio_anthropic_api_key', 'plain-anthropic-key');
+    localStorage.setItem('openscad_studio_ai_model', 'claude-3-5-sonnet-20241022');
+    const createModel = jest.fn(() => ({ id: 'anthropic-model' }));
+    const startAiStream = jest.fn(async () =>
+      createStreamResult([
+        {
+          type: 'finish',
+          finishReason: 'stop',
+          rawFinishReason: 'stop',
+          totalUsage: {} as never,
+        },
+      ] satisfies StreamChunk[])
+    );
+
+    const hook = createHarness({
+      testOverrides: {
+        availableProviders: ['anthropic'],
+        createModel: createModel as never,
+        buildTools: (() => ({})) as never,
+        messagesToModelMessages: (() => []) as never,
+        startAiStream: startAiStream as never,
+      },
+    });
+
+    await waitFor(() => {
+      expect(hook.current().currentProvider).toBe('anthropic');
+      expect(hook.current().currentModel).toBe('claude-3-5-sonnet-20241022');
+    });
+
+    await act(async () => {
+      await hook.current().submitPrompt('Use my existing Anthropic model');
+    });
+
+    await waitFor(() => {
+      expect(hook.current().isStreaming).toBe(false);
+    });
+
+    expect(createModel).toHaveBeenCalledWith(
+      'anthropic',
+      'plain-anthropic-key',
+      'claude-3-5-sonnet-20241022'
+    );
+    expect(localStorage.getItem('openscad_studio_anthropic_api_key')).toMatch(/^obf1:/);
+  });
+
+  it('uses provider-aware selection instead of a stale legacy model when both exist', async () => {
+    storeApiKey('anthropic', 'anthropic-key');
+    storeApiKey('openai', 'openai-key');
+    localStorage.setItem('openscad_studio_ai_model', 'gpt-4o');
+    localStorage.setItem(
+      'openscad_studio_ai_model_selection',
+      JSON.stringify({ provider: 'anthropic', modelId: 'claude-opus-4' })
+    );
+
+    const hook = createHarness({
+      testOverrides: {
+        availableProviders: ['anthropic', 'openai'],
+      },
+    });
+
+    await waitFor(() => {
+      expect(hook.current().currentProvider).toBe('anthropic');
+      expect(hook.current().currentModel).toBe('claude-opus-4');
+    });
+  });
+
   it('exposes project-aware tool callbacks that read from projectStore', async () => {
     const { getProjectStore } = await import('../../stores/projectStore');
     const updateSetting = jest.fn();

--- a/apps/ui/src/hooks/__tests__/useModels.test.tsx
+++ b/apps/ui/src/hooks/__tests__/useModels.test.tsx
@@ -4,7 +4,12 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { jest } from '@jest/globals';
 import { useModels } from '../useModels';
 import type { AiProvider } from '../../stores/apiKeyStore';
-import { clearApiKey, storeApiKey } from '../../stores/apiKeyStore';
+import {
+  clearApiKey,
+  clearOpenAiCompatibleConfig,
+  storeApiKey,
+  storeOpenAiCompatibleConfig,
+} from '../../stores/apiKeyStore';
 
 function createJsonResponse(body: unknown) {
   return {
@@ -32,6 +37,12 @@ function createFetchMock() {
       });
     }
 
+    if (url === 'http://127.0.0.1:11434/v1/models') {
+      return createJsonResponse({
+        data: [{ id: 'gemma4:12b' }, { id: 'qwen3-coder:latest' }],
+      });
+    }
+
     return {
       ok: false,
       status: 404,
@@ -51,6 +62,9 @@ function UseModelsHarness({ availableProviders }: { availableProviders: AiProvid
         {groupedByProvider.anthropic.map((model) => model.id).join(',')}
       </div>
       <div data-testid="openai">{groupedByProvider.openai.map((model) => model.id).join(',')}</div>
+      <div data-testid="openai-compatible">
+        {groupedByProvider.openaiCompatible.map((model) => model.id).join(',')}
+      </div>
     </div>
   );
 }
@@ -60,6 +74,7 @@ describe('useModels', () => {
     localStorage.clear();
     clearApiKey('anthropic');
     clearApiKey('openai');
+    clearOpenAiCompatibleConfig();
 
     Object.defineProperty(globalThis, 'fetch', {
       configurable: true,
@@ -135,6 +150,40 @@ describe('useModels', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('openai').textContent).toBe('gpt-5.4,gpt-5,gpt-4o');
+    });
+  });
+
+  it('fetches OpenAI-compatible models without filtering local model ids', async () => {
+    storeOpenAiCompatibleConfig({
+      baseUrl: 'http://127.0.0.1:11434/v1',
+      modelId: 'gemma4:12b',
+      apiKey: null,
+    });
+
+    render(<UseModelsHarness availableProviders={['openai-compatible']} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('openai-compatible').textContent).toBe(
+        'gemma4:12b,qwen3-coder:latest'
+      );
+    });
+
+    expect(globalThis.fetch as jest.Mock).toHaveBeenCalledWith('http://127.0.0.1:11434/v1/models', {
+      headers: {},
+    });
+  });
+
+  it('falls back to the configured OpenAI-compatible model when model refresh fails', async () => {
+    storeOpenAiCompatibleConfig({
+      baseUrl: 'http://localhost:1234/v1',
+      modelId: 'lm-studio-model',
+      apiKey: null,
+    });
+
+    render(<UseModelsHarness availableProviders={['openai-compatible']} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('openai-compatible').textContent).toBe('lm-studio-model');
     });
   });
 });

--- a/apps/ui/src/hooks/__tests__/useModels.test.tsx
+++ b/apps/ui/src/hooks/__tests__/useModels.test.tsx
@@ -156,7 +156,7 @@ describe('useModels', () => {
   it('fetches OpenAI-compatible models without filtering local model ids', async () => {
     storeOpenAiCompatibleConfig({
       baseUrl: 'http://127.0.0.1:11434/v1',
-      modelId: 'gemma4:12b',
+      modelId: '',
       apiKey: null,
     });
 

--- a/apps/ui/src/hooks/useAiAgent.ts
+++ b/apps/ui/src/hooks/useAiAgent.ts
@@ -13,6 +13,7 @@ import {
   SYSTEM_PROMPT,
   buildTools,
   type AiToolCallbacks,
+  type CreateModelOptions,
 } from '../services/aiService';
 import {
   buildProjectRenderInputs,
@@ -20,10 +21,13 @@ import {
 } from '../services/projectRenderInputs';
 import {
   getApiKey,
+  getOpenAiCompatibleConfig,
+  getPreferredDefaultModelSelection,
   getProviderFromModel,
-  getStoredModel,
-  setStoredModel,
+  getStoredModelSelection,
+  setStoredModelSelection,
   useAvailableProviders,
+  type AiProvider,
 } from '../stores/apiKeyStore';
 import type {
   AiDraft,
@@ -189,6 +193,7 @@ export interface AiAgentState {
   conversations: Conversation[];
   currentConversationId: string | null;
   currentToolCalls: ToolCall[];
+  currentProvider: AiProvider;
   currentModel: string;
   currentModelVisionSupport: VisionSupport;
   draft: AiDraft;
@@ -235,12 +240,11 @@ export function useAiAgent(options: UseAiAgentOptions = {}) {
   const getVisionSupportForModelIdImpl =
     overrides?.getVisionSupportForModelId ?? getVisionSupportForModelId;
   const messagesToModelMessagesImpl = overrides?.messagesToModelMessages ?? messagesToModelMessages;
-  const getPreferredDefaultModelImpl =
-    overrides?.getPreferredDefaultModel ?? getPreferredDefaultModel;
   const historyServiceImpl = overrides?.historyService ?? historyService;
   const eventBusImpl = overrides?.eventBus ?? eventBus;
   const updateSettingImpl = overrides?.updateSetting ?? updateSetting;
   const loadSettingsImpl = overrides?.loadSettings ?? loadSettings;
+  const initialSelection = getStoredModelSelection();
   const [state, setState] = useState<AiAgentState>({
     isStreaming: false,
     streamingResponse: null,
@@ -252,8 +256,9 @@ export function useAiAgent(options: UseAiAgentOptions = {}) {
     conversations: [],
     currentConversationId: null,
     currentToolCalls: [],
-    currentModel: getStoredModel(),
-    currentModelVisionSupport: getVisionSupportForModelIdImpl(getStoredModel()),
+    currentProvider: initialSelection.provider,
+    currentModel: initialSelection.modelId,
+    currentModelVisionSupport: getVisionSupportForModelIdImpl(initialSelection.modelId),
     draft: EMPTY_DRAFT,
     attachments: {},
     draftErrors: [],
@@ -409,31 +414,36 @@ export function useAiAgent(options: UseAiAgentOptions = {}) {
   }, []);
 
   const loadModelAndProviders = useCallback(() => {
-    const storedModel = getStoredModel();
-    const resolvedModel =
-      availableProviders.length === 0 ||
-      availableProviders.includes(getProviderFromModel(storedModel))
-        ? storedModel
-        : getPreferredDefaultModelImpl(availableProviders);
+    const storedSelection = getStoredModelSelection();
+    const resolvedSelection =
+      availableProviders.length === 0 || availableProviders.includes(storedSelection.provider)
+        ? storedSelection
+        : getPreferredDefaultModelSelection(availableProviders);
 
-    if (resolvedModel !== storedModel) {
-      setStoredModel(resolvedModel);
+    if (
+      resolvedSelection.provider !== storedSelection.provider ||
+      resolvedSelection.modelId !== storedSelection.modelId
+    ) {
+      setStoredModelSelection(resolvedSelection);
     }
 
     setState((prev) => ({
       ...prev,
-      currentModel: resolvedModel,
-      currentModelVisionSupport: getVisionSupportForModelIdImpl(resolvedModel),
+      currentProvider: resolvedSelection.provider,
+      currentModel: resolvedSelection.modelId,
+      currentModelVisionSupport: getVisionSupportForModelIdImpl(resolvedSelection.modelId),
     }));
     if (IS_DEV) {
       console.log(
         '[useAiAgent] Loaded model:',
-        resolvedModel,
+        resolvedSelection.modelId,
+        'Provider:',
+        resolvedSelection.provider,
         'Available providers:',
         availableProviders
       );
     }
-  }, [availableProviders, getPreferredDefaultModelImpl, getVisionSupportForModelIdImpl]);
+  }, [availableProviders, getVisionSupportForModelIdImpl]);
 
   useEffect(() => {
     loadModelAndProviders();
@@ -535,7 +545,7 @@ export function useAiAgent(options: UseAiAgentOptions = {}) {
       const toolNamesUsed = Array.from(new Set(toolMessages.map((tool) => tool.toolName))).sort();
       const appliedEditCount = toolMessages.filter((tool) => tool.toolName === 'apply_edit').length;
       const baseProperties = {
-        provider: getProviderFromModel(stateRef.current.currentModel),
+        provider: stateRef.current.currentProvider,
         model_id: stateRef.current.currentModel,
         duration_ms: durationMs,
         tool_call_count: toolMessages.length,
@@ -729,8 +739,23 @@ export function useAiAgent(options: UseAiAgentOptions = {}) {
         return;
       }
 
-      const provider = getProviderFromModel(currentState.currentModel);
-      const apiKey = getApiKey(provider);
+      const provider = currentState.currentProvider;
+      const modelOptions: CreateModelOptions = {};
+      let apiKey = getApiKey(provider);
+
+      if (provider === 'openai-compatible') {
+        const config = getOpenAiCompatibleConfig();
+        modelOptions.baseUrl = config.baseUrl;
+        apiKey = config.apiKey ?? 'local';
+
+        if (!config.baseUrl || !currentState.currentModel.trim()) {
+          setState((prev) => ({
+            ...prev,
+            error: 'Configure an OpenAI-compatible provider in Settings first',
+          }));
+          return;
+        }
+      }
 
       if (!apiKey) {
         setState((prev) => ({
@@ -785,7 +810,10 @@ export function useAiAgent(options: UseAiAgentOptions = {}) {
       abortControllerRef.current = abortController;
 
       try {
-        const model = createModelImpl(provider, apiKey, currentState.currentModel);
+        const model =
+          provider === 'openai-compatible'
+            ? createModelImpl(provider, apiKey, currentState.currentModel, modelOptions)
+            : createModelImpl(provider, apiKey, currentState.currentModel);
         const modelMessages = messagesToModelMessagesImpl(
           updatedMessages,
           currentState.attachments
@@ -965,16 +993,21 @@ export function useAiAgent(options: UseAiAgentOptions = {}) {
   }, []);
 
   const setCurrentModel = useCallback(
-    (model: string, sourceSurface: ModelSelectionSurface = 'unknown') => {
-      if (IS_DEV) console.log('[useAiAgent] Setting current model to:', model);
+    (
+      model: string,
+      sourceSurface: ModelSelectionSurface = 'unknown',
+      provider: AiProvider = getProviderFromModel(model)
+    ) => {
+      if (IS_DEV) console.log('[useAiAgent] Setting current model to:', model, provider);
       setState((prev) => ({
         ...prev,
+        currentProvider: provider,
         currentModel: model,
         currentModelVisionSupport: getVisionSupportForModelIdImpl(model),
       }));
-      setStoredModel(model);
+      setStoredModelSelection({ provider, modelId: model });
       analytics.track('model selected', {
-        provider: getProviderFromModel(model),
+        provider,
         model_id: model,
         source_surface: sourceSurface,
       });

--- a/apps/ui/src/hooks/useAiAgent.ts
+++ b/apps/ui/src/hooks/useAiAgent.ts
@@ -75,8 +75,11 @@ function extractErrorText(error: unknown): string {
   return String(error);
 }
 
-function humanizeStreamError(errorText: string): string {
+function humanizeStreamError(errorText: string, provider?: AiProvider): string {
   if (/failed to fetch/i.test(errorText)) {
+    if (provider === 'openai-compatible') {
+      return 'Could not reach the OpenAI-compatible provider — check that the local server is running and allows browser requests.';
+    }
     return 'Could not reach the AI service — check your internet connection.';
   }
   return `Failed: ${errorText}`;
@@ -527,7 +530,9 @@ export function useAiAgent(options: UseAiAgentOptions = {}) {
           isStreaming: false,
           streamingResponse: null,
           currentToolCalls: [],
-          error: options.errorText ? humanizeStreamError(options.errorText) : null,
+          error: options.errorText
+            ? humanizeStreamError(options.errorText, stateRef.current.currentProvider)
+            : null,
           errorObject: options.errorObject ?? null,
           messages: nextMessages,
           attachments: nextConversation.attachments,
@@ -934,7 +939,7 @@ export function useAiAgent(options: UseAiAgentOptions = {}) {
         } else {
           setState((prev) => ({
             ...prev,
-            error: humanizeStreamError(errorText),
+            error: humanizeStreamError(errorText, currentState.currentProvider),
             errorObject,
             isStreaming: false,
             streamingResponse: null,

--- a/apps/ui/src/hooks/useModels.ts
+++ b/apps/ui/src/hooks/useModels.ts
@@ -1,5 +1,10 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { getApiKey, type AiProvider } from '../stores/apiKeyStore';
+import {
+  getApiKey,
+  getOpenAiCompatibleConfig,
+  type AiProvider,
+  type OpenAiCompatibleConfig,
+} from '../stores/apiKeyStore';
 import { getVisionSupportForModelId } from '../utils/aiMessages';
 import {
   compareModelsByFreshness,
@@ -19,6 +24,7 @@ export interface ModelInfo {
 export interface GroupedModels {
   anthropic: ModelInfo[];
   openai: ModelInfo[];
+  openaiCompatible: ModelInfo[];
 }
 
 export interface UseModelsReturn {
@@ -38,6 +44,7 @@ interface CachedModels {
   models: ModelInfo[];
   fetchedAt: number;
   providers?: AiProvider[];
+  openAiCompatibleBaseUrl?: string;
 }
 
 const DEFAULT_MODELS: ModelInfo[] = DEFAULT_MODEL_CATALOG.map((model) => ({
@@ -133,6 +140,42 @@ async function fetchOpenAiModels(apiKey: string): Promise<ModelInfo[]> {
     }));
 }
 
+function createConfiguredOpenAiCompatibleModel(config: OpenAiCompatibleConfig): ModelInfo {
+  return {
+    id: config.modelId,
+    display_name: config.modelId,
+    provider: 'openai-compatible',
+    visionSupport: getVisionSupportForModelId(config.modelId),
+  };
+}
+
+async function fetchOpenAiCompatibleModels(config: OpenAiCompatibleConfig): Promise<ModelInfo[]> {
+  const headers: Record<string, string> = {};
+  if (config.apiKey) {
+    headers.Authorization = `Bearer ${config.apiKey}`;
+  }
+
+  const resp = await fetch(`${config.baseUrl}/models`, { headers });
+
+  if (!resp.ok) {
+    throw new Error(`OpenAI-compatible API error (${resp.status}): ${await resp.text()}`);
+  }
+
+  const data: OpenAiModelsResponse = await resp.json();
+  const models: ModelInfo[] = data.data.map((m) => ({
+    id: m.id,
+    display_name: m.id,
+    provider: 'openai-compatible' as const,
+    visionSupport: getVisionSupportForModelId(m.id),
+  }));
+
+  if (config.modelId && !models.some((model) => model.id === config.modelId)) {
+    models.unshift(createConfiguredOpenAiCompatibleModel(config));
+  }
+
+  return models;
+}
+
 function sortModels(models: ModelInfo[]): ModelInfo[] {
   return [...models].sort(compareModelsByFreshness);
 }
@@ -147,7 +190,14 @@ function getCachedProviders(cached: CachedModels): AiProvider[] {
 function hasCacheCoverage(cached: CachedModels, providers: readonly string[]): boolean {
   const requestedProviders = normalizeProviders(providers);
   const cachedProviders = getCachedProviders(cached);
-  return requestedProviders.every((provider) => cachedProviders.includes(provider));
+  if (!requestedProviders.every((provider) => cachedProviders.includes(provider))) {
+    return false;
+  }
+  if (requestedProviders.includes('openai-compatible')) {
+    const config = getOpenAiCompatibleConfig();
+    return cached.openAiCompatibleBaseUrl === config.baseUrl;
+  }
+  return true;
 }
 
 function loadCache(providers: string[]): { models: ModelInfo[]; ageMinutes: number } | null {
@@ -173,10 +223,12 @@ function loadCache(providers: string[]): { models: ModelInfo[]; ageMinutes: numb
 
 function saveCache(models: ModelInfo[], providers: readonly string[]): void {
   try {
+    const config = getOpenAiCompatibleConfig();
     const cached: CachedModels = {
       models,
       fetchedAt: Date.now(),
       providers: normalizeProviders(providers),
+      openAiCompatibleBaseUrl: providers.includes('openai-compatible') ? config.baseUrl : undefined,
     };
     localStorage.setItem(CACHE_KEY, JSON.stringify(cached));
   } catch {
@@ -256,6 +308,19 @@ export function useModels(availableProviders: string[]): UseModelsReturn {
             );
           }
         }
+        if (providers.includes('openai-compatible')) {
+          const config = getOpenAiCompatibleConfig();
+          if (config.baseUrl && config.modelId) {
+            fetches.push(
+              fetchOpenAiCompatibleModels(config)
+                .then((models) => ({ models, error: null }))
+                .catch((error) => ({
+                  models: [createConfiguredOpenAiCompatibleModel(config)],
+                  error: error instanceof Error ? error.message : String(error),
+                }))
+            );
+          }
+        }
 
         const results = await Promise.all(fetches);
         const allModels = results.flatMap((result) => result.models);
@@ -272,7 +337,15 @@ export function useModels(availableProviders: string[]): UseModelsReturn {
           setCacheAgeMinutes(null);
           saveCache(sorted, providers);
         } else {
-          const defaults = DEFAULT_MODELS.filter((m) => providers.includes(m.provider));
+          const customConfig = getOpenAiCompatibleConfig();
+          const customDefaults =
+            providers.includes('openai-compatible') && customConfig.modelId
+              ? [createConfiguredOpenAiCompatibleModel(customConfig)]
+              : [];
+          const defaults = [
+            ...DEFAULT_MODELS.filter((m) => providers.includes(m.provider)),
+            ...customDefaults,
+          ];
           setModels(defaults);
           setError(errors.length > 0 ? errors.join('\n') : null);
           setFromCache(false);
@@ -281,7 +354,15 @@ export function useModels(availableProviders: string[]): UseModelsReturn {
       } catch (e) {
         if (requestId !== requestIdRef.current) return;
         setError(String(e));
-        const defaults = DEFAULT_MODELS.filter((m) => providersRef.current.includes(m.provider));
+        const customConfig = getOpenAiCompatibleConfig();
+        const customDefaults =
+          providersRef.current.includes('openai-compatible') && customConfig.modelId
+            ? [createConfiguredOpenAiCompatibleModel(customConfig)]
+            : [];
+        const defaults = [
+          ...DEFAULT_MODELS.filter((m) => providersRef.current.includes(m.provider)),
+          ...customDefaults,
+        ];
         setModels(defaults);
         setFromCache(false);
         setCacheAgeMinutes(null);
@@ -306,6 +387,7 @@ export function useModels(availableProviders: string[]): UseModelsReturn {
     (): GroupedModels => ({
       anthropic: models.filter((m) => m.provider === 'anthropic'),
       openai: models.filter((m) => m.provider === 'openai'),
+      openaiCompatible: models.filter((m) => m.provider === 'openai-compatible'),
     }),
     [models]
   );

--- a/apps/ui/src/hooks/useModels.ts
+++ b/apps/ui/src/hooks/useModels.ts
@@ -310,12 +310,12 @@ export function useModels(availableProviders: string[]): UseModelsReturn {
         }
         if (providers.includes('openai-compatible')) {
           const config = getOpenAiCompatibleConfig();
-          if (config.baseUrl && config.modelId) {
+          if (config.baseUrl) {
             fetches.push(
               fetchOpenAiCompatibleModels(config)
                 .then((models) => ({ models, error: null }))
                 .catch((error) => ({
-                  models: [createConfiguredOpenAiCompatibleModel(config)],
+                  models: config.modelId ? [createConfiguredOpenAiCompatibleModel(config)] : [],
                   error: error instanceof Error ? error.message : String(error),
                 }))
             );

--- a/apps/ui/src/hooks/useOpenScad.ts
+++ b/apps/ui/src/hooks/useOpenScad.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useAnalytics, type RenderTrigger } from '../analytics/runtime';
-import { getStoredModel, getProviderFromModel } from '../stores/apiKeyStore';
+import { getStoredModelSelection } from '../stores/apiKeyStore';
 import {
   getRenderService,
   ensureRenderService,
@@ -199,9 +199,10 @@ export function useOpenScad(options: UseOpenScadOptions = {}) {
       let settledSnapshot: RenderSnapshot | null = null;
 
       const trackRenderCompleted = (renderDiagnostics: Diagnostic[]) => {
+        const aiSelection = getStoredModelSelection();
         const aiMeta =
           trigger === 'ai_edit'
-            ? { ai_model_id: getStoredModel(), ai_provider: getProviderFromModel(getStoredModel()) }
+            ? { ai_model_id: aiSelection.modelId, ai_provider: aiSelection.provider }
             : {};
         analytics.track('render completed', {
           trigger,

--- a/apps/ui/src/services/__tests__/aiService.test.ts
+++ b/apps/ui/src/services/__tests__/aiService.test.ts
@@ -2,6 +2,24 @@ import { jest } from '@jest/globals';
 
 const mockCaptureOffscreen = jest.fn(async () => 'data:image/png;base64,AAA=');
 const mockCheckSyntax = jest.fn(async () => ({ diagnostics: [] }));
+const mockAnthropicModel = jest.fn((modelId: string) => ({ provider: 'anthropic', modelId }));
+const mockCreateAnthropic = jest.fn(() => mockAnthropicModel);
+const mockOpenAiResponsesModel = jest.fn((modelId: string) => ({ provider: 'openai', modelId }));
+const mockOpenAiChatModel = jest.fn((modelId: string) => ({
+  provider: 'openai-compatible',
+  modelId,
+}));
+const mockCreateOpenAI = jest.fn(() =>
+  Object.assign(mockOpenAiResponsesModel, { chat: mockOpenAiChatModel })
+);
+
+jest.unstable_mockModule('@ai-sdk/anthropic', () => ({
+  createAnthropic: (...args: unknown[]) => mockCreateAnthropic(...args),
+}));
+
+jest.unstable_mockModule('@ai-sdk/openai', () => ({
+  createOpenAI: (...args: unknown[]) => mockCreateOpenAI(...args),
+}));
 
 jest.unstable_mockModule('@/services/renderService', () => ({
   getRenderService: () => ({
@@ -22,6 +40,7 @@ import { FALLBACK_PREVIEW_SCENE_STYLE } from '../previewSceneConfig';
 import type { AiToolCallbacks } from '../aiService';
 
 let buildTools: typeof import('../aiService').buildTools;
+let createModel: typeof import('../aiService').createModel;
 
 type ExecutableTool = {
   execute: (input: unknown) => Promise<unknown>;
@@ -70,6 +89,35 @@ function createCallbacks(overrides: Partial<AiToolCallbacks> = {}): AiToolCallba
     ...overrides,
   };
 }
+
+describe('createModel', () => {
+  beforeAll(async () => {
+    ({ createModel } = await import('../aiService'));
+  });
+
+  beforeEach(() => {
+    mockCreateAnthropic.mockClear();
+    mockAnthropicModel.mockClear();
+    mockCreateOpenAI.mockClear();
+    mockOpenAiResponsesModel.mockClear();
+    mockOpenAiChatModel.mockClear();
+  });
+
+  it('uses chat completions with baseURL for OpenAI-compatible providers', () => {
+    const model = createModel('openai-compatible', '', 'gemma4:12b', {
+      baseUrl: 'http://127.0.0.1:11434/v1',
+    });
+
+    expect(mockCreateOpenAI).toHaveBeenCalledWith({
+      apiKey: 'local',
+      baseURL: 'http://127.0.0.1:11434/v1',
+      name: 'openai-compatible',
+    });
+    expect(mockOpenAiChatModel).toHaveBeenCalledWith('gemma4:12b');
+    expect(mockOpenAiResponsesModel).not.toHaveBeenCalled();
+    expect(model).toEqual({ provider: 'openai-compatible', modelId: 'gemma4:12b' });
+  });
+});
 
 describe('buildTools', () => {
   beforeAll(async () => {

--- a/apps/ui/src/services/aiService.ts
+++ b/apps/ui/src/services/aiService.ts
@@ -140,13 +140,30 @@ You are an expert OpenSCAD assistant helping users design and modify 3D models. 
 - Prefer realistic 3D-printing-safe defaults, ranges, and steps.
 `;
 
-export function createModel(provider: AiProvider, apiKey: string, modelId: string) {
+export interface CreateModelOptions {
+  baseUrl?: string;
+}
+
+export function createModel(
+  provider: AiProvider,
+  apiKey: string,
+  modelId: string,
+  options: CreateModelOptions = {}
+) {
   if (provider === 'anthropic') {
     const anthropic = createAnthropic({
       apiKey,
       headers: { 'anthropic-dangerous-direct-browser-access': 'true' },
     });
     return anthropic(modelId);
+  }
+  if (provider === 'openai-compatible') {
+    const openai = createOpenAI({
+      apiKey: apiKey || 'local',
+      baseURL: options.baseUrl,
+      name: 'openai-compatible',
+    });
+    return openai.chat(modelId);
   }
   const openai = createOpenAI({ apiKey });
   return openai(modelId);

--- a/apps/ui/src/stores/__tests__/apiKeyStore.test.tsx
+++ b/apps/ui/src/stores/__tests__/apiKeyStore.test.tsx
@@ -3,12 +3,17 @@
 import { act } from 'react';
 import { render, screen } from '@testing-library/react';
 import {
+  clearOpenAiCompatibleConfig,
   clearApiKey,
+  getOpenAiCompatibleConfig,
   getApiKey,
   getProviderFromModel,
   getStoredModel,
+  getStoredModelSelection,
   invalidateApiKeyStatus,
+  setStoredModelSelection,
   setStoredModel,
+  storeOpenAiCompatibleConfig,
   storeApiKey,
   useAvailableProviders,
   useHasApiKey,
@@ -50,13 +55,44 @@ describe('apiKeyStore', () => {
 
   it('persists the selected model and infers providers from known model prefixes', () => {
     expect(getStoredModel()).toBe('claude-sonnet-4-5');
+    expect(getStoredModelSelection()).toEqual({
+      provider: 'anthropic',
+      modelId: 'claude-sonnet-4-5',
+    });
 
     setStoredModel('gpt-5.4');
     expect(getStoredModel()).toBe('gpt-5.4');
+    expect(getStoredModelSelection()).toEqual({ provider: 'openai', modelId: 'gpt-5.4' });
     expect(getProviderFromModel('claude-sonnet-4-5')).toBe('anthropic');
     expect(getProviderFromModel('gpt-5.4')).toBe('openai');
     expect(getProviderFromModel('chatgpt-4o-latest')).toBe('openai');
     expect(getProviderFromModel('unknown-model')).toBe('anthropic');
+
+    setStoredModelSelection({ provider: 'openai-compatible', modelId: 'gemma4:12b' });
+    expect(getStoredModel()).toBe('gemma4:12b');
+    expect(getStoredModelSelection()).toEqual({
+      provider: 'openai-compatible',
+      modelId: 'gemma4:12b',
+    });
+  });
+
+  it('uses configured OpenAI-compatible settings for unknown legacy model ids', () => {
+    storeOpenAiCompatibleConfig({
+      baseUrl: ' http://127.0.0.1:11434/v1/ ',
+      modelId: 'gemma4:12b',
+      apiKey: null,
+    });
+    localStorage.setItem('openscad_studio_ai_model', 'local-alias');
+
+    expect(getOpenAiCompatibleConfig()).toEqual({
+      baseUrl: 'http://127.0.0.1:11434/v1',
+      modelId: 'gemma4:12b',
+      apiKey: null,
+    });
+    expect(getStoredModelSelection()).toEqual({
+      provider: 'openai-compatible',
+      modelId: 'gemma4:12b',
+    });
   });
 
   it('publishes provider availability through useSyncExternalStore hooks', () => {
@@ -83,6 +119,29 @@ describe('apiKeyStore', () => {
 
     act(() => {
       clearApiKey('openai');
+    });
+
+    expect(screen.getByTestId('providers').textContent).toBe('');
+    expect(screen.getByTestId('has-key').textContent).toBe('false');
+  });
+
+  it('publishes OpenAI-compatible availability without requiring an API key', () => {
+    render(<StoreHarness />);
+
+    act(() => {
+      storeOpenAiCompatibleConfig({
+        baseUrl: 'http://localhost:1234/v1',
+        modelId: 'lm-studio-model',
+        apiKey: null,
+      });
+    });
+
+    expect(screen.getByTestId('providers').textContent).toBe('openai-compatible');
+    expect(screen.getByTestId('has-key').textContent).toBe('true');
+    expect(getApiKey('openai-compatible')).toBeNull();
+
+    act(() => {
+      clearOpenAiCompatibleConfig();
     });
 
     expect(screen.getByTestId('providers').textContent).toBe('');

--- a/apps/ui/src/stores/__tests__/apiKeyStore.test.tsx
+++ b/apps/ui/src/stores/__tests__/apiKeyStore.test.tsx
@@ -131,7 +131,7 @@ describe('apiKeyStore', () => {
     act(() => {
       storeOpenAiCompatibleConfig({
         baseUrl: 'http://localhost:1234/v1',
-        modelId: 'lm-studio-model',
+        modelId: '',
         apiKey: null,
       });
     });

--- a/apps/ui/src/stores/__tests__/apiKeyStore.test.tsx
+++ b/apps/ui/src/stores/__tests__/apiKeyStore.test.tsx
@@ -76,6 +76,63 @@ describe('apiKeyStore', () => {
     });
   });
 
+  it('migrates legacy bare hosted model ids to provider-aware selections', () => {
+    localStorage.setItem('openscad_studio_ai_model', 'claude-3-5-sonnet-20241022');
+
+    expect(getStoredModelSelection()).toEqual({
+      provider: 'anthropic',
+      modelId: 'claude-3-5-sonnet-20241022',
+    });
+
+    localStorage.setItem('openscad_studio_ai_model', 'gpt-4o');
+
+    expect(getStoredModelSelection()).toEqual({
+      provider: 'openai',
+      modelId: 'gpt-4o',
+    });
+
+    localStorage.setItem('openscad_studio_ai_model', 'o3-mini');
+
+    expect(getStoredModelSelection()).toEqual({
+      provider: 'openai',
+      modelId: 'o3-mini',
+    });
+  });
+
+  it('prefers the new provider-aware selection over a legacy bare model id', () => {
+    localStorage.setItem('openscad_studio_ai_model', 'gpt-4o');
+    localStorage.setItem(
+      'openscad_studio_ai_model_selection',
+      JSON.stringify({ provider: 'anthropic', modelId: 'claude-opus-4' })
+    );
+
+    expect(getStoredModel()).toBe('claude-opus-4');
+    expect(getStoredModelSelection()).toEqual({
+      provider: 'anthropic',
+      modelId: 'claude-opus-4',
+    });
+  });
+
+  it('falls back to a legacy bare model id when the provider-aware selection is corrupt', () => {
+    localStorage.setItem('openscad_studio_ai_model_selection', 'not-json');
+    localStorage.setItem('openscad_studio_ai_model', 'gpt-4o');
+
+    expect(getStoredModelSelection()).toEqual({
+      provider: 'openai',
+      modelId: 'gpt-4o',
+    });
+  });
+
+  it('falls back to the first configured provider for unknown legacy model ids', () => {
+    storeApiKey('openai', 'openai-key');
+    localStorage.setItem('openscad_studio_ai_model', 'unknown-legacy-model');
+
+    expect(getStoredModelSelection()).toEqual({
+      provider: 'openai',
+      modelId: 'gpt-5.4',
+    });
+  });
+
   it('uses configured OpenAI-compatible settings for unknown legacy model ids', () => {
     storeOpenAiCompatibleConfig({
       baseUrl: ' http://127.0.0.1:11434/v1/ ',

--- a/apps/ui/src/stores/apiKeyStore.ts
+++ b/apps/ui/src/stores/apiKeyStore.ts
@@ -1,5 +1,5 @@
 import { useSyncExternalStore } from 'react';
-import { getPreferredDefaultModel } from '../utils/aiModels';
+import { DEFAULT_MODEL_IDS, getPreferredDefaultModel } from '../utils/aiModels';
 
 // ============================================================================
 // Constants
@@ -8,15 +8,38 @@ import { getPreferredDefaultModel } from '../utils/aiModels';
 const STORAGE_KEYS = {
   anthropic: 'openscad_studio_anthropic_api_key',
   openai: 'openscad_studio_openai_api_key',
+  openaiCompatibleApiKey: 'openscad_studio_openai_compatible_api_key',
+  openaiCompatibleBaseUrl: 'openscad_studio_openai_compatible_base_url',
+  openaiCompatibleModel: 'openscad_studio_openai_compatible_model',
   model: 'openscad_studio_ai_model',
+  modelSelection: 'openscad_studio_ai_model_selection',
 } as const;
 
-export type AiProvider = 'anthropic' | 'openai';
+export type AiProvider = 'anthropic' | 'openai' | 'openai-compatible';
+
+export interface AiModelSelection {
+  provider: AiProvider;
+  modelId: string;
+}
+
+export interface OpenAiCompatibleConfig {
+  baseUrl: string;
+  modelId: string;
+  apiKey: string | null;
+}
 
 interface ApiKeySnapshot {
   availableProviders: AiProvider[];
   hasAnyKey: boolean;
 }
+
+export const DEFAULT_OPENAI_COMPATIBLE_BASE_URL = 'http://127.0.0.1:11434/v1';
+
+const API_KEY_STORAGE_KEYS: Record<AiProvider, string> = {
+  anthropic: STORAGE_KEYS.anthropic,
+  openai: STORAGE_KEYS.openai,
+  'openai-compatible': STORAGE_KEYS.openaiCompatibleApiKey,
+};
 
 // ============================================================================
 // API Key Storage (localStorage-based, obfuscated)
@@ -38,24 +61,24 @@ function deobfuscate(stored: string): string | null {
 }
 
 export function storeApiKey(provider: AiProvider, key: string): void {
-  localStorage.setItem(STORAGE_KEYS[provider], obfuscate(key));
+  localStorage.setItem(API_KEY_STORAGE_KEYS[provider], obfuscate(key));
   notify();
 }
 
 export function clearApiKey(provider: AiProvider): void {
-  localStorage.removeItem(STORAGE_KEYS[provider]);
+  localStorage.removeItem(API_KEY_STORAGE_KEYS[provider]);
   notify();
 }
 
 export function getApiKey(provider: AiProvider): string | null {
-  const stored = localStorage.getItem(STORAGE_KEYS[provider]);
+  const stored = localStorage.getItem(API_KEY_STORAGE_KEYS[provider]);
   if (stored === null) return null;
 
   const decoded = deobfuscate(stored);
   if (decoded !== null) return decoded;
 
   // Legacy plaintext value — re-encode so storage is clean going forward
-  localStorage.setItem(STORAGE_KEYS[provider], obfuscate(stored));
+  localStorage.setItem(API_KEY_STORAGE_KEYS[provider], obfuscate(stored));
   return stored;
 }
 
@@ -64,10 +87,73 @@ export function hasApiKeyForProvider(provider: AiProvider): boolean {
   return key !== null && key.length > 0;
 }
 
+export function normalizeOpenAiCompatibleBaseUrl(baseUrl: string): string {
+  return baseUrl.trim().replace(/\/+$/, '');
+}
+
+export function getOpenAiCompatibleConfig(): OpenAiCompatibleConfig {
+  const baseUrl =
+    normalizeOpenAiCompatibleBaseUrl(
+      localStorage.getItem(STORAGE_KEYS.openaiCompatibleBaseUrl) ??
+        DEFAULT_OPENAI_COMPATIBLE_BASE_URL
+    ) || DEFAULT_OPENAI_COMPATIBLE_BASE_URL;
+  const modelId = (localStorage.getItem(STORAGE_KEYS.openaiCompatibleModel) ?? '').trim();
+  return {
+    baseUrl,
+    modelId,
+    apiKey: getApiKey('openai-compatible'),
+  };
+}
+
+export function storeOpenAiCompatibleConfig(config: OpenAiCompatibleConfig): void {
+  const baseUrl = normalizeOpenAiCompatibleBaseUrl(config.baseUrl);
+  const modelId = config.modelId.trim();
+
+  if (baseUrl) {
+    localStorage.setItem(STORAGE_KEYS.openaiCompatibleBaseUrl, baseUrl);
+  } else {
+    localStorage.removeItem(STORAGE_KEYS.openaiCompatibleBaseUrl);
+  }
+
+  if (modelId) {
+    localStorage.setItem(STORAGE_KEYS.openaiCompatibleModel, modelId);
+  } else {
+    localStorage.removeItem(STORAGE_KEYS.openaiCompatibleModel);
+  }
+
+  if (config.apiKey?.trim()) {
+    localStorage.setItem(STORAGE_KEYS.openaiCompatibleApiKey, obfuscate(config.apiKey.trim()));
+  } else {
+    localStorage.removeItem(STORAGE_KEYS.openaiCompatibleApiKey);
+  }
+
+  notify();
+}
+
+export function clearOpenAiCompatibleConfig(): void {
+  localStorage.removeItem(STORAGE_KEYS.openaiCompatibleBaseUrl);
+  localStorage.removeItem(STORAGE_KEYS.openaiCompatibleModel);
+  localStorage.removeItem(STORAGE_KEYS.openaiCompatibleApiKey);
+  notify();
+}
+
+export function hasOpenAiCompatibleConfig(): boolean {
+  const config = getOpenAiCompatibleConfig();
+  return config.baseUrl.length > 0 && config.modelId.length > 0;
+}
+
+export function isProviderConfigured(provider: AiProvider): boolean {
+  if (provider === 'openai-compatible') {
+    return hasOpenAiCompatibleConfig();
+  }
+  return hasApiKeyForProvider(provider);
+}
+
 export function getAvailableProviders(): AiProvider[] {
   const providers: AiProvider[] = [];
-  if (hasApiKeyForProvider('anthropic')) providers.push('anthropic');
-  if (hasApiKeyForProvider('openai')) providers.push('openai');
+  if (isProviderConfigured('anthropic')) providers.push('anthropic');
+  if (isProviderConfigured('openai')) providers.push('openai');
+  if (isProviderConfigured('openai-compatible')) providers.push('openai-compatible');
   return providers;
 }
 
@@ -76,18 +162,54 @@ export function getAvailableProviders(): AiProvider[] {
 // ============================================================================
 
 export function getStoredModel(): string {
-  return localStorage.getItem(STORAGE_KEYS.model) || getPreferredDefaultModel(['anthropic']);
+  return getStoredModelSelection().modelId;
 }
 
 export function setStoredModel(model: string): void {
-  localStorage.setItem(STORAGE_KEYS.model, model);
+  setStoredModelSelection({
+    provider: getProviderFromModel(model),
+    modelId: model,
+  });
 }
 
-// ============================================================================
-// Provider Detection
-// ============================================================================
+export function getPreferredDefaultModelSelection(providers: readonly string[]): AiModelSelection {
+  if (providers.includes('anthropic')) {
+    return { provider: 'anthropic', modelId: getPreferredDefaultModel(['anthropic']) };
+  }
+  if (providers.includes('openai')) {
+    return { provider: 'openai', modelId: getPreferredDefaultModel(['openai']) };
+  }
+  if (providers.includes('openai-compatible')) {
+    const config = getOpenAiCompatibleConfig();
+    return {
+      provider: 'openai-compatible',
+      modelId: config.modelId || DEFAULT_MODEL_IDS['openai-compatible'],
+    };
+  }
+  return { provider: 'anthropic', modelId: getPreferredDefaultModel(['anthropic']) };
+}
 
-export function getProviderFromModel(modelId: string): AiProvider {
+function isAiProvider(value: unknown): value is AiProvider {
+  return value === 'anthropic' || value === 'openai' || value === 'openai-compatible';
+}
+
+function parseStoredModelSelection(raw: string | null): AiModelSelection | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Partial<AiModelSelection>;
+    if (isAiProvider(parsed.provider) && typeof parsed.modelId === 'string') {
+      const modelId = parsed.modelId.trim();
+      if (modelId) {
+        return { provider: parsed.provider, modelId };
+      }
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function getProviderFromKnownModelPrefix(modelId: string): AiProvider | null {
   if (modelId.startsWith('claude') || modelId.startsWith('anthropic')) {
     return 'anthropic';
   }
@@ -99,6 +221,46 @@ export function getProviderFromModel(modelId: string): AiProvider {
   ) {
     return 'openai';
   }
+  return null;
+}
+
+export function getStoredModelSelection(): AiModelSelection {
+  const storedSelection = parseStoredModelSelection(
+    localStorage.getItem(STORAGE_KEYS.modelSelection)
+  );
+  if (storedSelection) return storedSelection;
+
+  const legacyModel = localStorage.getItem(STORAGE_KEYS.model);
+  if (legacyModel?.trim()) {
+    const modelId = legacyModel.trim();
+    const provider = getProviderFromKnownModelPrefix(modelId);
+    if (provider) {
+      return { provider, modelId };
+    }
+  }
+
+  const availableProviders = getAvailableProviders();
+  return getPreferredDefaultModelSelection(availableProviders);
+}
+
+export function setStoredModelSelection(selection: AiModelSelection): void {
+  const modelId = selection.modelId.trim();
+  if (!modelId) return;
+  localStorage.setItem(
+    STORAGE_KEYS.modelSelection,
+    JSON.stringify({ provider: selection.provider, modelId } satisfies AiModelSelection)
+  );
+  // Keep the legacy string key updated for analytics and older callers during migration.
+  localStorage.setItem(STORAGE_KEYS.model, modelId);
+}
+
+// ============================================================================
+// Provider Detection
+// ============================================================================
+
+export function getProviderFromModel(modelId: string): AiProvider {
+  const provider = getProviderFromKnownModelPrefix(modelId);
+  if (provider) return provider;
   return 'anthropic'; // Default
 }
 

--- a/apps/ui/src/stores/apiKeyStore.ts
+++ b/apps/ui/src/stores/apiKeyStore.ts
@@ -92,11 +92,13 @@ export function normalizeOpenAiCompatibleBaseUrl(baseUrl: string): string {
 }
 
 export function getOpenAiCompatibleConfig(): OpenAiCompatibleConfig {
+  const storedBaseUrl = normalizeOpenAiCompatibleBaseUrl(
+    localStorage.getItem(STORAGE_KEYS.openaiCompatibleBaseUrl) ?? ''
+  );
   const baseUrl =
-    normalizeOpenAiCompatibleBaseUrl(
-      localStorage.getItem(STORAGE_KEYS.openaiCompatibleBaseUrl) ??
-        DEFAULT_OPENAI_COMPATIBLE_BASE_URL
-    ) || DEFAULT_OPENAI_COMPATIBLE_BASE_URL;
+    storedBaseUrl ||
+    normalizeOpenAiCompatibleBaseUrl(DEFAULT_OPENAI_COMPATIBLE_BASE_URL) ||
+    DEFAULT_OPENAI_COMPATIBLE_BASE_URL;
   const modelId = (localStorage.getItem(STORAGE_KEYS.openaiCompatibleModel) ?? '').trim();
   return {
     baseUrl,
@@ -134,12 +136,15 @@ export function clearOpenAiCompatibleConfig(): void {
   localStorage.removeItem(STORAGE_KEYS.openaiCompatibleBaseUrl);
   localStorage.removeItem(STORAGE_KEYS.openaiCompatibleModel);
   localStorage.removeItem(STORAGE_KEYS.openaiCompatibleApiKey);
+  clearStoredModelSelectionForProvider('openai-compatible');
   notify();
 }
 
 export function hasOpenAiCompatibleConfig(): boolean {
-  const config = getOpenAiCompatibleConfig();
-  return config.baseUrl.length > 0 && config.modelId.length > 0;
+  const storedBaseUrl = normalizeOpenAiCompatibleBaseUrl(
+    localStorage.getItem(STORAGE_KEYS.openaiCompatibleBaseUrl) ?? ''
+  );
+  return storedBaseUrl.length > 0;
 }
 
 export function isProviderConfigured(provider: AiProvider): boolean {
@@ -252,6 +257,15 @@ export function setStoredModelSelection(selection: AiModelSelection): void {
   );
   // Keep the legacy string key updated for analytics and older callers during migration.
   localStorage.setItem(STORAGE_KEYS.model, modelId);
+}
+
+export function clearStoredModelSelectionForProvider(provider: AiProvider): void {
+  const storedSelection = parseStoredModelSelection(
+    localStorage.getItem(STORAGE_KEYS.modelSelection)
+  );
+  if (storedSelection?.provider !== provider) return;
+  localStorage.removeItem(STORAGE_KEYS.modelSelection);
+  localStorage.removeItem(STORAGE_KEYS.model);
 }
 
 // ============================================================================

--- a/apps/ui/src/utils/aiModels.ts
+++ b/apps/ui/src/utils/aiModels.ts
@@ -1,4 +1,4 @@
-export type SupportedModelProvider = 'anthropic' | 'openai';
+export type SupportedModelProvider = 'anthropic' | 'openai' | 'openai-compatible';
 
 export interface KnownModelDefinition {
   id: string;
@@ -9,6 +9,7 @@ export interface KnownModelDefinition {
 export const DEFAULT_MODEL_IDS: Record<SupportedModelProvider, string> = {
   anthropic: 'claude-sonnet-4-5',
   openai: 'gpt-5.4',
+  'openai-compatible': 'gemma4:12b',
 };
 
 export const KNOWN_DISPLAY_NAMES: Record<string, string> = {
@@ -68,18 +69,26 @@ export const DEFAULT_MODEL_CATALOG: KnownModelDefinition[] = [
 ];
 
 const PROVIDER_ORDER: SupportedModelProvider[] = ['anthropic', 'openai'];
+const PROVIDER_ORDER_WITH_CUSTOM: SupportedModelProvider[] = [
+  'anthropic',
+  'openai',
+  'openai-compatible',
+];
 
 export function normalizeProviders(providers: readonly string[]): SupportedModelProvider[] {
-  return PROVIDER_ORDER.filter((provider) => providers.includes(provider));
+  return PROVIDER_ORDER_WITH_CUSTOM.filter((provider) => providers.includes(provider));
 }
 
 export function getPreferredDefaultModel(providers: readonly string[]): string {
-  const normalizedProviders = normalizeProviders(providers);
+  const normalizedProviders = PROVIDER_ORDER.filter((provider) => providers.includes(provider));
   if (normalizedProviders.includes('anthropic')) {
     return DEFAULT_MODEL_IDS.anthropic;
   }
   if (normalizedProviders.includes('openai')) {
     return DEFAULT_MODEL_IDS.openai;
+  }
+  if (providers.includes('openai-compatible')) {
+    return DEFAULT_MODEL_IDS['openai-compatible'];
   }
   return DEFAULT_MODEL_IDS.anthropic;
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -206,7 +206,8 @@
           >
             <h3 class="text-xl font-semibold mb-2 text-white">AI Copilot</h3>
             <p class="text-gray-400 text-sm mb-4 leading-relaxed">
-              Natural language to OpenSCAD. Works with Claude and GPT models. Bring your own API keys.
+              Natural language to OpenSCAD. Works with Claude, GPT, and local OpenAI-compatible
+              models such as Ollama, llama.cpp, and LM Studio.
             </p>
             <div class="rounded-xl overflow-hidden border border-slate-800/50">
               <img src="images/ai-conversation.png" alt="AI Copilot" class="w-full" />

--- a/e2e/fixtures/app.fixture.ts
+++ b/e2e/fixtures/app.fixture.ts
@@ -315,16 +315,29 @@ export class AppHelper {
   /** Dismiss the welcome screen if it's showing */
   async dismissWelcomeScreen() {
     const welcomeScreen = this.page.getByTestId('welcome-screen');
-    const startButton = this.page.getByTestId('welcome-start-empty-project');
-    if (!(await welcomeScreen.isVisible({ timeout: 2_000 }).catch(() => false))) {
+    const welcomeVisible = await welcomeScreen.isVisible({ timeout: 2_000 }).catch(() => false);
+    if (!welcomeVisible) {
       return;
     }
 
+    const startButton = this.page
+      .getByTestId('welcome-start-empty-project')
+      .or(this.page.getByRole('button', { name: /Start (with empty project|in folder)/i }))
+      .first();
+
     if (await startButton.isVisible({ timeout: 2000 }).catch(() => false)) {
       await startButton.click();
-      await welcomeScreen.waitFor({ state: 'hidden', timeout: 5_000 }).catch(() => {});
-      await this.page.waitForTimeout(500);
     }
+
+    await Promise.race([
+      welcomeScreen.waitFor({ state: 'hidden', timeout: 10_000 }).catch(() => {}),
+      this.page
+        .locator('.dv-tab')
+        .first()
+        .waitFor({ state: 'visible', timeout: 10_000 })
+        .catch(() => {}),
+    ]);
+    await this.page.waitForTimeout(500);
   }
 
   // -- NUX (legacy first-run layout picker) ----------------------------------
@@ -386,7 +399,13 @@ export class AppHelper {
 
   async configureAnthropicApiKey(key = 'test-anthropic-key') {
     await this.page.evaluate((apiKey) => {
-      localStorage.setItem('openscad_studio_anthropic_api_key', apiKey);
+      const obfuscatedKey = `obf1:${btoa(apiKey.split('').reverse().join(''))}`;
+      localStorage.setItem('openscad_studio_anthropic_api_key', obfuscatedKey);
+      localStorage.setItem(
+        'openscad_studio_ai_model_selection',
+        JSON.stringify({ provider: 'anthropic', modelId: 'claude-sonnet-4-5' })
+      );
+      localStorage.setItem('openscad_studio_ai_model', 'claude-sonnet-4-5');
     }, key);
     await this.page.reload();
     await this.page.waitForLoadState('domcontentloaded');

--- a/e2e/tests/ai/ai-chat.spec.ts
+++ b/e2e/tests/ai/ai-chat.spec.ts
@@ -12,6 +12,13 @@ test.describe('AI Chat Panel', () => {
     await clearAiMocks(app.page);
   });
 
+  function aiPanelReadyLocator(app: { page: import('@playwright/test').Page }) {
+    return app.page
+      .getByText('Configure an AI provider to get started')
+      .or(app.page.getByText('Use built-in AI or Studio MCP'))
+      .or(app.page.getByPlaceholder(/describe the changes/i));
+  }
+
   async function openConfiguredAi(app: {
     configureAnthropicApiKey: () => Promise<void>;
     openAiPanel: () => Promise<void>;
@@ -22,28 +29,18 @@ test.describe('AI Chat Panel', () => {
 
   test('AI panel is accessible via tab click', async ({ app }) => {
     await app.openAiPanel();
-    await expect(
-      app.page.getByText('Add an API key').or(app.page.getByPlaceholder(/describe the changes/i))
-    ).toBeVisible({ timeout: 5000 });
+    await expect(aiPanelReadyLocator(app)).toBeVisible({ timeout: 5000 });
   });
 
-  test('shows no API key message when unconfigured', async ({ app }) => {
+  test('shows no AI provider message when unconfigured', async ({ app }) => {
     await app.openAiPanel();
-    await expect(app.page.getByText('Add an API key')).toBeVisible({ timeout: 5000 });
+    await expect(app.page.getByText('Configure an AI provider to get started')).toBeVisible({
+      timeout: 5000,
+    });
   });
 
   test('new conversation button exists when API key set', async ({ app }) => {
-    await app.openAiPanel();
-    const hasApiKeyPrompt = await app.page
-      .getByText('Add an API key')
-      .isVisible({ timeout: 3000 })
-      .catch(() => false);
-
-    if (hasApiKeyPrompt) {
-      await expect(app.page.getByTestId('ai-new-conversation-button')).not.toBeAttached();
-      return;
-    }
-
+    await openConfiguredAi(app);
     await expect(app.page.getByTestId('ai-new-conversation-button')).toBeAttached({
       timeout: 5000,
     });
@@ -65,9 +62,7 @@ test.describe('AI Chat Panel', () => {
     }
 
     await app.page.keyboard.press('Meta+k');
-    await expect(
-      app.page.getByText('Add an API key').or(app.page.getByPlaceholder(/describe the changes/i))
-    ).toBeVisible({ timeout: 5000 });
+    await expect(aiPanelReadyLocator(app)).toBeVisible({ timeout: 5000 });
   });
 
   test('streams assistant text into the transcript with incremental updates', async ({ app }) => {

--- a/e2e/tests/integration/keyboard-shortcuts.spec.ts
+++ b/e2e/tests/integration/keyboard-shortcuts.spec.ts
@@ -21,7 +21,10 @@ test.describe('Keyboard shortcuts', () => {
   test('Meta+K activates AI panel', async ({ app }) => {
     await app.page.keyboard.press('Meta+k');
     await expect(
-      app.page.getByText('Add an API key').or(app.page.getByPlaceholder(/describe the changes/i))
+      app.page
+        .getByText('Configure an AI provider to get started')
+        .or(app.page.getByText('Use built-in AI or Studio MCP'))
+        .or(app.page.getByPlaceholder(/describe the changes/i))
     ).toBeVisible({ timeout: 5000 });
   });
 

--- a/e2e/tests/panels/customizer-panel.spec.ts
+++ b/e2e/tests/panels/customizer-panel.spec.ts
@@ -148,7 +148,7 @@ test.describe('Customizer Panel', () => {
       timeout: 10_000,
     });
     await app.page.getByTestId('customizer-refine-button').click();
-    await expect(app.page.getByText('Add an API key to get started')).toBeVisible({
+    await expect(app.page.getByText('Configure an AI provider to get started')).toBeVisible({
       timeout: 10_000,
     });
   });

--- a/implementation-plans/expandable-ai-thinking-blocks.md
+++ b/implementation-plans/expandable-ai-thinking-blocks.md
@@ -1,0 +1,174 @@
+# Expandable AI Thinking Blocks
+
+## Goal
+
+Add expandable "Thinking" blocks to the AI transcript when a model/provider emits reasoning tokens that are available to the app. The UI should keep the current compact thinking indicator for streams that do not expose reasoning, but when reasoning chunks are present it should show a collapsed block the user can expand to inspect the model-provided reasoning text.
+
+This plan is only for rendering reasoning that is actually present in the stream. The app should not synthesize hidden reasoning, ask a model to reveal private chain-of-thought, or infer content that was not delivered by the provider.
+
+## Current State
+
+- `apps/ui/src/utils/aiTurnState.ts` already receives Vercel AI SDK stream chunks.
+- `reasoning-start`, `reasoning-delta`, and `reasoning-end` are explicitly handled today, but they are ignored.
+- `deriveStreamingResponse()` only derives active assistant text parts from `text-start`/`text-delta`/`text-end`.
+- `apps/ui/src/components/AiPromptPanel.tsx` shows:
+  - persisted user, assistant, and tool-call messages;
+  - active tool-call cards;
+  - active streaming assistant text;
+  - a generic animated "Thinking..." card when the turn is streaming with no text and no pending tool.
+- `apps/ui/src/types/aiChat.ts` has no message type or assistant segment shape for reasoning content.
+- `apps/ui/src/utils/aiMessages.ts` serializes conversation history back to model messages, and should continue to exclude thinking blocks unless a provider explicitly requires otherwise.
+
+## UX Direction
+
+- Keep thinking collapsed by default.
+- Use a compact row with the existing three-dot activity indicator while reasoning is streaming.
+- Label collapsed content as `Thinking` or `Thinking...` while active, and something like `Thinking details` after completion.
+- Show the reasoning body only after the user expands it.
+- Keep the body visually subordinate to normal assistant output:
+  - smaller text;
+  - muted foreground;
+  - restrained border/background;
+  - max height with internal scrolling for long reasoning.
+- Preserve keyboard and screen-reader access:
+  - use a real button or disclosure control;
+  - expose `aria-expanded`;
+  - connect the button to the collapsible region.
+- Do not display a blank expandable block. If the provider emits reasoning lifecycle chunks but no non-whitespace content, keep the existing generic thinking indicator.
+
+## Data Model
+
+Add a reasoning segment type to `apps/ui/src/types/aiChat.ts`.
+
+Suggested shape:
+
+```ts
+export interface ReasoningMessage extends BaseMessage {
+  type: 'reasoning';
+  turnId: string;
+  content: string;
+  state: AssistantMessageState;
+}
+
+export type Message = UserMessage | AssistantMessage | ToolCallMessage | ReasoningMessage;
+```
+
+For active streaming state in `aiTurnState.ts`, mirror the text-part model:
+
+```ts
+interface ActiveReasoningPart {
+  id: string;
+  text: string;
+}
+
+interface ActiveTurnState {
+  activeReasoningPartsById: Record<string, ActiveReasoningPart>;
+  activeReasoningPartOrder: string[];
+  persistedReasoningSegments: ReasoningMessage[];
+}
+```
+
+Open question to resolve during implementation: whether reasoning should become first-class transcript messages, as above, or metadata attached to assistant messages for the same turn. First-class messages are simpler because tool calls can appear between reasoning and assistant text, and the current transcript already handles ordered message segments.
+
+## Stream Handling
+
+1. Inspect the actual `TextStreamPart` payloads from the installed AI SDK version for reasoning chunks.
+2. Add reducer cases in `reduceActiveTurnChunk()`:
+   - `reasoning-start`: create an active reasoning part.
+   - `reasoning-delta`: append chunk text to the matching active reasoning part.
+   - `reasoning-end`: persist the reasoning part if it has non-whitespace content.
+3. Add a flush path in `finalizeActiveTurn()` so partial reasoning is preserved on completion, cancellation, or error.
+4. Add `deriveStreamingReasoning()` or `deriveCurrentReasoningBlocks()` for active reasoning UI state.
+5. Update `useAiAgent.ts` state with a new field such as:
+
+```ts
+streamingReasoning: string | null;
+currentReasoningMessages: ReasoningMessage[];
+```
+
+6. Keep `didReceiveResponseRef` logic aware of reasoning chunks so a provider that emits only reasoning initially still counts as an active response.
+7. Continue ignoring unsupported `source`, `file`, `raw`, and approval chunks unless separately needed.
+
+## Transcript Rendering
+
+Add a small reusable component, likely in `AiPromptPanel.tsx` or a new `AiThinkingBlock.tsx`:
+
+- props:
+  - `content?: string`;
+  - `state: 'streaming' | 'complete' | 'cancelled' | 'error'`;
+  - `defaultExpanded?: boolean`;
+- collapsed state:
+  - animated dots while streaming;
+  - title only after completion;
+  - optional token/character count only if it feels useful and does not clutter the panel.
+- expanded state:
+  - render reasoning text in a pre-wrapped text container, not Markdown by default.
+  - Reasoning can contain scratch syntax or partial tokens; Markdown rendering may make it look more authoritative than it is.
+
+Render rules:
+
+- For persisted `reasoning` messages, render the expandable thinking block in transcript order.
+- For active streaming reasoning, render an expandable thinking block above active text/tool cards.
+- If there is active reasoning content but no assistant text yet, replace the generic "Thinking..." placeholder with the expandable thinking block.
+- If there is no reasoning content, keep the existing generic "Thinking..." placeholder exactly as today.
+
+## Conversation History
+
+- Persist reasoning blocks in local conversation history if the transcript persists other assistant/tool messages for that conversation.
+- Do not send reasoning blocks back to the model in `messagesToModelMessages()`.
+- Add a migration-safe fallback: unknown message types should be ignored by model-message serialization rather than crashing.
+- Do not include reasoning content in analytics payloads.
+
+## Provider Behavior
+
+- Anthropic, OpenAI, and OpenAI-compatible providers may differ in what reasoning chunks the Vercel AI SDK exposes.
+- Some local providers may emit reasoning as ordinary text, for example visible `<think>...</think>` content, rather than SDK `reasoning-*` chunks.
+- This first pass should support SDK reasoning chunks only.
+- A follow-up can sanitize visible `<think>` tags from ordinary text into thinking blocks if local OpenAI-compatible providers commonly stream them as text, but that should be separate because it is parser-sensitive and model-specific.
+
+## Implementation Checklist
+
+- [ ] Add `ReasoningMessage` to `apps/ui/src/types/aiChat.ts`.
+- [ ] Extend `ActiveTurnState` with active and persisted reasoning segment state.
+- [ ] Implement `reasoning-start`, `reasoning-delta`, and `reasoning-end` handling in `apps/ui/src/utils/aiTurnState.ts`.
+- [ ] Add finalize/flush behavior for partial reasoning on complete, cancel, and error.
+- [ ] Add selector helpers for active streaming reasoning.
+- [ ] Thread reasoning state through `useAiAgent.ts`, `WorkspaceContext.tsx`, `PanelComponents.tsx`, and `AiPromptPanel.tsx`.
+- [ ] Add an expandable thinking block component with accessible disclosure behavior.
+- [ ] Render persisted and active reasoning blocks in the transcript.
+- [ ] Ensure model-message serialization excludes reasoning blocks.
+- [ ] Add tests for reducer behavior, cancellation/error finalization, transcript rendering, accessibility state, and model serialization.
+- [ ] Manually test with a provider/model known to expose reasoning chunks through the AI SDK.
+
+## Test Plan
+
+Automated:
+
+- `apps/ui/src/utils/__tests__/aiTurnState.test.ts`
+  - persists completed reasoning chunks;
+  - preserves partial reasoning on cancel/error;
+  - does not create blank reasoning messages;
+  - keeps reasoning ordered relative to text/tool messages.
+- `apps/ui/src/hooks/__tests__/useAiAgent.test.tsx`
+  - exposes active reasoning while streaming;
+  - finalizes reasoning into transcript messages.
+- `apps/ui/src/components/__tests__/AiPromptPanel.test.tsx`
+  - shows generic `Thinking...` when no reasoning content exists;
+  - shows collapsed thinking block when reasoning content exists;
+  - expands/collapses with keyboard-accessible controls.
+- `apps/ui/src/utils/__tests__/aiMessages.test.ts`
+  - excludes reasoning messages from `messagesToModelMessages()`.
+
+Manual:
+
+- Verify a reasoning-capable hosted model if available.
+- Verify a local OpenAI-compatible model that emits SDK reasoning chunks, if available.
+- Confirm long reasoning text scrolls inside the expanded block without resizing the entire transcript awkwardly.
+- Confirm normal models that do not expose reasoning still show the existing animated placeholder.
+
+## Risks
+
+- Provider support may be inconsistent. The UI should be capability-driven: no reasoning chunks, no expandable block.
+- Reasoning content can be long. Use collapsed-by-default display and a max-height body.
+- Some local models emit `<think>` tags as ordinary assistant text. Avoid parsing that in v1 unless validated with several model outputs.
+- Reasoning may include sensitive prompt or tool context. Keep it local, exclude it from analytics, and do not include it in future model requests.

--- a/implementation-plans/issue-125-openai-compatible-provider.md
+++ b/implementation-plans/issue-125-openai-compatible-provider.md
@@ -184,11 +184,11 @@ Keep the existing hosted provider key storage and obfuscation behavior.
 
 ### 8. Desktop and web behavior
 
-- [ ] Support desktop as the primary path.
-- [ ] Allow web builds to use OpenAI-compatible endpoints when CORS permits, which Ollama currently appears to permit for localhost.
-- [ ] If fetch fails with a CORS/network-like error, show a targeted message explaining that the local server must be running and allow browser requests.
-- [ ] Avoid adding a Rust/Tauri proxy in the first implementation unless browser fetch proves unreliable in packaged desktop.
-- [ ] If a Tauri proxy becomes necessary, add it as a follow-up implementation plan rather than hiding it in this feature.
+- [x] Support desktop as the primary path.
+- [x] Allow web builds to use OpenAI-compatible endpoints when CORS permits, which Ollama currently appears to permit for localhost.
+- [x] If fetch fails with a CORS/network-like error, show a targeted message explaining that the local server must be running and allow browser requests.
+- [x] Avoid adding a Rust/Tauri proxy in the first implementation unless browser fetch proves unreliable in packaged desktop.
+- [x] If a Tauri proxy becomes necessary, add it as a follow-up implementation plan rather than hiding it in this feature.
 
 ### 9. Documentation and issue response
 

--- a/implementation-plans/issue-125-openai-compatible-provider.md
+++ b/implementation-plans/issue-125-openai-compatible-provider.md
@@ -1,0 +1,259 @@
+# Issue 125: OpenAI-Compatible Local Provider Support
+
+## Goal
+
+Add first-class support for local and self-hosted OpenAI-compatible chat providers, with Ollama and llama.cpp as the primary target servers. This addresses issue #125, where users currently only see API-key settings for hosted Anthropic/OpenAI models and have no obvious way to use local models.
+
+The intended user-facing outcome is a configurable "OpenAI-compatible" provider in AI settings:
+
+- Base URL, for example `http://127.0.0.1:11434/v1` for Ollama or `http://127.0.0.1:8080/v1` for llama.cpp.
+- Model id/name, for example `gemma4:12b` or the model id reported by the local server.
+- Optional API key for servers that require one.
+- Model refresh/test behavior that works against `/models` when available.
+
+## Issue Context
+
+The issue asks for "Ollama / Llama.cpp" support. A later clarification narrows the requested shape to local OpenAI-compatible providers with configurable base URL, model name, and optional API key, especially for the desktop app.
+
+This should be implemented as one generic OpenAI-compatible provider rather than separate hardcoded "Ollama" and "llama.cpp" providers. Ollama and llama.cpp should appear in copy, defaults, examples, tests, and manual validation.
+
+## Current State
+
+The AI copilot runs entirely in the frontend for both web and desktop builds.
+
+Relevant current files:
+
+- `apps/ui/src/stores/apiKeyStore.ts`
+  - Stores only Anthropic and OpenAI API keys.
+  - Defines `AiProvider = 'anthropic' | 'openai'`.
+  - Persists only a bare model id string.
+  - Infers the provider from the model id prefix.
+- `apps/ui/src/utils/aiModels.ts`
+  - Knows only Anthropic and OpenAI model catalogs and provider ordering.
+- `apps/ui/src/hooks/useModels.ts`
+  - Fetches Anthropic models from Anthropic's API.
+  - Fetches OpenAI models from `https://api.openai.com/v1/models`.
+  - Filters OpenAI models to known useful hosted model families.
+- `apps/ui/src/services/aiService.ts`
+  - Creates Anthropic models with `createAnthropic`.
+  - Creates OpenAI models with `createOpenAI({ apiKey })`.
+- `apps/ui/src/hooks/useAiAgent.ts`
+  - Resolves provider from the selected model id.
+  - Requires an API key before streaming.
+  - Sends analytics using provider inferred from model id.
+- `apps/ui/src/components/settings/AiSettings.tsx`
+  - Presents only Anthropic/OpenAI API-key cards.
+- `apps/ui/src/components/ModelSelector.tsx`
+  - Groups models only by Anthropic and OpenAI.
+- `apps/ui/src/hooks/useOpenScad.ts`
+  - Records AI edit render analytics using the stored bare model id and inferred provider.
+
+The main architectural problem is that a model id currently implies its provider. That breaks for local model names like `gemma4:12b`, `qwen3-coder`, or a llama.cpp server model alias.
+
+## Local Test Baseline
+
+The local machine has Ollama available for validation.
+
+Observed local Ollama behavior:
+
+- `ollama list` reports `gemma4:12b`.
+- `GET http://127.0.0.1:11434/v1/models` reports `gemma4:12b`.
+- Browser-style CORS preflight from `http://localhost:1420` to `http://127.0.0.1:11434/v1/chat/completions` succeeds.
+- `POST /v1/chat/completions` returns normal assistant text.
+- A request with OpenAI-style `tools` returns OpenAI-style `tool_calls`.
+- Responses may include separate reasoning content. The current stream reducer already ignores AI SDK reasoning chunks, which should remain the default behavior.
+
+## Design Principles
+
+1. Treat self-hosted support as OpenAI-compatible, not Ollama-specific.
+2. Do not regress Anthropic or hosted OpenAI behavior.
+3. Do not rely on model-id prefixes for request routing.
+4. Keep API keys optional for the custom provider.
+5. Keep local provider configuration local-only and marked `ph-no-capture`.
+6. Prefer desktop support first, while allowing the web build to attempt compatible URLs when CORS allows it.
+7. Make the feature understandable to hobbyist makers: one small, practical settings card with tested defaults, not provider jargon spread across the app.
+
+## Proposed Data Model
+
+Introduce an explicit model selection shape:
+
+```ts
+export type AiProvider = 'anthropic' | 'openai' | 'openai-compatible';
+
+export interface AiModelSelection {
+  provider: AiProvider;
+  modelId: string;
+}
+```
+
+Persist the new selection in local storage under a new key, while migrating legacy bare model ids:
+
+- Legacy `claude*`/`anthropic*` model ids become `{ provider: 'anthropic', modelId }`.
+- Legacy `gpt*`/`o1*`/`o3*`/`chatgpt*` model ids become `{ provider: 'openai', modelId }`.
+- Unknown legacy ids should not silently become Anthropic. Prefer resolving to the first configured provider, or fall back to the preferred default.
+
+Add a custom provider config shape:
+
+```ts
+export interface OpenAiCompatibleConfig {
+  baseUrl: string;
+  modelId: string;
+  apiKey: string | null;
+}
+```
+
+Suggested storage keys:
+
+- `openscad_studio_ai_model_selection`
+- `openscad_studio_openai_compatible_base_url`
+- `openscad_studio_openai_compatible_model`
+- `openscad_studio_openai_compatible_api_key`
+
+Keep the existing hosted provider key storage and obfuscation behavior.
+
+## Implementation Plan
+
+### 1. Refactor provider and model selection storage
+
+- [ ] Extend `AiProvider` to include `openai-compatible`.
+- [ ] Add `AiModelSelection` helpers in `apiKeyStore.ts`.
+- [ ] Add `getStoredModelSelection()` and `setStoredModelSelection()`.
+- [ ] Keep `getStoredModel()` temporarily as a compatibility helper if needed by existing callers, but migrate internal AI flow to explicit selection.
+- [ ] Replace provider inference in AI request paths with stored/current selection provider.
+- [ ] Keep `getProviderFromModel()` only for legacy migration and any unavoidable compatibility code.
+- [ ] Update tests in `apps/ui/src/stores/__tests__/apiKeyStore.test.tsx`.
+
+### 2. Add OpenAI-compatible provider configuration
+
+- [ ] Add storage helpers for custom base URL, model id, and optional key.
+- [ ] Normalize base URLs by trimming whitespace and removing trailing slashes.
+- [ ] Treat the provider as available when it has a valid base URL and model id.
+- [ ] Do not require a non-empty API key for provider availability.
+- [ ] Use a placeholder key such as `local` or no Authorization header depending on provider factory behavior; avoid blocking on missing key.
+- [ ] Add unit coverage for optional-key availability.
+
+### 3. Update model creation
+
+- [ ] Update `createModel()` in `aiService.ts` to accept a model selection/config object or provider plus resolved provider config.
+- [ ] For Anthropic, preserve existing `createAnthropic` behavior and browser access header.
+- [ ] For hosted OpenAI, preserve existing `createOpenAI({ apiKey })` behavior.
+- [ ] For OpenAI-compatible providers, create a provider with the configured `baseURL`, optional `apiKey`, and a non-hosted provider name such as `openai-compatible`.
+- [ ] Force the custom provider through the Chat Completions model factory, for example `.chat(modelId)`, rather than relying on the OpenAI provider default API selection.
+- [ ] Add tests verifying the custom provider receives base URL, model id, and optional API key.
+
+### 4. Update model listing
+
+- [ ] Extend `ModelInfo.provider` and `GroupedModels` for `openai-compatible`.
+- [ ] Add a generic fetcher for `${baseUrl}/models`.
+- [ ] Do not apply hosted OpenAI relevance filtering to custom provider models.
+- [ ] If `/models` fails but a custom model id is configured, show the configured model as a fallback option with a warning toast.
+- [ ] Store model cache per provider/base URL combination so a hosted OpenAI cache cannot satisfy a custom provider request.
+- [ ] Update `useModels` tests for custom model fetch, fallback configured model, cache isolation, and provider shrink behavior.
+
+### 5. Update settings UI
+
+- [ ] Add an OpenAI-compatible settings card in `AiSettings.tsx`.
+- [ ] Include fields for Base URL, Model, and optional API key.
+- [ ] Default the base URL to `http://127.0.0.1:11434/v1` for Ollama.
+- [ ] Include concise helper copy mentioning Ollama and llama.cpp examples.
+- [ ] Add a "Test connection" or "Refresh models" control that fetches `/models` and shows success/failure.
+- [ ] Keep all local provider fields under `ph-no-capture`.
+- [ ] Update save button behavior so AI settings can save API keys and custom provider config without confusing "Save Key" copy.
+- [ ] Add component coverage in `SettingsDialog.test.tsx`.
+
+### 6. Update model selector and access states
+
+- [ ] Update `ModelSelector.tsx` to show an "OpenAI-compatible" group.
+- [ ] Ensure select item values remain unique even if two providers expose the same model id.
+- [ ] Prefer storing selection as provider+model rather than overloading select values with raw model ids.
+- [ ] Update empty states from "No API keys" to "No AI provider configured" where appropriate.
+- [ ] Update `WelcomeScreen`, `AiPromptPanel`, and `AiAccessEmptyState` copy to mention local/OpenAI-compatible configuration without making the UI feel AI-generic.
+- [ ] Add component tests for a configured local provider appearing without an API key.
+
+### 7. Update AI request flow
+
+- [ ] Update `useAiAgent.ts` state from `currentModel: string` to explicit current selection, or add `currentProvider` alongside `currentModel`.
+- [ ] Resolve provider config before submit.
+- [ ] For Anthropic/OpenAI, keep missing-key validation.
+- [ ] For OpenAI-compatible, validate base URL/model id and allow missing API key.
+- [ ] Track analytics with explicit provider and model id.
+- [ ] Avoid sending the local base URL or API key to analytics.
+- [ ] Update `useOpenScad.ts` AI edit analytics to use explicit provider selection.
+- [ ] Keep reasoning chunks ignored in `aiTurnState.ts`.
+- [ ] Add tests for submitting with a local provider and no API key.
+
+### 8. Desktop and web behavior
+
+- [ ] Support desktop as the primary path.
+- [ ] Allow web builds to use OpenAI-compatible endpoints when CORS permits, which Ollama currently appears to permit for localhost.
+- [ ] If fetch fails with a CORS/network-like error, show a targeted message explaining that the local server must be running and allow browser requests.
+- [ ] Avoid adding a Rust/Tauri proxy in the first implementation unless browser fetch proves unreliable in packaged desktop.
+- [ ] If a Tauri proxy becomes necessary, add it as a follow-up implementation plan rather than hiding it in this feature.
+
+### 9. Documentation and issue response
+
+- [ ] Add concise user-facing docs in an appropriate developer/user doc if the project has a current AI settings guide.
+- [ ] Do not expand top-level `README.md` into an engineering index.
+- [ ] When implementation ships, reply to issue #125 explaining the OpenAI-compatible setup:
+  - Ollama: `ollama serve`, `ollama pull <model>`, base URL `http://127.0.0.1:11434/v1`.
+  - llama.cpp: run `llama-server`, base URL `http://127.0.0.1:8080/v1`.
+
+## Acceptance Criteria
+
+- [ ] A user can configure Ollama in Settings with base URL `http://127.0.0.1:11434/v1`, model `gemma4:12b`, and no API key.
+- [ ] The configured local model appears in the model selector.
+- [ ] The AI assistant can send a normal chat request to the local model.
+- [ ] The AI assistant can execute the existing local tool flow with a compatible model that emits OpenAI-style tool calls.
+- [ ] Anthropic and hosted OpenAI model selection still work.
+- [ ] Legacy stored model ids migrate without losing the selected hosted model.
+- [ ] Local provider configuration is not captured by analytics.
+- [ ] Error messages distinguish missing hosted API keys from missing or unreachable local provider config.
+
+## Validation Plan
+
+Automated validation:
+
+- [ ] `pnpm --filter ui test -- src/stores/__tests__/apiKeyStore.test.tsx`
+- [ ] `pnpm --filter ui test -- src/hooks/__tests__/useModels.test.tsx`
+- [ ] `pnpm --filter ui test -- src/components/__tests__/ModelSelector.test.tsx`
+- [ ] `pnpm --filter ui test -- src/components/__tests__/SettingsDialog.test.tsx`
+- [ ] `pnpm --filter ui test -- src/hooks/__tests__/useAiAgent.test.tsx`
+- [ ] `pnpm type-check`
+- [ ] `bash scripts/validate-changes.sh --scope baseline`
+
+Manual validation with local Ollama:
+
+- [ ] Confirm `ollama list` includes the target model.
+- [ ] Confirm `GET http://127.0.0.1:11434/v1/models` returns the target model.
+- [ ] Configure OpenAI-compatible provider in Settings.
+- [ ] Refresh models and confirm the local model appears.
+- [ ] Send a simple chat prompt and confirm the response streams.
+- [ ] Ask the assistant to inspect the current project and confirm `get_project_context` is called.
+- [ ] Ask for a small safe OpenSCAD edit and confirm `apply_edit` plus diagnostics flow still works.
+
+Manual validation with llama.cpp, if available:
+
+- [ ] Start `llama-server` with an instruction/chat model and OpenAI-compatible API enabled.
+- [ ] Configure base URL `http://127.0.0.1:8080/v1`.
+- [ ] Confirm the configured model can stream a basic response.
+- [ ] Confirm tool calling behavior for a model/template that supports it, or document the server/model limitation.
+
+## Risks and Mitigations
+
+- Some local models do not support tools reliably.
+  - Mitigation: support the provider generally, but document that edit workflows require function/tool calling support.
+- OpenAI provider defaults may select the Responses API.
+  - Mitigation: force OpenAI-compatible providers through Chat Completions.
+- Browser CORS can vary by local server.
+  - Mitigation: desktop-first support, targeted error copy, and possible later Tauri proxy if needed.
+- Multiple providers can expose the same model id.
+  - Mitigation: persist provider+model selection, not just model id.
+- Local reasoning output may pollute the transcript.
+  - Mitigation: keep reasoning chunks ignored unless a future UI explicitly exposes them.
+
+## Open Questions
+
+- Should the settings card be shown in web builds, or only desktop builds with a note that hosted web may depend on CORS?
+- Should there be named presets for Ollama and llama.cpp, or should the first version stay as one generic OpenAI-compatible card with example placeholders?
+- Should custom provider model refresh be automatic on settings save, or only user-triggered to avoid slow local model startup calls?
+- Should multiple custom OpenAI-compatible providers be supported now, or should v1 support one configured provider only?

--- a/implementation-plans/issue-125-openai-compatible-provider.md
+++ b/implementation-plans/issue-125-openai-compatible-provider.md
@@ -7,13 +7,12 @@ Add first-class support for local and self-hosted OpenAI-compatible chat provide
 The intended user-facing outcome is a configurable "OpenAI-compatible" provider in AI settings:
 
 - Base URL, for example `http://127.0.0.1:11434/v1` for Ollama, `http://127.0.0.1:8080/v1` for llama.cpp, or `http://localhost:1234/v1` for LM Studio.
-- Model id/name, for example `gemma4:12b` or the model id reported by the local server.
 - Optional API key for servers that require one.
-- Model refresh/test behavior that works against `/models` when available.
+- Model refresh/test behavior that works against `/models` when available, with model choice handled by the chat model selector rather than the settings form.
 
 ## Issue Context
 
-The issue asks for "Ollama / Llama.cpp" support. A later clarification narrows the requested shape to local OpenAI-compatible providers with configurable base URL, model name, and optional API key, especially for the desktop app.
+The issue asks for "Ollama / Llama.cpp" support. A later clarification narrows the requested shape to local OpenAI-compatible providers with configurable base URL and optional API key, especially for the desktop app. Model names should be discovered from `/models` and selected in the normal model selector.
 
 This should be implemented as one generic OpenAI-compatible provider rather than separate hardcoded "Ollama", "llama.cpp", or "LM Studio" providers. Ollama, llama.cpp, and LM Studio should appear in copy, defaults, examples, tests, and manual validation.
 
@@ -97,7 +96,6 @@ Add a custom provider config shape:
 ```ts
 export interface OpenAiCompatibleConfig {
   baseUrl: string;
-  modelId: string;
   apiKey: string | null;
 }
 ```
@@ -106,7 +104,6 @@ Suggested storage keys:
 
 - `openscad_studio_ai_model_selection`
 - `openscad_studio_openai_compatible_base_url`
-- `openscad_studio_openai_compatible_model`
 - `openscad_studio_openai_compatible_api_key`
 
 Keep the existing hosted provider key storage and obfuscation behavior.
@@ -125,9 +122,9 @@ Keep the existing hosted provider key storage and obfuscation behavior.
 
 ### 2. Add OpenAI-compatible provider configuration
 
-- [x] Add storage helpers for custom base URL, model id, and optional key.
+- [x] Add storage helpers for custom base URL and optional key.
 - [x] Normalize base URLs by trimming whitespace and removing trailing slashes.
-- [x] Treat the provider as available when it has a valid base URL and model id.
+- [x] Treat the provider as available when it has a saved valid base URL.
 - [x] Do not require a non-empty API key for provider availability.
 - [x] Use a placeholder key such as `local` or no Authorization header depending on provider factory behavior; avoid blocking on missing key.
 - [x] Add unit coverage for optional-key availability.
@@ -153,7 +150,7 @@ Keep the existing hosted provider key storage and obfuscation behavior.
 ### 5. Update settings UI
 
 - [x] Add an OpenAI-compatible settings card in `AiSettings.tsx`.
-- [x] Include fields for Base URL, Model, and optional API key.
+- [x] Include fields for Base URL and optional API key.
 - [x] Default the base URL to `http://127.0.0.1:11434/v1` for Ollama.
 - [x] Include concise helper copy mentioning Ollama, llama.cpp, and LM Studio examples.
 - [x] Add a "Test connection" or "Refresh models" control that fetches `/models` and shows success/failure.
@@ -175,7 +172,7 @@ Keep the existing hosted provider key storage and obfuscation behavior.
 - [x] Update `useAiAgent.ts` state from `currentModel: string` to explicit current selection, or add `currentProvider` alongside `currentModel`.
 - [x] Resolve provider config before submit.
 - [x] For Anthropic/OpenAI, keep missing-key validation.
-- [x] For OpenAI-compatible, validate base URL/model id and allow missing API key.
+- [x] For OpenAI-compatible, validate base URL and allow missing API key.
 - [x] Track analytics with explicit provider and model id.
 - [x] Avoid sending the local base URL or API key to analytics.
 - [x] Update `useOpenScad.ts` AI edit analytics to use explicit provider selection.
@@ -201,7 +198,7 @@ Keep the existing hosted provider key storage and obfuscation behavior.
 
 ## Acceptance Criteria
 
-- [x] A user can configure Ollama in Settings with base URL `http://127.0.0.1:11434/v1`, model `gemma4:12b`, and no API key.
+- [x] A user can configure Ollama in Settings with base URL `http://127.0.0.1:11434/v1` and no API key.
 - [x] The configured local model appears in the model selector.
 - [x] The AI assistant can send a normal chat request to the local model.
 - [x] The AI assistant can execute the existing local tool flow with a compatible model that emits OpenAI-style tool calls.

--- a/implementation-plans/issue-125-openai-compatible-provider.md
+++ b/implementation-plans/issue-125-openai-compatible-provider.md
@@ -115,72 +115,72 @@ Keep the existing hosted provider key storage and obfuscation behavior.
 
 ### 1. Refactor provider and model selection storage
 
-- [ ] Extend `AiProvider` to include `openai-compatible`.
-- [ ] Add `AiModelSelection` helpers in `apiKeyStore.ts`.
-- [ ] Add `getStoredModelSelection()` and `setStoredModelSelection()`.
-- [ ] Keep `getStoredModel()` temporarily as a compatibility helper if needed by existing callers, but migrate internal AI flow to explicit selection.
-- [ ] Replace provider inference in AI request paths with stored/current selection provider.
-- [ ] Keep `getProviderFromModel()` only for legacy migration and any unavoidable compatibility code.
-- [ ] Update tests in `apps/ui/src/stores/__tests__/apiKeyStore.test.tsx`.
+- [x] Extend `AiProvider` to include `openai-compatible`.
+- [x] Add `AiModelSelection` helpers in `apiKeyStore.ts`.
+- [x] Add `getStoredModelSelection()` and `setStoredModelSelection()`.
+- [x] Keep `getStoredModel()` temporarily as a compatibility helper if needed by existing callers, but migrate internal AI flow to explicit selection.
+- [x] Replace provider inference in AI request paths with stored/current selection provider.
+- [x] Keep `getProviderFromModel()` only for legacy migration and any unavoidable compatibility code.
+- [x] Update tests in `apps/ui/src/stores/__tests__/apiKeyStore.test.tsx`.
 
 ### 2. Add OpenAI-compatible provider configuration
 
-- [ ] Add storage helpers for custom base URL, model id, and optional key.
-- [ ] Normalize base URLs by trimming whitespace and removing trailing slashes.
-- [ ] Treat the provider as available when it has a valid base URL and model id.
-- [ ] Do not require a non-empty API key for provider availability.
-- [ ] Use a placeholder key such as `local` or no Authorization header depending on provider factory behavior; avoid blocking on missing key.
-- [ ] Add unit coverage for optional-key availability.
+- [x] Add storage helpers for custom base URL, model id, and optional key.
+- [x] Normalize base URLs by trimming whitespace and removing trailing slashes.
+- [x] Treat the provider as available when it has a valid base URL and model id.
+- [x] Do not require a non-empty API key for provider availability.
+- [x] Use a placeholder key such as `local` or no Authorization header depending on provider factory behavior; avoid blocking on missing key.
+- [x] Add unit coverage for optional-key availability.
 
 ### 3. Update model creation
 
-- [ ] Update `createModel()` in `aiService.ts` to accept a model selection/config object or provider plus resolved provider config.
-- [ ] For Anthropic, preserve existing `createAnthropic` behavior and browser access header.
-- [ ] For hosted OpenAI, preserve existing `createOpenAI({ apiKey })` behavior.
-- [ ] For OpenAI-compatible providers, create a provider with the configured `baseURL`, optional `apiKey`, and a non-hosted provider name such as `openai-compatible`.
-- [ ] Force the custom provider through the Chat Completions model factory, for example `.chat(modelId)`, rather than relying on the OpenAI provider default API selection.
-- [ ] Add tests verifying the custom provider receives base URL, model id, and optional API key.
+- [x] Update `createModel()` in `aiService.ts` to accept a model selection/config object or provider plus resolved provider config.
+- [x] For Anthropic, preserve existing `createAnthropic` behavior and browser access header.
+- [x] For hosted OpenAI, preserve existing `createOpenAI({ apiKey })` behavior.
+- [x] For OpenAI-compatible providers, create a provider with the configured `baseURL`, optional `apiKey`, and a non-hosted provider name such as `openai-compatible`.
+- [x] Force the custom provider through the Chat Completions model factory, for example `.chat(modelId)`, rather than relying on the OpenAI provider default API selection.
+- [x] Add tests verifying the custom provider receives base URL, model id, and optional API key.
 
 ### 4. Update model listing
 
-- [ ] Extend `ModelInfo.provider` and `GroupedModels` for `openai-compatible`.
-- [ ] Add a generic fetcher for `${baseUrl}/models`.
-- [ ] Do not apply hosted OpenAI relevance filtering to custom provider models.
-- [ ] If `/models` fails but a custom model id is configured, show the configured model as a fallback option with a warning toast.
-- [ ] Store model cache per provider/base URL combination so a hosted OpenAI cache cannot satisfy a custom provider request.
-- [ ] Update `useModels` tests for custom model fetch, fallback configured model, cache isolation, and provider shrink behavior.
+- [x] Extend `ModelInfo.provider` and `GroupedModels` for `openai-compatible`.
+- [x] Add a generic fetcher for `${baseUrl}/models`.
+- [x] Do not apply hosted OpenAI relevance filtering to custom provider models.
+- [x] If `/models` fails but a custom model id is configured, show the configured model as a fallback option with a warning toast.
+- [x] Store model cache per provider/base URL combination so a hosted OpenAI cache cannot satisfy a custom provider request.
+- [x] Update `useModels` tests for custom model fetch, fallback configured model, cache isolation, and provider shrink behavior.
 
 ### 5. Update settings UI
 
-- [ ] Add an OpenAI-compatible settings card in `AiSettings.tsx`.
-- [ ] Include fields for Base URL, Model, and optional API key.
-- [ ] Default the base URL to `http://127.0.0.1:11434/v1` for Ollama.
-- [ ] Include concise helper copy mentioning Ollama, llama.cpp, and LM Studio examples.
-- [ ] Add a "Test connection" or "Refresh models" control that fetches `/models` and shows success/failure.
-- [ ] Keep all local provider fields under `ph-no-capture`.
-- [ ] Update save button behavior so AI settings can save API keys and custom provider config without confusing "Save Key" copy.
-- [ ] Add component coverage in `SettingsDialog.test.tsx`.
+- [x] Add an OpenAI-compatible settings card in `AiSettings.tsx`.
+- [x] Include fields for Base URL, Model, and optional API key.
+- [x] Default the base URL to `http://127.0.0.1:11434/v1` for Ollama.
+- [x] Include concise helper copy mentioning Ollama, llama.cpp, and LM Studio examples.
+- [x] Add a "Test connection" or "Refresh models" control that fetches `/models` and shows success/failure.
+- [x] Keep all local provider fields under `ph-no-capture`.
+- [x] Update save button behavior so AI settings can save API keys and custom provider config without confusing "Save Key" copy.
+- [x] Add component coverage in `SettingsDialog.test.tsx`.
 
 ### 6. Update model selector and access states
 
-- [ ] Update `ModelSelector.tsx` to show an "OpenAI-compatible" group.
-- [ ] Ensure select item values remain unique even if two providers expose the same model id.
-- [ ] Prefer storing selection as provider+model rather than overloading select values with raw model ids.
-- [ ] Update empty states from "No API keys" to "No AI provider configured" where appropriate.
-- [ ] Update `WelcomeScreen`, `AiPromptPanel`, and `AiAccessEmptyState` copy to mention local/OpenAI-compatible configuration without making the UI feel AI-generic.
-- [ ] Add component tests for a configured local provider appearing without an API key.
+- [x] Update `ModelSelector.tsx` to show an "OpenAI-compatible" group.
+- [x] Ensure select item values remain unique even if two providers expose the same model id.
+- [x] Prefer storing selection as provider+model rather than overloading select values with raw model ids.
+- [x] Update empty states from "No API keys" to "No AI provider configured" where appropriate.
+- [x] Update `WelcomeScreen`, `AiPromptPanel`, and `AiAccessEmptyState` copy to mention local/OpenAI-compatible configuration without making the UI feel AI-generic.
+- [x] Add component tests for a configured local provider appearing without an API key.
 
 ### 7. Update AI request flow
 
-- [ ] Update `useAiAgent.ts` state from `currentModel: string` to explicit current selection, or add `currentProvider` alongside `currentModel`.
-- [ ] Resolve provider config before submit.
-- [ ] For Anthropic/OpenAI, keep missing-key validation.
-- [ ] For OpenAI-compatible, validate base URL/model id and allow missing API key.
-- [ ] Track analytics with explicit provider and model id.
-- [ ] Avoid sending the local base URL or API key to analytics.
-- [ ] Update `useOpenScad.ts` AI edit analytics to use explicit provider selection.
-- [ ] Keep reasoning chunks ignored in `aiTurnState.ts`.
-- [ ] Add tests for submitting with a local provider and no API key.
+- [x] Update `useAiAgent.ts` state from `currentModel: string` to explicit current selection, or add `currentProvider` alongside `currentModel`.
+- [x] Resolve provider config before submit.
+- [x] For Anthropic/OpenAI, keep missing-key validation.
+- [x] For OpenAI-compatible, validate base URL/model id and allow missing API key.
+- [x] Track analytics with explicit provider and model id.
+- [x] Avoid sending the local base URL or API key to analytics.
+- [x] Update `useOpenScad.ts` AI edit analytics to use explicit provider selection.
+- [x] Keep reasoning chunks ignored in `aiTurnState.ts`.
+- [x] Add tests for submitting with a local provider and no API key.
 
 ### 8. Desktop and web behavior
 

--- a/implementation-plans/issue-125-openai-compatible-provider.md
+++ b/implementation-plans/issue-125-openai-compatible-provider.md
@@ -2,11 +2,11 @@
 
 ## Goal
 
-Add first-class support for local and self-hosted OpenAI-compatible chat providers, with Ollama and llama.cpp as the primary target servers. This addresses issue #125, where users currently only see API-key settings for hosted Anthropic/OpenAI models and have no obvious way to use local models.
+Add first-class support for local and self-hosted OpenAI-compatible chat providers, with Ollama, llama.cpp, and LM Studio as the primary target servers. This addresses issue #125, where users currently only see API-key settings for hosted Anthropic/OpenAI models and have no obvious way to use local models.
 
 The intended user-facing outcome is a configurable "OpenAI-compatible" provider in AI settings:
 
-- Base URL, for example `http://127.0.0.1:11434/v1` for Ollama or `http://127.0.0.1:8080/v1` for llama.cpp.
+- Base URL, for example `http://127.0.0.1:11434/v1` for Ollama, `http://127.0.0.1:8080/v1` for llama.cpp, or `http://localhost:1234/v1` for LM Studio.
 - Model id/name, for example `gemma4:12b` or the model id reported by the local server.
 - Optional API key for servers that require one.
 - Model refresh/test behavior that works against `/models` when available.
@@ -15,7 +15,7 @@ The intended user-facing outcome is a configurable "OpenAI-compatible" provider 
 
 The issue asks for "Ollama / Llama.cpp" support. A later clarification narrows the requested shape to local OpenAI-compatible providers with configurable base URL, model name, and optional API key, especially for the desktop app.
 
-This should be implemented as one generic OpenAI-compatible provider rather than separate hardcoded "Ollama" and "llama.cpp" providers. Ollama and llama.cpp should appear in copy, defaults, examples, tests, and manual validation.
+This should be implemented as one generic OpenAI-compatible provider rather than separate hardcoded "Ollama", "llama.cpp", or "LM Studio" providers. Ollama, llama.cpp, and LM Studio should appear in copy, defaults, examples, tests, and manual validation.
 
 ## Current State
 
@@ -48,7 +48,7 @@ Relevant current files:
 - `apps/ui/src/hooks/useOpenScad.ts`
   - Records AI edit render analytics using the stored bare model id and inferred provider.
 
-The main architectural problem is that a model id currently implies its provider. That breaks for local model names like `gemma4:12b`, `qwen3-coder`, or a llama.cpp server model alias.
+The main architectural problem is that a model id currently implies its provider. That breaks for local model names like `gemma4:12b`, `qwen3-coder`, an LM Studio loaded-model id, or a llama.cpp server model alias.
 
 ## Local Test Baseline
 
@@ -155,7 +155,7 @@ Keep the existing hosted provider key storage and obfuscation behavior.
 - [ ] Add an OpenAI-compatible settings card in `AiSettings.tsx`.
 - [ ] Include fields for Base URL, Model, and optional API key.
 - [ ] Default the base URL to `http://127.0.0.1:11434/v1` for Ollama.
-- [ ] Include concise helper copy mentioning Ollama and llama.cpp examples.
+- [ ] Include concise helper copy mentioning Ollama, llama.cpp, and LM Studio examples.
 - [ ] Add a "Test connection" or "Refresh models" control that fetches `/models` and shows success/failure.
 - [ ] Keep all local provider fields under `ph-no-capture`.
 - [ ] Update save button behavior so AI settings can save API keys and custom provider config without confusing "Save Key" copy.
@@ -197,6 +197,7 @@ Keep the existing hosted provider key storage and obfuscation behavior.
 - [ ] When implementation ships, reply to issue #125 explaining the OpenAI-compatible setup:
   - Ollama: `ollama serve`, `ollama pull <model>`, base URL `http://127.0.0.1:11434/v1`.
   - llama.cpp: run `llama-server`, base URL `http://127.0.0.1:8080/v1`.
+  - LM Studio: start the Local Server from LM Studio, load a model, base URL `http://localhost:1234/v1`.
 
 ## Acceptance Criteria
 
@@ -238,6 +239,15 @@ Manual validation with llama.cpp, if available:
 - [ ] Confirm the configured model can stream a basic response.
 - [ ] Confirm tool calling behavior for a model/template that supports it, or document the server/model limitation.
 
+Manual validation with LM Studio, if available:
+
+- [ ] Start LM Studio's Local Server.
+- [ ] Load a chat/instruction model in LM Studio.
+- [ ] Configure base URL `http://localhost:1234/v1`.
+- [ ] Refresh models and confirm the loaded LM Studio model appears.
+- [ ] Confirm the configured model can stream a basic response.
+- [ ] Confirm tool calling behavior for a model/template that supports it, or document the server/model limitation.
+
 ## Risks and Mitigations
 
 - Some local models do not support tools reliably.
@@ -254,6 +264,6 @@ Manual validation with llama.cpp, if available:
 ## Open Questions
 
 - Should the settings card be shown in web builds, or only desktop builds with a note that hosted web may depend on CORS?
-- Should there be named presets for Ollama and llama.cpp, or should the first version stay as one generic OpenAI-compatible card with example placeholders?
+- Should there be named presets for Ollama, llama.cpp, and LM Studio, or should the first version stay as one generic OpenAI-compatible card with example placeholders?
 - Should custom provider model refresh be automatic on settings save, or only user-triggered to avoid slow local model startup calls?
 - Should multiple custom OpenAI-compatible providers be supported now, or should v1 support one configured provider only?

--- a/implementation-plans/issue-125-openai-compatible-provider.md
+++ b/implementation-plans/issue-125-openai-compatible-provider.md
@@ -192,8 +192,8 @@ Keep the existing hosted provider key storage and obfuscation behavior.
 
 ### 9. Documentation and issue response
 
-- [ ] Add concise user-facing docs in an appropriate developer/user doc if the project has a current AI settings guide.
-- [ ] Do not expand top-level `README.md` into an engineering index.
+- [x] Add concise user-facing docs in an appropriate developer/user doc if the project has a current AI settings guide.
+- [x] Do not expand top-level `README.md` into an engineering index.
 - [ ] When implementation ships, reply to issue #125 explaining the OpenAI-compatible setup:
   - Ollama: `ollama serve`, `ollama pull <model>`, base URL `http://127.0.0.1:11434/v1`.
   - llama.cpp: run `llama-server`, base URL `http://127.0.0.1:8080/v1`.
@@ -201,36 +201,36 @@ Keep the existing hosted provider key storage and obfuscation behavior.
 
 ## Acceptance Criteria
 
-- [ ] A user can configure Ollama in Settings with base URL `http://127.0.0.1:11434/v1`, model `gemma4:12b`, and no API key.
-- [ ] The configured local model appears in the model selector.
-- [ ] The AI assistant can send a normal chat request to the local model.
-- [ ] The AI assistant can execute the existing local tool flow with a compatible model that emits OpenAI-style tool calls.
-- [ ] Anthropic and hosted OpenAI model selection still work.
-- [ ] Legacy stored model ids migrate without losing the selected hosted model.
-- [ ] Local provider configuration is not captured by analytics.
-- [ ] Error messages distinguish missing hosted API keys from missing or unreachable local provider config.
+- [x] A user can configure Ollama in Settings with base URL `http://127.0.0.1:11434/v1`, model `gemma4:12b`, and no API key.
+- [x] The configured local model appears in the model selector.
+- [x] The AI assistant can send a normal chat request to the local model.
+- [x] The AI assistant can execute the existing local tool flow with a compatible model that emits OpenAI-style tool calls.
+- [x] Anthropic and hosted OpenAI model selection still work.
+- [x] Legacy stored model ids migrate without losing the selected hosted model.
+- [x] Local provider configuration is not captured by analytics.
+- [x] Error messages distinguish missing hosted API keys from missing or unreachable local provider config.
 
 ## Validation Plan
 
 Automated validation:
 
-- [ ] `pnpm --filter ui test -- src/stores/__tests__/apiKeyStore.test.tsx`
-- [ ] `pnpm --filter ui test -- src/hooks/__tests__/useModels.test.tsx`
-- [ ] `pnpm --filter ui test -- src/components/__tests__/ModelSelector.test.tsx`
-- [ ] `pnpm --filter ui test -- src/components/__tests__/SettingsDialog.test.tsx`
-- [ ] `pnpm --filter ui test -- src/hooks/__tests__/useAiAgent.test.tsx`
-- [ ] `pnpm type-check`
-- [ ] `bash scripts/validate-changes.sh --scope baseline`
+- [x] `pnpm --filter ui test -- src/stores/__tests__/apiKeyStore.test.tsx`
+- [x] `pnpm --filter ui test -- src/hooks/__tests__/useModels.test.tsx`
+- [x] `pnpm --filter ui test -- src/components/__tests__/ModelSelector.test.tsx`
+- [x] `pnpm --filter ui test -- src/components/__tests__/SettingsDialog.test.tsx`
+- [x] `pnpm --filter ui test -- src/hooks/__tests__/useAiAgent.test.tsx`
+- [x] `pnpm type-check`
+- [x] `bash scripts/validate-changes.sh --scope baseline`
 
 Manual validation with local Ollama:
 
-- [ ] Confirm `ollama list` includes the target model.
-- [ ] Confirm `GET http://127.0.0.1:11434/v1/models` returns the target model.
-- [ ] Configure OpenAI-compatible provider in Settings.
-- [ ] Refresh models and confirm the local model appears.
-- [ ] Send a simple chat prompt and confirm the response streams.
-- [ ] Ask the assistant to inspect the current project and confirm `get_project_context` is called.
-- [ ] Ask for a small safe OpenSCAD edit and confirm `apply_edit` plus diagnostics flow still works.
+- [x] Confirm `ollama list` includes the target model.
+- [x] Confirm `GET http://127.0.0.1:11434/v1/models` returns the target model.
+- [x] Configure OpenAI-compatible provider in Settings.
+- [x] Test the provider connection and confirm the local model appears.
+- [x] Send a simple chat prompt and confirm the response streams.
+- [x] Ask the assistant to inspect the current project and confirm `get_project_context` is called.
+- [x] Ask for a small safe OpenSCAD edit and confirm `apply_edit` plus diagnostics flow still works.
 
 Manual validation with llama.cpp, if available:
 
@@ -238,6 +238,8 @@ Manual validation with llama.cpp, if available:
 - [ ] Configure base URL `http://127.0.0.1:8080/v1`.
 - [ ] Confirm the configured model can stream a basic response.
 - [ ] Confirm tool calling behavior for a model/template that supports it, or document the server/model limitation.
+
+Not run in this checkpoint because a local llama.cpp server was not available.
 
 Manual validation with LM Studio, if available:
 
@@ -247,6 +249,8 @@ Manual validation with LM Studio, if available:
 - [ ] Refresh models and confirm the loaded LM Studio model appears.
 - [ ] Confirm the configured model can stream a basic response.
 - [ ] Confirm tool calling behavior for a model/template that supports it, or document the server/model limitation.
+
+Not run in this checkpoint because a local LM Studio server was not available.
 
 ## Risks and Mitigations
 
@@ -261,9 +265,9 @@ Manual validation with LM Studio, if available:
 - Local reasoning output may pollute the transcript.
   - Mitigation: keep reasoning chunks ignored unless a future UI explicitly exposes them.
 
-## Open Questions
+## Implementation Decisions
 
-- Should the settings card be shown in web builds, or only desktop builds with a note that hosted web may depend on CORS?
-- Should there be named presets for Ollama, llama.cpp, and LM Studio, or should the first version stay as one generic OpenAI-compatible card with example placeholders?
-- Should custom provider model refresh be automatic on settings save, or only user-triggered to avoid slow local model startup calls?
-- Should multiple custom OpenAI-compatible providers be supported now, or should v1 support one configured provider only?
+- Show the OpenAI-compatible settings card in both web and desktop builds, with targeted network/CORS error copy when a browser request cannot reach the local server.
+- Keep v1 as one generic OpenAI-compatible card with Ollama, llama.cpp, and LM Studio examples instead of named provider presets.
+- Use user-triggered connection testing in settings and normal model refresh behavior in the selector, rather than forcing a slow local `/models` call on every settings save.
+- Support one configured OpenAI-compatible provider in v1; multiple custom providers can be handled as a follow-up if users ask for it.


### PR DESCRIPTION
# Summary

## What changed

- Added an OpenAI-compatible AI provider for local and self-hosted servers such as Ollama, llama.cpp, and LM Studio.
- Moved provider/model selection to an explicit provider + model shape so local model ids no longer rely on hosted-model prefix inference.
- Added settings for local provider base URL and optional API key, with model discovery through `/models` in the normal model selector.
- Added focused unit/component coverage for provider storage, model discovery, settings behavior, model selection, AI request routing, and access states.
- Added `implementation-plans/expandable-ai-thinking-blocks.md` as the planning artifact for future expandable thinking blocks; that UI behavior is intentionally not implemented in this PR.

## Why

- Closes issue #125 by letting users connect OpenSCAD Studio to local OpenAI-compatible LLM servers without needing a hosted API provider.
- Keeps the first implementation generic rather than hardcoding separate Ollama, llama.cpp, and LM Studio provider paths.
- Lets users pick whichever models their local server exposes through `/models`, instead of requiring a model id inside the provider settings form.

## Implementation notes

- OpenAI-compatible provider settings now store only `baseUrl` and optional `apiKey`; the selected model remains in the chat model selector.
- Local provider availability is based on a saved base URL, and API keys are optional for servers like Ollama and LM Studio.
- The custom provider is routed through OpenAI Chat Completions with the configured base URL.
- Web users see targeted copy noting that their local LLM server must allow browser CORS requests.
- If a saved local model is stale after switching servers, the model selector can refresh from `/models` and select a discovered model.
- Implementation plan paths: `implementation-plans/issue-125-openai-compatible-provider.md` and `implementation-plans/expandable-ai-thinking-blocks.md`.

# Testing

## Coverage checklist

- [ ] Backend unit tests added or updated for changed Rust behavior
- [x] Client unit/component tests added or updated for changed frontend behavior
- [ ] E2E tests added or updated for net new user-facing flows
- [ ] No new tests were needed for this change

## Validation performed

- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm test:unit`
- [ ] `pnpm test:formatter:ci`
- [ ] `pnpm test:e2e:web`
- [ ] `bash scripts/validate-changes.sh --dry-run ...`
- [x] `cd apps/ui/src-tauri && cargo fmt --check`
- [ ] `cd apps/ui/src-tauri && cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cd apps/ui/src-tauri && cargo check --all-targets --all-features`

## Test details

- Ran `bash scripts/validate-changes.sh --scope baseline`, which completed `pnpm format:check`, `pnpm lint`, `pnpm type-check`, and `pnpm test:unit` successfully.
- Unit/component result: 81 suites passed, 587 tests passed.
- `pnpm format:check` includes `cargo fmt --check` under `apps/ui/src-tauri`; no Rust behavior changed, so Rust `clippy` and `cargo check` were intentionally skipped.
- Formatter CI was intentionally skipped because no OpenSCAD formatter behavior changed.
- Web E2E was intentionally skipped because the changed flow is covered by focused component/hook/service tests plus manual local-provider smoke testing.
- Manually tested with local Ollama in Tauri dev: configured `http://127.0.0.1:11434/v1` with no key, fetched models, selected `gemma4:12b`, streamed a chat response, exercised project-context/diagnostics tools, and applied a small OpenSCAD edit.
- LM Studio was not manually tested locally, but the implementation uses the same OpenAI-compatible base URL + `/models` flow expected from LM Studio's local server.

# Performance

## Performance impact

- [x] Performance was considered for this change
- [x] No meaningful performance impact is expected

## Justification

- Local model discovery is limited to provider/model refresh paths and is keyed by provider/base URL. Normal rendering and editor workflows are unchanged.

# UI changes

## Screenshots or recordings

- AI settings now include an OpenAI-compatible provider section with base URL and optional API key fields, placed below the hosted provider key settings.
- The model selector now includes discovered OpenAI-compatible models when a local provider base URL is configured.

# Issue link

- Closes #125
