### PR TITLE
Refine viewer tool rail layout

### DIFF
--- a/apps/ui/src/components/SvgViewer.tsx
+++ b/apps/ui/src/components/SvgViewer.tsx
@@ -115,12 +115,9 @@ function Svg2DToolPalette({
 }) {
   return (
     <div
-      className="flex flex-col shrink-0 items-center"
+      className="absolute left-2 top-2 z-20 flex flex-col items-center"
       style={{
-        width: '44px',
-        padding: '6px 0',
-        gap: '2px',
-        borderRight: '1px solid var(--border-primary)',
+        gap: '6px',
       }}
       data-testid="preview-2d-tool-palette"
       onClick={(event) => event.stopPropagation()}
@@ -148,10 +145,10 @@ function Svg2DToolPalette({
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
-              backgroundColor: isActive ? 'var(--bg-tertiary, var(--bg-elevated))' : 'transparent',
-              color: isActive ? 'var(--text-primary)' : 'var(--text-secondary)',
+              backgroundColor: isActive ? 'var(--bg-tertiary)' : 'var(--bg-elevated)',
+              color: isActive ? 'var(--accent-primary)' : 'var(--text-secondary)',
               opacity: isDisabled ? 0.35 : 1,
-              border: isActive ? '1px solid var(--border-primary)' : '1px solid transparent',
+              border: `1px solid ${isActive ? 'var(--accent-primary)' : 'var(--border-primary)'}`,
               borderRadius: 'var(--radius-md)',
               cursor: isDisabled ? 'not-allowed' : 'pointer',
               transition: 'background-color 0.15s, color 0.15s, border-color 0.15s',
@@ -1201,13 +1198,6 @@ export function SvgViewer({
   return (
     <div className="flex flex-col h-full w-full" data-testid="preview-2d-root">
       <div className="flex flex-row flex-1 min-h-0">
-        {!isMobile && (
-          <Svg2DToolPalette
-            mode={viewMode}
-            onModeChange={(mode) => handleViewModeChange(mode, 'toolbar')}
-            canInteract={canInteract}
-          />
-        )}
         <div
           ref={containerRef}
           className="relative flex-1 min-w-0 outline-none"
@@ -1229,6 +1219,13 @@ export function SvgViewer({
           }}
           onClick={handleClick}
         >
+          {!isMobile && (
+            <Svg2DToolPalette
+              mode={viewMode}
+              onModeChange={(mode) => handleViewModeChange(mode, 'toolbar')}
+              canInteract={canInteract}
+            />
+          )}
           <div
             className="absolute top-2 right-2 z-20 flex gap-2"
             onClick={(event) => event.stopPropagation()}

--- a/apps/ui/src/components/ThreeViewer.tsx
+++ b/apps/ui/src/components/ThreeViewer.tsx
@@ -1638,18 +1638,18 @@ export function ThreeViewer({
       )}
 
       <div className="flex flex-row flex-1 min-h-0">
-        {!isMobile && (
-          <ViewerToolPalette
-            mode={interactionMode}
-            onModeChange={(mode) => handleModeChange(mode, 'toolbar')}
-            loadedModel={loadedModel}
-          />
-        )}
         <div
           ref={previewSurfaceRef}
           className="relative flex-1 min-w-0"
           data-preview-root={viewerId ?? 'default-preview'}
         >
+          {!isMobile && (
+            <ViewerToolPalette
+              mode={interactionMode}
+              onModeChange={(mode) => handleModeChange(mode, 'toolbar')}
+              loadedModel={loadedModel}
+            />
+          )}
           <div
             className="absolute top-2 right-2 z-10 flex gap-2"
             onClick={(event) => event.stopPropagation()}

--- a/apps/ui/src/components/three-viewer/ViewerToolPalette.tsx
+++ b/apps/ui/src/components/three-viewer/ViewerToolPalette.tsx
@@ -11,12 +11,9 @@ interface ViewerToolPaletteProps {
 export function ViewerToolPalette({ mode, onModeChange, loadedModel }: ViewerToolPaletteProps) {
   return (
     <div
-      className="flex flex-col shrink-0 items-center"
+      className="absolute left-2 top-2 z-20 flex flex-col items-center"
       style={{
-        width: '44px',
-        padding: '6px 0',
-        gap: '2px',
-        borderRight: '1px solid var(--border-primary)',
+        gap: '6px',
       }}
       data-testid="preview-tool-palette"
       onClick={(event) => event.stopPropagation()}
@@ -31,6 +28,7 @@ export function ViewerToolPalette({ mode, onModeChange, loadedModel }: ViewerToo
         return (
           <IconButton
             key={tool.id}
+            variant="toolbar"
             title={`${tool.label}${shortcutLabel}`}
             tooltipSide="right"
             aria-label={`${tool.label}${shortcutLabel}`}

--- a/implementation-plans/floating-viewer-side-rail.md
+++ b/implementation-plans/floating-viewer-side-rail.md
@@ -1,0 +1,25 @@
+# Floating Viewer Side Rail
+
+## Goal
+
+Replace the bordered 2D and 3D viewer side rails with floating vertical tool buttons that sit over the viewer surface.
+
+## Approach
+
+- Keep the existing 2D and 3D tool definitions and interaction behavior intact.
+- Move the desktop-only palettes into the viewer surface so they no longer consume a fixed rail column.
+- Remove the palette container width, padding, and border while preserving button active, disabled, tooltip, and click isolation behavior.
+
+## Affected Areas
+
+- `apps/ui/src/components/SvgViewer.tsx`
+- `apps/ui/src/components/ThreeViewer.tsx`
+- `apps/ui/src/components/three-viewer/ViewerToolPalette.tsx`
+
+## Checklist
+
+- [x] Capture the implementation plan before code changes.
+- [x] Update the 2D viewer tool palette to float over the preview surface.
+- [x] Update the 3D viewer tool palette to float over the preview surface.
+- [x] Run formatting and validation for the changed frontend files.
+- [x] Prepare the branch and draft PR handoff.


### PR DESCRIPTION
# Summary

## What changed

- Moved the desktop 2D and 3D viewer tool palettes into the viewer surfaces as floating vertical button stacks.
- Removed the fixed palette rail width, padding, and right border while preserving tool behavior, disabled states, active styling, and click isolation.
- Added implementation plan: `implementation-plans/floating-viewer-side-rail.md`.

## Why

- Keeps the preview pane visually lighter and lets the scene fill the full pane width behind the tools.

## Implementation notes

- `Svg2DToolPalette` and `ViewerToolPalette` are now absolutely positioned inside their respective preview surfaces.
- Existing mobile behavior is unchanged; these palettes remain desktop-only.

# Testing

## Coverage checklist

- [ ] Backend unit tests added or updated for changed Rust behavior
- [ ] Client unit/component tests added or updated for changed frontend behavior
- [ ] E2E tests added or updated for net new user-facing flows
- [x] No new tests were needed for this change

## Validation performed

- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm test:unit`
- [ ] `pnpm test:formatter:ci`
- [ ] `pnpm test:e2e:web`
- [x] `bash scripts/validate-changes.sh --dry-run ...`
- [ ] `cd apps/ui/src-tauri && cargo fmt --check`
- [ ] `cd apps/ui/src-tauri && cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cd apps/ui/src-tauri && cargo check --all-targets --all-features`

## Test details

- Ran `pnpm install --frozen-lockfile` for checkout readiness.
- Ran `pnpm exec prettier --write apps/ui/src/components/SvgViewer.tsx apps/ui/src/components/ThreeViewer.tsx apps/ui/src/components/three-viewer/ViewerToolPalette.tsx implementation-plans/floating-viewer-side-rail.md`.
- Ran `bash scripts/validate-changes.sh --dry-run --changed-file apps/ui/src/components/SvgViewer.tsx --changed-file apps/ui/src/components/ThreeViewer.tsx --changed-file apps/ui/src/components/three-viewer/ViewerToolPalette.tsx`.
- Ran `bash scripts/validate-changes.sh --changed-file apps/ui/src/components/SvgViewer.tsx --changed-file apps/ui/src/components/ThreeViewer.tsx --changed-file apps/ui/src/components/three-viewer/ViewerToolPalette.tsx`; baseline passed with 81 suites and 574 tests.
- Smoke checked 3D and 2D in the local web app at `http://localhost:3000/`; both rail containers were absolute, transparent, 32px wide, and had `border-right: 0px`.
- Skipped formatter, Rust clippy/check, and e2e-web because this change does not touch the formatter, Rust/Tauri code, or introduce a new flow.

# Performance

## Performance impact

- [x] Performance was considered for this change
- [x] No meaningful performance impact is expected

## Justification

- This is a layout-only React/CSS positioning change with no new rendering work or event listeners.

# UI changes

## Screenshots or recordings

- N/A; local smoke check confirmed the 2D and 3D rail geometry.

# Issue link

- Closes #
