### PR TITLE
docs: refresh current project documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,7 +257,7 @@ pnpm validate:changes   # Run the shared validation helper
 
 ### Adding or Modifying Themes
 
-**Current Themes (27 total):**
+**Current Themes (22 total):**
 
 - Classic: Solarized Dark/Light
 - Popular Dark: Monokai, Dracula, One Dark Pro, GitHub Dark, Tokyo Night, Ayu Dark, Material Palenight, Night Owl
@@ -315,7 +315,7 @@ pnpm validate:changes   # Run the shared validation helper
 
 ## Current Status
 
-### Current Capabilities (v1.2.2)
+### Current Capabilities (v1.3.0)
 
 ✅ Monaco editor with OpenSCAD syntax highlighting
 ✅ Live STL/SVG preview (web: openscad-wasm, desktop: native binary)
@@ -324,13 +324,13 @@ pnpm validate:changes   # Run the shared validation helper
 ✅ Export to STL, OBJ, AMF, 3MF, PNG, SVG, DXF
 ✅ Content-hash caching
 ✅ 2D mode with SVG viewer
-✅ AI copilot with Vercel AI SDK (streaming, tool calls)
+✅ AI copilot with Vercel AI SDK (streaming, tool calls, Anthropic/OpenAI/OpenAI-compatible providers)
 ✅ Diff-based code editing
 ✅ Tool call visualization
 ✅ Multi-turn AI chat with draft and attachment state
 ✅ Customizer panel with interactive parameter controls
 ✅ Tree-sitter based parameter parsing
-✅ 27 editor themes with categorized dropdown
+✅ 22 editor themes with categorized dropdown
 ✅ Vim mode with configurable keybindings
 ✅ Web version (openscad-studio.pages.dev)
 ✅ Platform abstraction (PlatformBridge interface)
@@ -406,5 +406,5 @@ pnpm validate:changes   # Run the shared validation helper
 
 ---
 
-**Last Updated**: 2026-04-28
-**Current Version**: v1.2.2 — Web + Desktop
+**Last Updated**: 2026-06-14
+**Current Version**: v1.3.0 — Web + Desktop

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -113,7 +113,7 @@ openscad-studio/
 │   │   │   │   └── webBridge.ts # Web implementation
 │   │   │   ├── services/        # Render services (WASM + native), AI service, OpenSCAD worker
 │   │   │   ├── stores/          # Zustand state (project files, workspace, settings)
-│   │   │   └── themes/          # 27 editor themes
+│   │   │   └── themes/          # 22 editor themes
 │   │   └── src-tauri/           # Rust backend (desktop only)
 │   └── web/                     # Web app entry point (Vite)
 └── packages/
@@ -126,13 +126,18 @@ The AI copilot uses the [Vercel AI SDK](https://sdk.vercel.ai/) with streaming s
 
 1. Open Settings (⌘,)
 2. Navigate to "AI" tab
-3. Enter your Anthropic / OpenAI API key
+3. Enter an Anthropic or OpenAI API key, or configure an OpenAI-compatible local provider
 
 **Supported Providers:**
-All models from the following providers are supported:
 
 - Anthropic
 - OpenAI
+- OpenAI-compatible local or self-hosted endpoints such as Ollama, llama.cpp, and LM Studio
+
+For OpenAI-compatible providers, configure the base URL in Settings > AI. The default is
+`http://127.0.0.1:11434/v1` for Ollama. API keys are optional for local providers and are only
+needed when the configured server requires one. Model discovery uses `/models` when the server
+supports it; browser-based web usage also depends on the local server allowing CORS requests.
 
 The AI can:
 

--- a/PRODUCT_ROADMAP.md
+++ b/PRODUCT_ROADMAP.md
@@ -4,7 +4,7 @@
 >
 > OpenSCAD is the engine, not the product. The product is: you describe what you want, it makes it, you print it.
 
-**Current version**: v1.2.2 | **Last updated**: 2026-04-28
+**Current version**: v1.3.0 | **Last updated**: 2026-06-14
 
 This roadmap mixes shipped milestones with future planning. Older sections may describe the implementation assumptions that existed when they were written rather than the current client-side `openscad-wasm` architecture.
 
@@ -20,14 +20,14 @@ This roadmap mixes shipped milestones with future planning. Older sections may d
 
 ---
 
-## What We Have (v1.2.2)
+## What We Have (v1.3.0)
 
 | Area                                                                                  | Status |
 | ------------------------------------------------------------------------------------- | ------ |
-| Monaco editor with OpenSCAD syntax, 27 themes, vim mode, tree-sitter formatting       | ✅     |
+| Monaco editor with OpenSCAD syntax, 22 themes, vim mode, tree-sitter formatting       | ✅     |
 | Live 3D preview (Three.js mesh viewer, orbit controls, wireframe/solid/section tools) | ✅     |
 | 2D SVG mode for laser cutting / engraving                                             | ✅     |
-| AI copilot (Claude + GPT, streaming, tool-calling, diff-based editing, image attachments, auto-rollback) | ✅     |
+| AI copilot (Claude, GPT, OpenAI-compatible local endpoints, streaming, tool-calling, diff-based editing, image attachments, auto-rollback) | ✅     |
 | AI can see the 3D preview (screenshot tool returns base64 PNG to vision models)       | ✅     |
 | Customizer panel (tree-sitter parsed parameters → sliders, dropdowns, vectors)        | ✅     |
 | Share links with remixable web entry and thumbnail support                            | ✅     |
@@ -37,7 +37,7 @@ This roadmap mixes shipped milestones with future planning. Older sections may d
 | Web app via openscad-wasm (zero install, Cloudflare Pages)                            | ✅     |
 | Desktop app (macOS, Homebrew)                                                         | ✅     |
 | Library path management, include/use resolution, BOSL2 support                        | ✅     |
-| Multi-tab editing, undo/redo checkpoints, conversation persistence                    | ✅     |
+| Multi-tab editing, undo/redo checkpoints, and multi-turn AI chat state                | ✅     |
 | E2E test suite (Playwright, ~2700 lines, CI on every PR)                              | ✅     |
 
 ---
@@ -179,10 +179,10 @@ Customizer-first sharing shipped for share links. SEO landing pages remain futur
 
 The AI should understand the full project, not just the active file.
 
-- [ ] Include referenced files (`use`/`include`) in AI system prompt as context
-- [ ] Add `explore_project` AI tool that lists files in the working directory
-- [ ] Limit context to files actually referenced (don't dump entire directories)
-- [ ] AI can suggest creating helper modules and splitting complex designs
+- [x] Provide project-aware tools for render target context, folder listing, file reading, file creation, and render-target changes
+- [x] AI can edit any project file by relative path and suggest splitting complex designs into helper modules
+- [ ] Add automatic referenced-file context for `use`/`include` dependencies without requiring explicit tool calls
+- [ ] Limit automatic context to files actually referenced (don't dump entire directories)
 
 ### 4.2 3D-Printing-Aware AI
 
@@ -203,8 +203,8 @@ Bake domain knowledge into the AI so it produces print-ready designs.
 
 - [ ] Dockview panel listing saved conversations (title, date, message count)
 - [ ] Click to load, delete with confirmation, search across titles
-- [ ] Backend already supports `save_conversation`, `load_conversations`, `delete_conversation`
-- [ ] Frontend just needs the UI
+- [ ] Add persistent conversation storage; the current frontend hook exposes placeholders but no saved-conversation store is wired
+- [ ] Restore saved conversations into the active chat state
 
 ### 4.4 Configurable Edit Size Limit
 
@@ -330,7 +330,7 @@ Don't schedule these as standalone work items. Fix them when they're in the crit
 | ------------------------------------------------ | -------- | --------------------------------------------------------------- |
 | App.tsx is 1189 lines                            | Medium   | When adding a feature that touches App.tsx and it's too painful |
 | Refs-as-state anti-pattern (7+ refs)             | Medium   | When a state bug is traced to this pattern                      |
-| EditorState duplication (frontend + backend)     | Medium   | When AI context or multi-file features need coherent state      |
+| Legacy desktop `EditorState` mirror              | Low      | When history or desktop IPC state needs simplification          |
 | Settings split across localStorage + Tauri store | Low      | When adding new settings gets confusing                         |
 | Error boundary only at top level                 | Low      | When a panel crash takes down the whole app                     |
 | DiffViewer shows same code for old/new           | Low      | When someone actually uses the diff panel                       |
@@ -345,7 +345,7 @@ Don't schedule these as standalone work items. Fix them when they're in the crit
 
 ### Leading Indicators
 
-- Web app weekly active users (Plausible analytics)
+- Web app weekly active users (PostHog product analytics)
 - AI conversations started per session
 - STL exports per session (= user got a result they wanted)
 - Shared design links generated

--- a/docs/coordinate-system.md
+++ b/docs/coordinate-system.md
@@ -56,11 +56,11 @@ Use `threeToOpenScadSize` when displaying bounding-box dimensions. Use `threeToO
 | `ThreeViewer.tsx` mesh `rotation` | Internal Three.js ↔ OpenSCAD boundary | Do not change this rotation |
 | `previewFraming.ts` | Three.js world space | Grid, framing, bounding-box math; correct as-is |
 | `previewAxes.ts` | Three.js world space (geometry) / OpenSCAD (tick labels) | Tick label *values* are converted; axis line positions are not |
-| `BBoxPanel.tsx` | OpenSCAD display space | Uses `threeToOpenScadSize` before rendering |
+| `components/three-viewer/panels/BBoxPanel.tsx` | OpenSCAD display space | Uses `threeToOpenScadSize` before rendering |
 | `ThreeViewer.tsx` `BBoxOverlay` | Three.js world space (HTML positions) / OpenSCAD (badge text) | Badge text remapped: Three.js Y face → "Z", Three.js Z face → "Y" |
-| `SectionPlanePanel.tsx` | Three.js world space (axis values) / OpenSCAD (labels) | `value: 'y'` is Three.js Y = OpenSCAD Z, displayed as "Z" |
+| `components/three-viewer/panels/SectionPlanePanel.tsx` | Three.js world space (axis values) / OpenSCAD (labels) | `value: 'y'` is Three.js Y = OpenSCAD Z, displayed as "Z" |
 | `sectionPlaneController.ts` | Three.js world space | No display; correct as-is |
-| `measurementController3d.ts` | Three.js world space | Apply `threeToOpenScadDelta` before displaying measurements |
+| `components/three-viewer/measurementController3d.ts` | Three.js world space | Apply `threeToOpenScadDelta` before displaying measurements |
 
 ## Axis overlay tick labels
 

--- a/engineering-roadmap.md
+++ b/engineering-roadmap.md
@@ -1,6 +1,6 @@
 # OpenSCAD Studio — Engineering Roadmap
 
-> Current app version: **v1.2.2**. This roadmap mixes historical milestone notes with future planning, so older phase sections may reference the version they originally shipped in rather than the current release.
+> Current app version: **v1.3.0**. This roadmap mixes historical milestone notes with future planning, so older phase sections may reference the version they originally shipped in rather than the current release.
 >
 > A modern OpenSCAD editor with live preview and AI copilot capabilities, available as both a web app and a macOS desktop app. The application uses openscad-wasm for rendering and provides a superior editing experience with real-time feedback and AI-assisted code generation.
 
@@ -62,7 +62,7 @@
 - ✅ SSE streaming with incremental text deltas
 - ✅ AiPromptPanel, ModelSelector, DiffViewer UI components
 - ✅ Multi-turn tool calling with automatic execution
-- ✅ Conversation persistence (save/load/delete)
+- ✅ Multi-turn chat state with draft, attachment, and checkpoint restoration support
 - ✅ Checkpoint-based undo with "restore to before this turn"
 - ✅ Multi-provider support (Anthropic + OpenAI)
 
@@ -208,8 +208,8 @@
 - [ ] Click to load a conversation
 - [ ] Delete conversations with confirmation
 - [ ] Search across conversation titles
-- [ ] Backend already supports `save_conversation`, `load_conversations`, `delete_conversation`
-- [ ] Frontend just needs the UI — `loadConversation` already exists in `useAiAgent`
+- [ ] Add persistent conversation storage; `useAiAgent` currently exposes `loadConversation`/`saveConversation` placeholders only
+- [ ] Restore saved conversations into the active chat state
 
 ### ✅ 5.2: Image Input for AI (COMPLETED)
 
@@ -237,7 +237,8 @@
   --- main.scad (active) ---
   [contents]
   ```
-- [ ] Add an `explore_project` AI tool that lists files in the working directory
+- [x] Add project browsing tools (`get_project_context`, `list_folder_contents`, `read_file`) for incremental multi-file context
+- [x] Add project mutation tools (`apply_edit`, `create_file`, `set_render_target`) for multi-file workflows
 - [ ] Limit context to files actually referenced (don't dump entire directories)
 
 ### 5.4: AI Prompt Templates
@@ -257,7 +258,7 @@
 - [ ] Default: 120 lines (current behavior)
 - [ ] Allow increase to 250 or 500 for users who want full-file generation
 - [ ] Setting in `SettingsDialog.tsx` → AI tab
-- [ ] Update `validate_edit()` in `ai_tools.rs` to read from settings
+- [ ] Add frontend validation around `apply_edit` if an edit-size limit returns
 
 **Success criteria:** AI chat renders beautifully. Users can reference images and past conversations. AI understands multi-file projects. Common operations are one-click.
 
@@ -518,9 +519,9 @@ Items to address opportunistically, not as dedicated phases:
 | Issue                                                 | Location                           | Severity | Notes                                                                       |
 | ----------------------------------------------------- | ---------------------------------- | -------- | --------------------------------------------------------------------------- |
 | Refs-as-state anti-pattern                            | `App.tsx` (7+ refs)                | Medium   | Address in 4B.1 decomposition                                               |
-| Settings split across localStorage and Tauri store    | `settingsStore.ts`, `cmd/ai.rs`    | Low      | Consider unifying in platform abstraction                                   |
-| OpenSCAD stderr parsing is regex-based                | `utils/parser.rs`                  | Low      | Works but may miss edge cases. Revisit if OpenSCAD adds JSON output         |
-| `EditorState` duplicated between frontend and backend | `useOpenScad.ts`, `ai_agent.rs`    | Medium   | Backend should be source of truth (4B.3)                                    |
+| Settings split across localStorage and Tauri store    | `settingsStore.ts`, `apiKeyStore.ts` | Low    | Consider unifying in platform abstraction                                   |
+| OpenSCAD stderr parsing is regex-based                | `renderService.ts`                 | Low      | Works but may miss edge cases. Revisit if OpenSCAD adds JSON output         |
+| Legacy desktop `EditorState` mirror                   | `cmd/ai_tools.rs`                  | Low      | Currently limited to history/workspace state helpers                        |
 | No graceful degradation when OpenSCAD is unavailable  | Various                            | Low      | Editor works, just no preview. Could be clearer about what's disabled       |
 | `DiffViewer` panel always shows same code for old/new | `PanelComponents.tsx:58-66`        | Low      | `oldCode={source} newCode={source}` — not actually showing a diff           |
 | Error boundary only at top level                      | `ErrorBoundary.tsx`                | Low      | Per-panel boundaries would improve resilience (see 4B.2 follow-up)          |
@@ -583,6 +584,6 @@ Decisions made during roadmap planning that affect ordering:
 
 ---
 
-**Last Updated:** 2026-04-19
-**Current Phase:** v1.2.1 — web + desktop app shipping with sharing, analytics/privacy controls, formatter coverage, advanced viewer tooling, and desktop MCP support for external agents
+**Last Updated:** 2026-06-14
+**Current Phase:** v1.3.0 — web + desktop app shipping with sharing, analytics/privacy controls, formatter coverage, advanced viewer tooling, desktop MCP support, and OpenAI-compatible local provider support
 **Next Milestone:** Phase 4B.1/4B.3 (App.tsx decomposition, centralized state) or Phase 5 (AI experience) based on user feedback


### PR DESCRIPTION
# Summary

## What changed

- Updated maintainer docs and roadmaps for v1.3.0.
- Documented OpenAI-compatible local provider support in developer setup.
- Corrected stale theme counts, conversation persistence claims, project-aware AI tool status, and 3D coordinate-system file paths.

## Why

- Documentation had drifted after the v1.3.0 release and local/self-hosted provider work.
- Roadmap docs still described some older Rust-side AI and conversation-storage assumptions.

## Implementation notes

- README.md was intentionally left unchanged to keep it user-facing.
- Only documentation files were edited.

# Testing

## Coverage checklist

- [ ] Backend unit tests added or updated for changed Rust behavior
- [ ] Client unit/component tests added or updated for changed frontend behavior
- [ ] E2E tests added or updated for net new user-facing flows
- [x] No new tests were needed for this change

## Validation performed

- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm test:unit`
- [ ] `pnpm test:formatter:ci`
- [ ] `pnpm test:e2e:web`
- [ ] `bash scripts/validate-changes.sh --dry-run ...`
- [ ] `cd apps/ui/src-tauri && cargo fmt --check`
- [ ] `cd apps/ui/src-tauri && cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cd apps/ui/src-tauri && cargo check --all-targets --all-features`

## Test details

- Ran `bash scripts/validate-changes.sh --scope baseline`, which completed format check, lint, type-check, and unit tests.
- Unit results: 81 test suites passed, 594 tests passed.
- Formatter, e2e, and Rust-specific checks were skipped because this PR only changes documentation.

# Performance

## Performance impact

- [x] Performance was considered for this change
- [x] No meaningful performance impact is expected

## Justification

- Documentation-only updates do not change runtime behavior or shipped assets.

# UI changes

## Screenshots or recordings

- N/A

# Issue link

- N/A