### PR TITLE
Fix Apple Silicon Mac download link

### DIFF
--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -77,6 +77,12 @@ import { addRecentFile, removeRecentFile } from './utils/recentFiles';
 import { captureCurrentPreview, MAIN_PREVIEW_VIEWER_ID } from './utils/capturePreview';
 import { normalizeAppError, notifyError, notifySuccess } from './utils/notifications';
 import { exportProjectZip } from './utils/projectZip';
+import {
+  getInitialMacDownloadArch,
+  getMacDownloadUrl,
+  resolveMacDownloadArch,
+  type MacArch,
+} from './utils/macDownload';
 import { getRelativeProjectPath } from './utils/projectFilePaths';
 import { generateRandomProjectName } from './utils/projectNaming';
 import { resolveFolderImport } from './utils/folderImport';
@@ -90,16 +96,8 @@ import {
   isOpenScadProjectFilePath,
 } from '../../../packages/shared/src/openscadProjectFiles';
 
-const RELEASE_BASE = 'https://github.com/zacharyfmarion/openscad-studio/releases/latest/download';
 const REPOSITORY_URL = 'https://github.com/zacharyfmarion/openscad-studio';
 const HEADER_WORKSPACE_SWITCHER_MEDIA_QUERY = '(max-width: 900px)';
-
-const RELEASE_ASSETS: Record<MacArch, string> = {
-  aarch64: 'OpenSCAD.Studio_latest_aarch64.dmg',
-  x64: 'OpenSCAD.Studio_latest_x64.dmg',
-};
-
-type MacArch = 'aarch64' | 'x64';
 
 const OPENSCAD_FILE_FILTERS = [
   { name: 'OpenSCAD Files', extensions: [...OPENSCAD_PROJECT_FILE_EXTENSIONS] },
@@ -186,32 +184,23 @@ function revokeBlobUrl(url: string | null | undefined) {
 }
 
 function useMacDownloadUrl() {
-  const [arch, setArch] = useState<MacArch>('aarch64');
+  const [arch, setArch] = useState<MacArch>(() => getInitialMacDownloadArch());
 
   useEffect(() => {
-    const platform = navigator.platform.toLowerCase();
-    if (platform.includes('intel') || platform.includes('x86_64')) {
-      setArch('x64');
-    }
+    let isCancelled = false;
 
-    const uaData = (
-      navigator as unknown as {
-        userAgentData?: {
-          getHighEntropyValues?: (hints: string[]) => Promise<{ architecture?: string }>;
-        };
+    void resolveMacDownloadArch().then((resolvedArch) => {
+      if (!isCancelled) {
+        setArch(resolvedArch);
       }
-    ).userAgentData;
+    });
 
-    if (uaData?.getHighEntropyValues) {
-      void uaData.getHighEntropyValues(['architecture']).then((values) => {
-        if (values.architecture === 'x86') {
-          setArch('x64');
-        }
-      });
-    }
+    return () => {
+      isCancelled = true;
+    };
   }, []);
 
-  return `${RELEASE_BASE}/${RELEASE_ASSETS[arch]}`;
+  return getMacDownloadUrl(arch);
 }
 
 interface HeaderIconLinkProps {

--- a/apps/ui/src/utils/__tests__/macDownload.test.ts
+++ b/apps/ui/src/utils/__tests__/macDownload.test.ts
@@ -1,0 +1,74 @@
+import {
+  getInitialMacDownloadArch,
+  getMacDownloadArchFromPlatform,
+  getMacDownloadUrl,
+  resolveMacDownloadArch,
+  type MacDownloadNavigator,
+} from '../macDownload';
+
+describe('macDownload', () => {
+  it('keeps Apple Silicon as the initial choice when high entropy architecture is available', () => {
+    const navigatorLike: MacDownloadNavigator = {
+      platform: 'MacIntel',
+      userAgentData: {
+        getHighEntropyValues: async () => ({}),
+      },
+    };
+
+    expect(getInitialMacDownloadArch(navigatorLike)).toBe('aarch64');
+  });
+
+  it('resolves MacIntel Apple Silicon browsers to the aarch64 DMG', async () => {
+    const navigatorLike: MacDownloadNavigator = {
+      platform: 'MacIntel',
+      userAgentData: {
+        getHighEntropyValues: async () => ({ architecture: 'arm' }),
+      },
+    };
+
+    await expect(resolveMacDownloadArch(navigatorLike)).resolves.toBe('aarch64');
+    expect(getMacDownloadUrl('aarch64')).toBe(
+      'https://github.com/zacharyfmarion/openscad-studio/releases/latest/download/OpenSCAD.Studio_latest_aarch64.dmg'
+    );
+  });
+
+  it('resolves Chromium Intel Macs to the x64 DMG when high entropy architecture says x86', async () => {
+    const navigatorLike: MacDownloadNavigator = {
+      platform: 'MacIntel',
+      userAgentData: {
+        getHighEntropyValues: async () => ({ architecture: 'x86' }),
+      },
+    };
+
+    await expect(resolveMacDownloadArch(navigatorLike)).resolves.toBe('x64');
+    expect(getMacDownloadUrl('x64')).toBe(
+      'https://github.com/zacharyfmarion/openscad-studio/releases/latest/download/OpenSCAD.Studio_latest_x64.dmg'
+    );
+  });
+
+  it('treats legacy MacIntel platform strings as ambiguous and defaults to Apple Silicon', () => {
+    expect(getMacDownloadArchFromPlatform('MacIntel')).toBe('aarch64');
+  });
+
+  it('uses x64 for explicit x86 platform strings when high entropy architecture is unavailable', async () => {
+    const navigatorLike: MacDownloadNavigator = {
+      platform: 'x86_64-apple-darwin',
+    };
+
+    expect(getInitialMacDownloadArch(navigatorLike)).toBe('x64');
+    await expect(resolveMacDownloadArch(navigatorLike)).resolves.toBe('x64');
+  });
+
+  it('falls back to the platform-derived architecture if high entropy lookup fails', async () => {
+    const navigatorLike: MacDownloadNavigator = {
+      platform: 'x86_64-apple-darwin',
+      userAgentData: {
+        getHighEntropyValues: async () => {
+          throw new Error('blocked');
+        },
+      },
+    };
+
+    await expect(resolveMacDownloadArch(navigatorLike)).resolves.toBe('x64');
+  });
+});

--- a/apps/ui/src/utils/macDownload.ts
+++ b/apps/ui/src/utils/macDownload.ts
@@ -1,0 +1,81 @@
+const RELEASE_BASE = 'https://github.com/zacharyfmarion/openscad-studio/releases/latest/download';
+
+export type MacArch = 'aarch64' | 'x64';
+
+const RELEASE_ASSETS: Record<MacArch, string> = {
+  aarch64: 'OpenSCAD.Studio_latest_aarch64.dmg',
+  x64: 'OpenSCAD.Studio_latest_x64.dmg',
+};
+
+interface UserAgentDataLike {
+  getHighEntropyValues?: (hints: string[]) => Promise<{ architecture?: string }>;
+}
+
+export interface MacDownloadNavigator {
+  platform?: string;
+  userAgentData?: UserAgentDataLike;
+}
+
+function getBrowserNavigator(): MacDownloadNavigator | null {
+  if (typeof navigator === 'undefined') return null;
+  return navigator as MacDownloadNavigator;
+}
+
+function getArchFromHighEntropyValue(architecture: string | undefined): MacArch | null {
+  const normalized = architecture?.trim().toLowerCase();
+  if (!normalized) return null;
+
+  if (normalized.includes('arm') || normalized.includes('aarch64')) {
+    return 'aarch64';
+  }
+
+  if (normalized.includes('x86') || normalized.includes('x64') || normalized.includes('amd64')) {
+    return 'x64';
+  }
+
+  return null;
+}
+
+export function getMacDownloadArchFromPlatform(platform: string | undefined): MacArch {
+  const normalized = platform?.trim().toLowerCase() ?? '';
+
+  if (normalized.includes('x86_64') || normalized.includes('x64') || normalized.includes('amd64')) {
+    return 'x64';
+  }
+
+  // `MacIntel` is ambiguous: Apple Silicon browsers commonly preserve it for compatibility.
+  return 'aarch64';
+}
+
+export function getInitialMacDownloadArch(
+  navigatorLike: MacDownloadNavigator | null = getBrowserNavigator()
+): MacArch {
+  if (!navigatorLike) return 'aarch64';
+
+  if (navigatorLike.userAgentData?.getHighEntropyValues) {
+    return 'aarch64';
+  }
+
+  return getMacDownloadArchFromPlatform(navigatorLike.platform);
+}
+
+export async function resolveMacDownloadArch(
+  navigatorLike: MacDownloadNavigator | null = getBrowserNavigator()
+): Promise<MacArch> {
+  if (!navigatorLike) return 'aarch64';
+
+  const platformFallback = getMacDownloadArchFromPlatform(navigatorLike.platform);
+  const getHighEntropyValues = navigatorLike.userAgentData?.getHighEntropyValues;
+  if (!getHighEntropyValues) return platformFallback;
+
+  try {
+    const values = await getHighEntropyValues.call(navigatorLike.userAgentData, ['architecture']);
+    return getArchFromHighEntropyValue(values.architecture) ?? platformFallback;
+  } catch {
+    return platformFallback;
+  }
+}
+
+export function getMacDownloadUrl(arch: MacArch): string {
+  return `${RELEASE_BASE}/${RELEASE_ASSETS[arch]}`;
+}

--- a/implementation-plans/mac-download-architecture.md
+++ b/implementation-plans/mac-download-architecture.md
@@ -1,0 +1,26 @@
+# Mac Download Architecture
+
+## Goal
+
+Make the web header download button choose the Apple Silicon DMG on M1/M2/M3 Macs instead of incorrectly falling back to the Intel x64 asset.
+
+## Approach
+
+- Move Mac release asset URL and architecture selection into a small utility.
+- Prefer high-entropy browser architecture data when available so Apple Silicon can override the legacy `MacIntel` platform string.
+- Keep a conservative x64 fallback for browsers that clearly report Intel without better architecture data.
+- Add focused tests for Apple Silicon, Intel, and default behavior.
+
+## Affected Areas
+
+- `apps/ui/src/App.tsx`
+- `apps/ui/src/utils/macDownload.ts`
+- `apps/ui/src/utils/__tests__/macDownload.test.ts`
+
+## Checklist
+
+- [x] Create implementation plan record
+- [x] Extract Mac download URL selection into a utility
+- [x] Fix Apple Silicon detection
+- [x] Add focused regression tests
+- [x] Run targeted validation


### PR DESCRIPTION
# Summary

## What changed

- Extracted Mac release asset selection into `apps/ui/src/utils/macDownload.ts`.
- Updated the header download hook to prefer Apple Silicon for ambiguous `MacIntel` browser strings and use high-entropy architecture data when available.
- Added focused regression coverage for Apple Silicon, Intel, ambiguous platform, and high-entropy fallback cases.
- Added implementation plan: `implementation-plans/mac-download-architecture.md`.

## Why

- Apple Silicon browsers can report `navigator.platform` as `MacIntel`, causing the header download button to serve the x64 DMG on M1 Macs.

## Implementation notes

- `MacIntel` is now treated as ambiguous and defaults to the Apple Silicon DMG.
- Chromium high-entropy architecture data still selects x64 when it reports `x86`.

# Testing

## Coverage checklist

- [ ] Backend unit tests added or updated for changed Rust behavior
- [x] Client unit/component tests added or updated for changed frontend behavior
- [ ] E2E tests added or updated for net new user-facing flows
- [ ] No new tests were needed for this change

## Validation performed

- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm test:unit`
- [ ] `pnpm test:formatter:ci`
- [ ] `pnpm test:e2e:web`
- [x] `bash scripts/validate-changes.sh --dry-run ...`
- [ ] `cd apps/ui/src-tauri && cargo fmt --check`
- [ ] `cd apps/ui/src-tauri && cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cd apps/ui/src-tauri && cargo check --all-targets --all-features`

## Test details

- Ran `pnpm --dir apps/ui test -- src/utils/__tests__/macDownload.test.ts --runInBand`: 6 tests passed.
- Ran `bash scripts/validate-changes.sh --changed-file apps/ui/src/App.tsx --changed-file apps/ui/src/utils/macDownload.ts --changed-file apps/ui/src/utils/__tests__/macDownload.test.ts --changed-file implementation-plans/mac-download-architecture.md`: baseline validation passed, including 82 unit suites and 600 tests.
- Formatter, E2E, and Rust-specific checks were skipped because this change does not touch formatter behavior, browser workflows beyond an href selection helper, or Rust/Tauri code.

# Performance

## Performance impact

- [x] Performance was considered for this change
- [ ] No meaningful performance impact is expected

## Justification

- No meaningful performance impact is expected. The header performs one small architecture lookup on mount, matching the previous behavior but with corrected handling.

# UI changes

## Screenshots or recordings

- N/A

# Issue link

- Closes #
