### PR TITLE
feat: customizer parameter search and filter chips

### DIFF
--- a/apps/ui/eslint.config.js
+++ b/apps/ui/eslint.config.js
@@ -66,6 +66,8 @@ export default tseslint.config(
       'src/components/ui/Button.tsx',
       'src/components/ui/IconButton.tsx',
       'src/components/ui/SegmentedControl.tsx',
+      'src/components/ui/FilterChip.tsx',
+      'src/components/ui/SearchInput.tsx',
     ],
     rules: {
       'no-restricted-syntax': [

--- a/apps/ui/src/components/CustomizerPanel.tsx
+++ b/apps/ui/src/components/CustomizerPanel.tsx
@@ -13,6 +13,7 @@ import { replaceParamValue } from '../utils/customizer/replaceParamValue';
 import { isParserReady, onParserReady } from '../utils/formatter/parser';
 import type { CustomizerParam, ParameterProminence } from '../utils/customizer/types';
 import { ParameterControl } from './customizer/ParameterControl';
+import { ALL_FILTER, EDITED_FILTER, CustomizerFilterBar } from './customizer/CustomizerFilterBar';
 import { Button, IconButton, Text, Toggle } from './ui';
 import { TbAdjustmentsHorizontal, TbRefresh, TbSparkles, TbCode, TbDownload } from 'react-icons/tb';
 import { eventBus } from '../platform';
@@ -50,6 +51,19 @@ const COMPACT_HEADER_ACTIONS_BREAKPOINT = 420;
 
 function getParamKey(param: CustomizerParam): string {
   return `${param.line}:${param.name}`;
+}
+
+function paramMatchesQuery(param: CustomizerParam, tabName: string, query: string): boolean {
+  const haystacks = [
+    param.label,
+    param.name,
+    param.name.replace(/[_-]+/g, ' '),
+    param.description,
+    param.group,
+    param.tab ?? tabName,
+    param.unit,
+  ];
+  return haystacks.some((value) => value != null && value.toLowerCase().includes(query));
 }
 
 function groupParams(params: CustomizerParam[], showAdvanced: boolean): GroupedParams[] {
@@ -158,6 +172,8 @@ export function CustomizerPanel({
   isDownloadingSvg = false,
 }: CustomizerPanelProps) {
   const [showAdvanced, setShowAdvanced] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [activeFilter, setActiveFilter] = useState<string>(ALL_FILTER);
   const [parserReady, setParserReady] = useState(isParserReady);
   const headerRef = useRef<HTMLDivElement | null>(null);
   const [headerWidth, setHeaderWidth] = useState(0);
@@ -242,6 +258,82 @@ export function CustomizerPanel({
   );
   const showTabHeaders =
     groupedTabs.length > 1 || groupedTabs.some((tab) => tab.name !== 'Parameters');
+
+  // Keys of parameters whose value differs from the opened-file baseline. Derived from the
+  // currently visible (advanced-aware) tabs so chip counts match what the user can actually see.
+  const dirtyKeys = useMemo(() => {
+    const keys = new Set<string>();
+    if (!baselineParams.size) return keys;
+    for (const tab of groupedTabs) {
+      for (const group of tab.groups) {
+        for (const param of group.params) {
+          const baseline = baselineParams.get(getParamKey(param));
+          if (baseline !== undefined && param.rawValue !== baseline) {
+            keys.add(getParamKey(param));
+          }
+        }
+      }
+    }
+    return keys;
+  }, [groupedTabs, baselineParams]);
+
+  const categoryChips = useMemo(
+    () => (showTabHeaders ? groupedTabs.map((tab) => tab.name) : []),
+    [groupedTabs, showTabHeaders]
+  );
+  const editedCount = dirtyKeys.size;
+  const totalVisibleParamCount = useMemo(
+    () =>
+      groupedTabs.reduce(
+        (count, tab) => count + tab.groups.reduce((sum, group) => sum + group.params.length, 0),
+        0
+      ),
+    [groupedTabs]
+  );
+
+  const showEditedChip = editedCount > 0 || activeFilter === EDITED_FILTER;
+  const showFilterBar = totalVisibleParamCount > 4 || categoryChips.length > 1;
+
+  // Reset the active chip if its target disappears (e.g. the only edited param was reset, or a
+  // category became empty after toggling advanced controls).
+  const effectiveFilter = useMemo(() => {
+    if (activeFilter === EDITED_FILTER) {
+      return editedCount > 0 ? EDITED_FILTER : ALL_FILTER;
+    }
+    if (activeFilter !== ALL_FILTER && !categoryChips.includes(activeFilter)) {
+      return ALL_FILTER;
+    }
+    return activeFilter;
+  }, [activeFilter, categoryChips, editedCount]);
+
+  const normalizedQuery = searchQuery.trim().toLowerCase();
+  const isFiltering = effectiveFilter !== ALL_FILTER || normalizedQuery.length > 0;
+
+  const filteredTabs = useMemo(() => {
+    if (!isFiltering) return groupedTabs;
+    const isCategoryFilter = effectiveFilter !== ALL_FILTER && effectiveFilter !== EDITED_FILTER;
+    return groupedTabs
+      .filter((tab) => !isCategoryFilter || tab.name === effectiveFilter)
+      .map((tab) => ({
+        ...tab,
+        groups: tab.groups
+          .map((group) => ({
+            ...group,
+            params: group.params.filter((param) => {
+              if (effectiveFilter === EDITED_FILTER && !dirtyKeys.has(getParamKey(param))) {
+                return false;
+              }
+              if (normalizedQuery && !paramMatchesQuery(param, tab.name, normalizedQuery)) {
+                return false;
+              }
+              return true;
+            }),
+          }))
+          .filter((group) => group.params.length > 0),
+      }))
+      .filter((tab) => tab.groups.length > 0);
+  }, [groupedTabs, isFiltering, effectiveFilter, normalizedQuery, dirtyKeys]);
+
   const analyticsSummary = useMemo(() => getCustomizerAnalyticsSummary(tabs), [tabs]);
   const useCompactHeaderActions =
     isCustomizerFirstMode && headerWidth > 0 && headerWidth <= COMPACT_HEADER_ACTIONS_BREAKPOINT;
@@ -743,83 +835,117 @@ export function CustomizerPanel({
             </div>
           </div>
         )}
+
+        {showFilterBar && (
+          <div className="border-t px-3 py-2" style={{ borderColor: 'var(--border-primary)' }}>
+            <CustomizerFilterBar
+              searchQuery={searchQuery}
+              onSearchChange={setSearchQuery}
+              activeFilter={effectiveFilter}
+              onFilterChange={setActiveFilter}
+              categories={categoryChips}
+              editedCount={editedCount}
+              showEdited={showEditedChip}
+            />
+          </div>
+        )}
       </div>
 
       <div className="p-3 space-y-3">
-        {groupedTabs.map((tab) => (
-          <section key={tab.name} className="space-y-3">
-            {showTabHeaders && (
-              <div className="flex items-center justify-between">
-                <div>
-                  <Text variant="overline">{tab.name}</Text>
+        {filteredTabs.length === 0 ? (
+          <div
+            className="flex flex-col items-center gap-3 px-4 py-10 text-center"
+            data-testid="customizer-no-matches"
+          >
+            <Text variant="caption">No parameters match your filters.</Text>
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={() => {
+                setSearchQuery('');
+                setActiveFilter(ALL_FILTER);
+              }}
+            >
+              Clear filters
+            </Button>
+          </div>
+        ) : (
+          filteredTabs.map((tab) => (
+            <section key={tab.name} className="space-y-3">
+              {showTabHeaders && (
+                <div className="flex items-center justify-between">
+                  <div>
+                    <Text variant="overline">{tab.name}</Text>
+                  </div>
                 </div>
-              </div>
-            )}
+              )}
 
-            {tab.groups.map((group) =>
-              (() => {
-                const shouldFlattenGroup =
-                  tab.groups.length === 1 && isRedundantGroupName(tab.name, group.name);
+              {tab.groups.map((group) =>
+                (() => {
+                  const shouldFlattenGroup =
+                    tab.groups.length === 1 && isRedundantGroupName(tab.name, group.name);
 
-                if (shouldFlattenGroup) {
+                  if (shouldFlattenGroup) {
+                    return (
+                      <div key={`${tab.name}-${group.id}`} className="space-y-2">
+                        {group.params.map((param) => {
+                          const baseline = baselineParams.get(getParamKey(param));
+                          const isDirty = baseline !== undefined && param.rawValue !== baseline;
+
+                          return (
+                            <ParameterControl
+                              key={`${param.name}-${param.line}`}
+                              param={param}
+                              onChange={(newValue) => handleParameterChange(param, newValue)}
+                              isDirty={isDirty}
+                              onReset={isDirty ? () => handleResetParameter(param) : undefined}
+                            />
+                          );
+                        })}
+                      </div>
+                    );
+                  }
+
                   return (
-                    <div key={`${tab.name}-${group.id}`} className="space-y-2">
-                      {group.params.map((param) => {
-                        const baseline = baselineParams.get(getParamKey(param));
-                        const isDirty = baseline !== undefined && param.rawValue !== baseline;
+                    <div
+                      key={`${tab.name}-${group.id}`}
+                      className="rounded-xl p-3"
+                      style={{
+                        backgroundColor: 'var(--bg-secondary)',
+                      }}
+                    >
+                      {group.name && !isRedundantGroupName(tab.name, group.name) && (
+                        <div className="mb-2">
+                          <Text variant="overline" weight="medium" className="tracking-[0.08em]">
+                            {group.name}
+                          </Text>
+                        </div>
+                      )}
 
-                        return (
-                          <ParameterControl
-                            key={`${param.name}-${param.line}`}
-                            param={param}
-                            onChange={(newValue) => handleParameterChange(param, newValue)}
-                            isDirty={isDirty}
-                            onReset={isDirty ? () => handleResetParameter(param) : undefined}
-                          />
-                        );
-                      })}
+                      <div className="space-y-2">
+                        {group.params.map((param) => {
+                          const baseline = baselineParams.get(getParamKey(param));
+                          const isDirty = baseline !== undefined && param.rawValue !== baseline;
+
+                          return (
+                            <ParameterControl
+                              key={`${param.name}-${param.line}`}
+                              param={param}
+                              onChange={(newValue) => handleParameterChange(param, newValue)}
+                              isDirty={isDirty}
+                              onReset={isDirty ? () => handleResetParameter(param) : undefined}
+                            />
+                          );
+                        })}
+                      </div>
                     </div>
                   );
-                }
-
-                return (
-                  <div
-                    key={`${tab.name}-${group.id}`}
-                    className="rounded-xl p-3"
-                    style={{
-                      backgroundColor: 'var(--bg-secondary)',
-                    }}
-                  >
-                    {group.name && !isRedundantGroupName(tab.name, group.name) && (
-                      <div className="mb-2">
-                        <Text variant="overline" weight="medium" className="tracking-[0.08em]">
-                          {group.name}
-                        </Text>
-                      </div>
-                    )}
-
-                    <div className="space-y-2">
-                      {group.params.map((param) => {
-                        const baseline = baselineParams.get(getParamKey(param));
-                        const isDirty = baseline !== undefined && param.rawValue !== baseline;
-
-                        return (
-                          <ParameterControl
-                            key={`${param.name}-${param.line}`}
-                            param={param}
-                            onChange={(newValue) => handleParameterChange(param, newValue)}
-                            isDirty={isDirty}
-                            onReset={isDirty ? () => handleResetParameter(param) : undefined}
-                          />
-                        );
-                      })}
-                    </div>
-                  </div>
-                );
-              })()
-            )}
-          </section>
-        ))}
+                })()
+              )}
+            </section>
+          ))
+        )}
       </div>
     </div>
   );

--- a/apps/ui/src/components/CustomizerPanel.tsx
+++ b/apps/ui/src/components/CustomizerPanel.tsx
@@ -15,7 +15,14 @@ import type { CustomizerParam, ParameterProminence } from '../utils/customizer/t
 import { ParameterControl } from './customizer/ParameterControl';
 import { ALL_FILTER, EDITED_FILTER, CustomizerFilterBar } from './customizer/CustomizerFilterBar';
 import { Button, IconButton, Text, Toggle } from './ui';
-import { TbAdjustmentsHorizontal, TbRefresh, TbSparkles, TbCode, TbDownload } from 'react-icons/tb';
+import {
+  TbAdjustmentsHorizontal,
+  TbRefresh,
+  TbSparkles,
+  TbCode,
+  TbDownload,
+  TbSearch,
+} from 'react-icons/tb';
 import { eventBus } from '../platform';
 import { useSettings } from '../stores/settingsStore';
 
@@ -174,8 +181,11 @@ export function CustomizerPanel({
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [activeFilter, setActiveFilter] = useState<string>(ALL_FILTER);
+  const [searchExpanded, setSearchExpanded] = useState(false);
   const [parserReady, setParserReady] = useState(isParserReady);
   const headerRef = useRef<HTMLDivElement | null>(null);
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
+  const filterRegionRef = useRef<HTMLDivElement | null>(null);
   const [headerWidth, setHeaderWidth] = useState(0);
   const analytics = useAnalytics();
   const [settings] = useSettings();
@@ -333,6 +343,49 @@ export function CustomizerPanel({
       }))
       .filter((tab) => tab.groups.length > 0);
   }, [groupedTabs, isFiltering, effectiveFilter, normalizedQuery, dirtyKeys]);
+
+  const closeSearch = useCallback(() => {
+    setSearchExpanded(false);
+    setSearchQuery('');
+    setActiveFilter(ALL_FILTER);
+  }, []);
+
+  const toggleSearch = useCallback(() => {
+    setSearchExpanded((expanded) => {
+      if (expanded) {
+        setSearchQuery('');
+        setActiveFilter(ALL_FILTER);
+        return false;
+      }
+      return true;
+    });
+  }, []);
+
+  // Collapse the search region if filtering is no longer available.
+  useEffect(() => {
+    if (!showFilterBar && searchExpanded) {
+      setSearchExpanded(false);
+    }
+  }, [showFilterBar, searchExpanded]);
+
+  // Toggle `inert` so the collapsed region is fully removed from tab/focus order while still
+  // animating open and closed.
+  useEffect(() => {
+    const element = filterRegionRef.current;
+    if (!element) return;
+    if (searchExpanded) {
+      element.removeAttribute('inert');
+    } else {
+      element.setAttribute('inert', '');
+    }
+  }, [searchExpanded]);
+
+  // Focus the search field once the region has expanded.
+  useEffect(() => {
+    if (!searchExpanded) return;
+    const id = requestAnimationFrame(() => searchInputRef.current?.focus());
+    return () => cancelAnimationFrame(id);
+  }, [searchExpanded]);
 
   const analyticsSummary = useMemo(() => getCustomizerAnalyticsSummary(tabs), [tabs]);
   const useCompactHeaderActions =
@@ -592,6 +645,21 @@ export function CustomizerPanel({
                 </div>
               )}
               <div className="flex items-center gap-1.5 ml-auto">
+                {showFilterBar && (
+                  <IconButton
+                    variant="toolbar"
+                    size={useCompactHeaderActions ? 'md' : 'sm'}
+                    onClick={toggleSearch}
+                    isActive={searchExpanded}
+                    title="Search parameters"
+                    aria-label="Search parameters"
+                    aria-expanded={searchExpanded}
+                    tooltipSide="bottom"
+                    data-testid="customizer-search-toggle"
+                  >
+                    <TbSearch size={useCompactHeaderActions ? 14 : 13} />
+                  </IconButton>
+                )}
                 {useCompactHeaderActions ? (
                   <IconButton
                     variant="toolbar"
@@ -822,6 +890,21 @@ export function CustomizerPanel({
                   <span>Advanced</span>
                 </div>
               )}
+              {showFilterBar && (
+                <IconButton
+                  variant="toolbar"
+                  size="sm"
+                  onClick={toggleSearch}
+                  isActive={searchExpanded}
+                  title="Search parameters"
+                  aria-label="Search parameters"
+                  aria-expanded={searchExpanded}
+                  tooltipSide="bottom"
+                  data-testid="customizer-search-toggle"
+                >
+                  <TbSearch size={14} />
+                </IconButton>
+              )}
               <Button
                 type="button"
                 variant="secondary"
@@ -837,16 +920,29 @@ export function CustomizerPanel({
         )}
 
         {showFilterBar && (
-          <div className="border-t px-3 py-2" style={{ borderColor: 'var(--border-primary)' }}>
-            <CustomizerFilterBar
-              searchQuery={searchQuery}
-              onSearchChange={setSearchQuery}
-              activeFilter={effectiveFilter}
-              onFilterChange={setActiveFilter}
-              categories={categoryChips}
-              editedCount={editedCount}
-              showEdited={showEditedChip}
-            />
+          <div
+            className="grid transition-[grid-template-rows,opacity] duration-200 ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none"
+            style={{
+              gridTemplateRows: searchExpanded ? '1fr' : '0fr',
+              opacity: searchExpanded ? 1 : 0,
+            }}
+          >
+            <div ref={filterRegionRef} className="overflow-hidden">
+              <div className="border-t px-3 py-2" style={{ borderColor: 'var(--border-primary)' }}>
+                <CustomizerFilterBar
+                  searchQuery={searchQuery}
+                  onSearchChange={setSearchQuery}
+                  activeFilter={effectiveFilter}
+                  onFilterChange={setActiveFilter}
+                  categories={categoryChips}
+                  editedCount={editedCount}
+                  showEdited={showEditedChip}
+                  onCollapse={closeSearch}
+                  inputRef={searchInputRef}
+                  inputTabbable={searchExpanded}
+                />
+              </div>
+            </div>
           </div>
         )}
       </div>

--- a/apps/ui/src/components/__tests__/CustomizerPanel.test.tsx
+++ b/apps/ui/src/components/__tests__/CustomizerPanel.test.tsx
@@ -540,11 +540,17 @@ describe('CustomizerPanel', () => {
     ];
   }
 
-  it('renders the search field and category chips for multi-category models', () => {
+  it('expands the search field and category chips from the header toggle', () => {
     mockParseCustomizerParams.mockReturnValue(multiCategoryTabs());
 
     renderWithProviders(<CustomizerPanel code="//" baselineCode="//" isCustomizerFirstMode />);
 
+    const toggle = screen.getByTestId('customizer-search-toggle');
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+
+    fireEvent.click(toggle);
+
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
     expect(screen.getByPlaceholderText('Search parameters...')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'All' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'View' })).toBeTruthy();
@@ -556,6 +562,7 @@ describe('CustomizerPanel', () => {
 
     renderWithProviders(<CustomizerPanel code="//" baselineCode="//" isCustomizerFirstMode />);
 
+    fireEvent.click(screen.getByTestId('customizer-search-toggle'));
     fireEvent.change(screen.getByPlaceholderText('Search parameters...'), {
       target: { value: 'depth' },
     });
@@ -570,6 +577,7 @@ describe('CustomizerPanel', () => {
 
     renderWithProviders(<CustomizerPanel code="//" baselineCode="//" isCustomizerFirstMode />);
 
+    fireEvent.click(screen.getByTestId('customizer-search-toggle'));
     fireEvent.click(screen.getByRole('button', { name: 'View' }));
 
     expect(screen.getByText('Show tray')).toBeTruthy();
@@ -586,6 +594,7 @@ describe('CustomizerPanel', () => {
       <CustomizerPanel code="width = 60;" baselineCode="width = 60;" isCustomizerFirstMode />
     );
 
+    fireEvent.click(screen.getByTestId('customizer-search-toggle'));
     expect(screen.queryByRole('button', { name: /edited/i })).toBeNull();
 
     rerender(
@@ -604,6 +613,7 @@ describe('CustomizerPanel', () => {
 
     renderWithProviders(<CustomizerPanel code="//" baselineCode="//" isCustomizerFirstMode />);
 
+    fireEvent.click(screen.getByTestId('customizer-search-toggle'));
     fireEvent.change(screen.getByPlaceholderText('Search parameters...'), {
       target: { value: 'no-such-parameter' },
     });
@@ -614,6 +624,27 @@ describe('CustomizerPanel', () => {
 
     expect(screen.getByText('Width')).toBeTruthy();
     expect(screen.getByText('Show tray')).toBeTruthy();
+  });
+
+  it('collapses the search region and resets filters via the close button', () => {
+    mockParseCustomizerParams.mockReturnValue(multiCategoryTabs());
+
+    renderWithProviders(<CustomizerPanel code="//" baselineCode="//" isCustomizerFirstMode />);
+
+    const toggle = screen.getByTestId('customizer-search-toggle');
+    fireEvent.click(toggle);
+
+    const search = screen.getByPlaceholderText('Search parameters...') as HTMLInputElement;
+    fireEvent.change(search, { target: { value: 'depth' } });
+    expect(screen.queryByText('Width')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close search' }));
+
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    expect((screen.getByPlaceholderText('Search parameters...') as HTMLInputElement).value).toBe(
+      ''
+    );
+    expect(screen.getByText('Width')).toBeTruthy();
   });
 
   it('treats slider changes as resettable against the opened-file baseline', () => {

--- a/apps/ui/src/components/__tests__/CustomizerPanel.test.tsx
+++ b/apps/ui/src/components/__tests__/CustomizerPanel.test.tsx
@@ -459,6 +459,163 @@ describe('CustomizerPanel', () => {
     });
   });
 
+  function multiCategoryTabs(editWidth = false): CustomizerTab[] {
+    return [
+      {
+        name: 'View',
+        params: [
+          {
+            name: 'show_tray',
+            type: 'boolean',
+            value: true,
+            rawValue: 'true',
+            line: 1,
+            tab: 'View',
+            label: 'Show tray',
+          },
+          {
+            name: 'show_top_frame',
+            type: 'boolean',
+            value: true,
+            rawValue: 'true',
+            line: 2,
+            tab: 'View',
+            label: 'Show top frame',
+          },
+          {
+            name: 'render_quality',
+            type: 'number',
+            value: 1,
+            rawValue: '1',
+            line: 3,
+            tab: 'View',
+            label: 'Render quality',
+          },
+        ],
+      },
+      {
+        name: 'Dimensions',
+        params: [
+          {
+            name: 'width',
+            type: 'slider',
+            value: editWidth ? 120 : 60,
+            rawValue: editWidth ? '120' : '60',
+            min: 40,
+            max: 240,
+            step: 1,
+            line: 4,
+            tab: 'Dimensions',
+            label: 'Width',
+            unit: 'mm',
+          },
+          {
+            name: 'depth',
+            type: 'slider',
+            value: 80,
+            rawValue: '80',
+            min: 40,
+            max: 240,
+            step: 1,
+            line: 5,
+            tab: 'Dimensions',
+            label: 'Depth',
+            unit: 'mm',
+          },
+          {
+            name: 'height',
+            type: 'slider',
+            value: 35,
+            rawValue: '35',
+            min: 10,
+            max: 120,
+            step: 1,
+            line: 6,
+            tab: 'Dimensions',
+            label: 'Height',
+            unit: 'mm',
+          },
+        ],
+      },
+    ];
+  }
+
+  it('renders the search field and category chips for multi-category models', () => {
+    mockParseCustomizerParams.mockReturnValue(multiCategoryTabs());
+
+    renderWithProviders(<CustomizerPanel code="//" baselineCode="//" isCustomizerFirstMode />);
+
+    expect(screen.getByPlaceholderText('Search parameters...')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'All' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'View' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Dimensions' })).toBeTruthy();
+  });
+
+  it('filters parameters by free-text search', () => {
+    mockParseCustomizerParams.mockReturnValue(multiCategoryTabs());
+
+    renderWithProviders(<CustomizerPanel code="//" baselineCode="//" isCustomizerFirstMode />);
+
+    fireEvent.change(screen.getByPlaceholderText('Search parameters...'), {
+      target: { value: 'depth' },
+    });
+
+    expect(screen.getByText('Depth')).toBeTruthy();
+    expect(screen.queryByText('Width')).toBeNull();
+    expect(screen.queryByText('Show tray')).toBeNull();
+  });
+
+  it('filters parameters by category chip', () => {
+    mockParseCustomizerParams.mockReturnValue(multiCategoryTabs());
+
+    renderWithProviders(<CustomizerPanel code="//" baselineCode="//" isCustomizerFirstMode />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'View' }));
+
+    expect(screen.getByText('Show tray')).toBeTruthy();
+    expect(screen.queryByText('Width')).toBeNull();
+    expect(screen.queryByText('Depth')).toBeNull();
+  });
+
+  it('filters to edited parameters via the Edited chip', () => {
+    mockParseCustomizerParams.mockImplementation((code: string) =>
+      multiCategoryTabs(code.includes('120'))
+    );
+
+    const { rerender } = renderWithProviders(
+      <CustomizerPanel code="width = 60;" baselineCode="width = 60;" isCustomizerFirstMode />
+    );
+
+    expect(screen.queryByRole('button', { name: /edited/i })).toBeNull();
+
+    rerender(
+      <CustomizerPanel code="width = 120;" baselineCode="width = 60;" isCustomizerFirstMode />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /edited/i }));
+
+    expect(screen.getByText('Width')).toBeTruthy();
+    expect(screen.queryByText('Depth')).toBeNull();
+    expect(screen.queryByText('Show tray')).toBeNull();
+  });
+
+  it('shows a no-matches state and clears filters', () => {
+    mockParseCustomizerParams.mockReturnValue(multiCategoryTabs());
+
+    renderWithProviders(<CustomizerPanel code="//" baselineCode="//" isCustomizerFirstMode />);
+
+    fireEvent.change(screen.getByPlaceholderText('Search parameters...'), {
+      target: { value: 'no-such-parameter' },
+    });
+
+    expect(screen.getByTestId('customizer-no-matches')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear filters' }));
+
+    expect(screen.getByText('Width')).toBeTruthy();
+    expect(screen.getByText('Show tray')).toBeTruthy();
+  });
+
   it('treats slider changes as resettable against the opened-file baseline', () => {
     jest.useFakeTimers();
 

--- a/apps/ui/src/components/customizer/CustomizerFilterBar.tsx
+++ b/apps/ui/src/components/customizer/CustomizerFilterBar.tsx
@@ -1,12 +1,14 @@
 /**
  * Search + filter chip row for the customizer panel.
  *
- * Renders a free-text search field above a horizontally scrollable row of filter chips:
- * "All", an optional "Edited" chip (with a count of overridden parameters), and one chip per
- * parameter category. The chip row sits permanently under the search field.
+ * Renders a free-text search field (with a trailing collapse button) above a horizontally
+ * scrollable row of filter chips: "All", an optional "Edited" chip (with a count of overridden
+ * parameters), and one chip per parameter category.
  */
 
-import { FilterChip, SearchInput } from '../ui';
+import type { Ref } from 'react';
+import { TbX } from 'react-icons/tb';
+import { FilterChip, IconButton, SearchInput } from '../ui';
 
 export const ALL_FILTER = 'all';
 export const EDITED_FILTER = 'edited';
@@ -21,6 +23,11 @@ interface CustomizerFilterBarProps {
   editedCount: number;
   /** Whether to render the "Edited" chip (hidden when there is nothing edited). */
   showEdited: boolean;
+  /** Collapse the search/filter region back to the header search icon. */
+  onCollapse: () => void;
+  inputRef?: Ref<HTMLInputElement>;
+  /** Marks the search field untabbable while the region is collapsed. */
+  inputTabbable?: boolean;
 }
 
 export function CustomizerFilterBar({
@@ -31,24 +38,49 @@ export function CustomizerFilterBar({
   categories,
   editedCount,
   showEdited,
+  onCollapse,
+  inputRef,
+  inputTabbable = true,
 }: CustomizerFilterBarProps) {
   const showChipRow = showEdited || categories.length > 0;
 
   return (
     <div className="space-y-2">
-      <SearchInput
-        value={searchQuery}
-        onChange={(event) => onSearchChange(event.target.value)}
-        onClear={() => onSearchChange('')}
-        placeholder="Search parameters..."
-        aria-label="Search parameters"
-        spellCheck={false}
-        autoComplete="off"
-      />
+      <div className="flex items-center gap-2">
+        <SearchInput
+          ref={inputRef}
+          value={searchQuery}
+          onChange={(event) => onSearchChange(event.target.value)}
+          placeholder="Search parameters..."
+          aria-label="Search parameters"
+          spellCheck={false}
+          autoComplete="off"
+          tabIndex={inputTabbable ? undefined : -1}
+          className="flex-1"
+          onKeyDown={(event) => {
+            if (event.key === 'Escape') {
+              event.preventDefault();
+              onCollapse();
+            }
+          }}
+        />
+        <IconButton
+          variant="toolbar"
+          size="md"
+          onClick={onCollapse}
+          aria-label="Close search"
+          title="Close search"
+          tooltipSide="bottom"
+        >
+          <TbX size={16} />
+        </IconButton>
+      </div>
 
       {showChipRow && (
+        // Vertical padding keeps the active chip's accent border from being clipped by the
+        // horizontal scroll container (overflow-x also clips the cross axis).
         <div
-          className="flex items-center gap-1.5 overflow-x-auto pb-0.5"
+          className="flex items-center gap-1.5 overflow-x-auto px-0.5 py-1"
           role="group"
           aria-label="Filter parameters"
         >

--- a/apps/ui/src/components/customizer/CustomizerFilterBar.tsx
+++ b/apps/ui/src/components/customizer/CustomizerFilterBar.tsx
@@ -1,0 +1,94 @@
+/**
+ * Search + filter chip row for the customizer panel.
+ *
+ * Renders a free-text search field above a horizontally scrollable row of filter chips:
+ * "All", an optional "Edited" chip (with a count of overridden parameters), and one chip per
+ * parameter category. The chip row sits permanently under the search field.
+ */
+
+import { FilterChip, SearchInput } from '../ui';
+
+export const ALL_FILTER = 'all';
+export const EDITED_FILTER = 'edited';
+
+interface CustomizerFilterBarProps {
+  searchQuery: string;
+  onSearchChange: (value: string) => void;
+  /** Active filter: `ALL_FILTER`, `EDITED_FILTER`, or a category name. */
+  activeFilter: string;
+  onFilterChange: (filter: string) => void;
+  categories: string[];
+  editedCount: number;
+  /** Whether to render the "Edited" chip (hidden when there is nothing edited). */
+  showEdited: boolean;
+}
+
+export function CustomizerFilterBar({
+  searchQuery,
+  onSearchChange,
+  activeFilter,
+  onFilterChange,
+  categories,
+  editedCount,
+  showEdited,
+}: CustomizerFilterBarProps) {
+  const showChipRow = showEdited || categories.length > 0;
+
+  return (
+    <div className="space-y-2">
+      <SearchInput
+        value={searchQuery}
+        onChange={(event) => onSearchChange(event.target.value)}
+        onClear={() => onSearchChange('')}
+        placeholder="Search parameters..."
+        aria-label="Search parameters"
+        spellCheck={false}
+        autoComplete="off"
+      />
+
+      {showChipRow && (
+        <div
+          className="flex items-center gap-1.5 overflow-x-auto pb-0.5"
+          role="group"
+          aria-label="Filter parameters"
+        >
+          <FilterChip
+            selected={activeFilter === ALL_FILTER}
+            onClick={() => onFilterChange(ALL_FILTER)}
+          >
+            All
+          </FilterChip>
+
+          {showEdited && (
+            <FilterChip
+              selected={activeFilter === EDITED_FILTER}
+              count={editedCount}
+              showDot
+              onClick={() => onFilterChange(EDITED_FILTER)}
+            >
+              Edited
+            </FilterChip>
+          )}
+
+          {categories.length > 0 && (
+            <span
+              className="h-4 w-px shrink-0"
+              style={{ backgroundColor: 'var(--border-primary)' }}
+              aria-hidden="true"
+            />
+          )}
+
+          {categories.map((category) => (
+            <FilterChip
+              key={category}
+              selected={activeFilter === category}
+              onClick={() => onFilterChange(category)}
+            >
+              {category}
+            </FilterChip>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/ui/src/components/customizer/CustomizerFilterBar.tsx
+++ b/apps/ui/src/components/customizer/CustomizerFilterBar.tsx
@@ -56,7 +56,7 @@ export function CustomizerFilterBar({
           spellCheck={false}
           autoComplete="off"
           tabIndex={inputTabbable ? undefined : -1}
-          className="flex-1"
+          containerClassName="flex-1 min-w-0"
           onKeyDown={(event) => {
             if (event.key === 'Escape') {
               event.preventDefault();

--- a/apps/ui/src/components/ui/FilterChip.tsx
+++ b/apps/ui/src/components/ui/FilterChip.tsx
@@ -32,7 +32,7 @@ export const FilterChip = forwardRef<HTMLButtonElement, FilterChipProps>(
         ref={ref}
         type="button"
         aria-pressed={selected}
-        className={`inline-flex h-7 shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full px-3 text-xs font-medium transition-colors focus:outline-none focus:ring-2 ${className}`}
+        className={`inline-flex h-6 shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full px-3 text-xs font-medium transition-colors focus:outline-none focus:ring-2 ${className}`}
         style={baseStyle}
         onMouseEnter={(event) => {
           if (!selected) {

--- a/apps/ui/src/components/ui/FilterChip.tsx
+++ b/apps/ui/src/components/ui/FilterChip.tsx
@@ -1,0 +1,80 @@
+import { forwardRef, type ButtonHTMLAttributes, type CSSProperties } from 'react';
+
+export interface FilterChipProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  /** Whether the chip is the active selection. */
+  selected?: boolean;
+  /** Optional count shown in a trailing badge (e.g. number of edited parameters). */
+  count?: number;
+  /** Render a small leading status dot (used to flag "edited"-style chips). */
+  showDot?: boolean;
+}
+
+/**
+ * Pill-style toggle button used for filter rows. Supports a selected state, an optional leading
+ * status dot, and an optional trailing count badge.
+ */
+export const FilterChip = forwardRef<HTMLButtonElement, FilterChipProps>(
+  ({ selected = false, count, showDot = false, className = '', children, ...props }, ref) => {
+    const baseStyle: CSSProperties = selected
+      ? {
+          backgroundColor: 'color-mix(in srgb, var(--accent-primary) 15%, var(--bg-secondary))',
+          color: 'var(--text-primary)',
+          border: '1px solid var(--accent-primary)',
+        }
+      : {
+          backgroundColor: 'transparent',
+          color: 'var(--text-secondary)',
+          border: '1px solid var(--border-primary)',
+        };
+
+    return (
+      <button
+        ref={ref}
+        type="button"
+        aria-pressed={selected}
+        className={`inline-flex h-7 shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full px-3 text-xs font-medium transition-colors focus:outline-none focus:ring-2 ${className}`}
+        style={baseStyle}
+        onMouseEnter={(event) => {
+          if (!selected) {
+            event.currentTarget.style.backgroundColor =
+              'color-mix(in srgb, var(--accent-primary) 10%, transparent)';
+            event.currentTarget.style.color = 'var(--text-primary)';
+          }
+          props.onMouseEnter?.(event);
+        }}
+        onMouseLeave={(event) => {
+          if (!selected) {
+            event.currentTarget.style.backgroundColor = 'transparent';
+            event.currentTarget.style.color = 'var(--text-secondary)';
+          }
+          props.onMouseLeave?.(event);
+        }}
+        {...props}
+      >
+        {showDot && (
+          <span
+            className="h-1.5 w-1.5 shrink-0 rounded-full"
+            style={{ backgroundColor: 'var(--accent-primary)' }}
+            aria-hidden="true"
+          />
+        )}
+        <span>{children}</span>
+        {typeof count === 'number' && (
+          <span
+            className="inline-flex min-w-[18px] items-center justify-center rounded-full px-1.5 text-[10px] font-semibold tabular-nums"
+            style={{
+              backgroundColor: selected
+                ? 'color-mix(in srgb, var(--accent-primary) 22%, transparent)'
+                : 'var(--bg-tertiary)',
+              color: selected ? 'var(--accent-primary)' : 'var(--text-secondary)',
+            }}
+          >
+            {count}
+          </span>
+        )}
+      </button>
+    );
+  }
+);
+
+FilterChip.displayName = 'FilterChip';

--- a/apps/ui/src/components/ui/SearchInput.tsx
+++ b/apps/ui/src/components/ui/SearchInput.tsx
@@ -1,0 +1,68 @@
+import { forwardRef, type InputHTMLAttributes } from 'react';
+import { TbSearch, TbX } from 'react-icons/tb';
+
+export interface SearchInputProps extends InputHTMLAttributes<HTMLInputElement> {
+  /** Called when the inline clear button is pressed. When omitted, no clear button is shown. */
+  onClear?: () => void;
+}
+
+/**
+ * Text input with a leading search icon and an optional inline clear button.
+ *
+ * Styling mirrors the shared `Input` component so it sits naturally inside any theme.
+ */
+export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
+  ({ className = '', value, onClear, disabled, ...props }, ref) => {
+    const hasValue = value != null && (typeof value === 'string' ? value.length > 0 : true);
+    const showClear = Boolean(onClear) && hasValue && !disabled;
+
+    return (
+      <div className="relative">
+        <span
+          className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2"
+          style={{ color: 'var(--text-tertiary)' }}
+          aria-hidden="true"
+        >
+          <TbSearch size={15} />
+        </span>
+        <input
+          ref={ref}
+          type="text"
+          value={value}
+          disabled={disabled}
+          className={`w-full rounded-lg border py-2 pl-9 text-sm focus:outline-none focus:ring-2 ${
+            showClear ? 'pr-9' : 'pr-3'
+          } ${className}`}
+          style={{
+            backgroundColor: disabled ? 'var(--bg-tertiary)' : 'var(--bg-elevated)',
+            color: disabled ? 'var(--text-tertiary)' : 'var(--text-primary)',
+            borderColor: 'var(--border-primary)',
+            cursor: disabled ? 'not-allowed' : 'text',
+          }}
+          {...props}
+        />
+        {showClear && (
+          <button
+            type="button"
+            onClick={onClear}
+            aria-label="Clear search"
+            className="absolute right-2 top-1/2 flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded-md transition-colors"
+            style={{ color: 'var(--text-tertiary)' }}
+            onMouseEnter={(event) => {
+              event.currentTarget.style.backgroundColor = 'var(--bg-secondary)';
+              event.currentTarget.style.color = 'var(--text-primary)';
+            }}
+            onMouseLeave={(event) => {
+              event.currentTarget.style.backgroundColor = 'transparent';
+              event.currentTarget.style.color = 'var(--text-tertiary)';
+            }}
+          >
+            <TbX size={14} />
+          </button>
+        )}
+      </div>
+    );
+  }
+);
+
+SearchInput.displayName = 'SearchInput';

--- a/apps/ui/src/components/ui/SearchInput.tsx
+++ b/apps/ui/src/components/ui/SearchInput.tsx
@@ -4,6 +4,8 @@ import { TbSearch, TbX } from 'react-icons/tb';
 export interface SearchInputProps extends InputHTMLAttributes<HTMLInputElement> {
   /** Called when the inline clear button is pressed. When omitted, no clear button is shown. */
   onClear?: () => void;
+  /** Classes for the wrapping element (e.g. `flex-1` so the field grows to fill its row). */
+  containerClassName?: string;
 }
 
 /**
@@ -12,12 +14,12 @@ export interface SearchInputProps extends InputHTMLAttributes<HTMLInputElement> 
  * Styling mirrors the shared `Input` component so it sits naturally inside any theme.
  */
 export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
-  ({ className = '', value, onClear, disabled, ...props }, ref) => {
+  ({ className = '', containerClassName = '', value, onClear, disabled, ...props }, ref) => {
     const hasValue = value != null && (typeof value === 'string' ? value.length > 0 : true);
     const showClear = Boolean(onClear) && hasValue && !disabled;
 
     return (
-      <div className="relative">
+      <div className={`relative ${containerClassName}`}>
         <span
           className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2"
           style={{ color: 'var(--text-tertiary)' }}

--- a/apps/ui/src/components/ui/index.ts
+++ b/apps/ui/src/components/ui/index.ts
@@ -10,6 +10,12 @@ export type { IconButtonProps } from './IconButton';
 export { Input } from './Input';
 export type { InputProps } from './Input';
 
+export { SearchInput } from './SearchInput';
+export type { SearchInputProps } from './SearchInput';
+
+export { FilterChip } from './FilterChip';
+export type { FilterChipProps } from './FilterChip';
+
 export {
   Select,
   SelectTrigger,

--- a/implementation-plans/customizer-parameter-search.md
+++ b/implementation-plans/customizer-parameter-search.md
@@ -41,4 +41,20 @@ and one chip per parameter category. Search + chip filters compose.
 - [x] Add "no matches" empty state
 - [x] Add/adjust unit tests
 - [x] Run baseline validation (`format:check`, `lint`, `type-check`, `test:unit` — all pass)
-- [ ] Open draft PR against `main`
+- [x] Open draft PR against `main` ([#150](https://github.com/zacharyfmarion/openscad-studio/pull/150))
+
+## Follow-up refinement (collapsible search)
+
+Per updated mock, the search/filter region is collapsed by default behind a header search
+icon and expands on demand:
+
+- The customizer header shows a search **toggle icon** (active state while open) in both the
+  customizer-first and standard header layouts; it only renders when the filter bar is useful.
+- Clicking the toggle expands the search field + chip row; an external **X button** beside the
+  search field (and the `Escape` key) collapses it and resets the query/active filter.
+- Expand/collapse animates via a CSS `grid-template-rows` `0fr`→`1fr` transition plus opacity
+  (200ms, `cubic-bezier(0.32, 0.72, 0, 1)`), honoring `prefers-reduced-motion`.
+- The collapsed region is `inert` so it stays out of tab/focus order; the field is focused on
+  expand.
+- Chips were made shorter (`h-6`) and the chip scroll row gained vertical padding so the active
+  chip's accent border is no longer clipped by the horizontal scroll container.

--- a/implementation-plans/customizer-parameter-search.md
+++ b/implementation-plans/customizer-parameter-search.md
@@ -1,0 +1,44 @@
+# Customizer Parameter Search & Filters
+
+## Goal
+
+Implement [issue #149](https://github.com/zacharyfmarion/openscad-studio/issues/149): let users
+free-text search customizer parameters and filter them with a persistent chip row (mock
+"Customizer Search - Option B"). Chips cover **All**, **Edited** (count of overridden params),
+and one chip per parameter category. Search + chip filters compose.
+
+## Approach
+
+- Add two reusable UI primitives under `apps/ui/src/components/ui/`:
+  - `SearchInput` — text input with a leading search icon and optional clear button.
+  - `FilterChip` — pill button with selected state, optional leading dot, optional count badge.
+- Add a customizer-specific composition `CustomizerFilterBar` under
+  `apps/ui/src/components/customizer/` that lays out the search input + horizontally scrollable
+  chip row (All / Edited / category chips), matching the mock.
+- Wire search + filter state into `CustomizerPanel`:
+  - Derive dirty (edited) param keys and category list from the already-grouped tabs.
+  - Filter the rendered tabs/groups/params by the active chip + normalized search query.
+  - Show the filter bar only when it is useful (>4 visible params or >1 category); show the chip
+    row only when there is something to filter (edited params or multiple categories).
+  - Render a "no matches" empty state with a clear action when filters hide everything.
+
+## Affected Areas
+
+- `apps/ui/src/components/ui/SearchInput.tsx` (new)
+- `apps/ui/src/components/ui/FilterChip.tsx` (new)
+- `apps/ui/src/components/ui/index.ts` (exports)
+- `apps/ui/src/components/customizer/CustomizerFilterBar.tsx` (new)
+- `apps/ui/src/components/CustomizerPanel.tsx` (state + filtering + render)
+- `apps/ui/src/components/__tests__/CustomizerPanel.test.tsx` (coverage)
+
+## Checklist
+
+- [x] Add `SearchInput` reusable component
+- [x] Add `FilterChip` reusable component
+- [x] Export new primitives from `ui/index.ts`
+- [x] Add `CustomizerFilterBar` composition
+- [x] Wire search + filter state and filtering into `CustomizerPanel`
+- [x] Add "no matches" empty state
+- [x] Add/adjust unit tests
+- [x] Run baseline validation (`format:check`, `lint`, `type-check`, `test:unit` — all pass)
+- [ ] Open draft PR against `main`


### PR DESCRIPTION
# Summary

## What changed

- Added free-text **parameter search** and a persistent **filter chip row** to the customizer panel (mock "Customizer Search – Option B").
- Chips cover **All**, **Edited** (count of overridden parameters, shown only when something is edited), and one chip per parameter **category**. Search and chip filters compose.
- Added a **no-matches** empty state with a "Clear filters" action.
- Introduced two reusable UI primitives — `SearchInput` (icon + clear button) and `FilterChip` (selected state, optional leading dot + count badge) — plus a customizer-specific `CustomizerFilterBar` composition.

## Why

- Closes #149: makers with parameter-heavy models need to quickly find and focus on specific parameters instead of scrolling the whole customizer.

## Implementation notes

- Filtering operates on the already-grouped, advanced-aware tab structure in `CustomizerPanel`, so chip counts always match what is visible.
- Dirty (edited) detection reuses the existing opened-file baseline comparison that powers the per-parameter "Edited" badge and "Reset to defaults".
- The filter bar only renders when useful (>4 visible params or >1 category); the chip row only renders when there is something to filter (edited params or multiple categories), so small single-category models are unaffected.
- `effectiveFilter` self-heals if its target disappears (e.g. the last edited param is reset, or a category empties after toggling advanced controls).
- `FilterChip` and `SearchInput` are genuine `<button>`-bearing UI primitives and are added to the existing eslint raw-`<button>` ignore list alongside `Button`/`IconButton`/`SegmentedControl`.
- Implementation plan: `implementation-plans/customizer-parameter-search.md`.

# Testing

## Coverage checklist

- [ ] Backend unit tests added or updated for changed Rust behavior
- [x] Client unit/component tests added or updated for changed frontend behavior
- [ ] E2E tests added or updated for net new user-facing flows
- [ ] No new tests were needed for this change

## Validation performed

- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm test:unit`
- [ ] `pnpm test:formatter:ci`
- [ ] `pnpm test:e2e:web`
- [ ] `cd apps/ui/src-tauri && cargo ...`

## Test details

- Added `CustomizerPanel` tests: renders search + category chips for multi-category models, filters by free-text search, filters by category chip, filters to edited parameters via the Edited chip, and shows/clears the no-matches state.
- Ran `bash scripts/validate-changes.sh --scope baseline` — format check, lint, type-check, and all 605 unit tests pass.
- Manually verified in the web preview: search filtering, category chip filtering, mock-matching layout, and the no-matches empty state; no console errors.
- Skipped `formatter` (no formatter changes), `rust` (no Rust changes), and `e2e-web` (no new cross-cutting user flow; behavior covered by component tests).

# Performance

## Performance impact

- [x] Performance was considered for this change
- [x] No meaningful performance impact is expected

## Justification

- Filtering is memoized, in-memory string matching over already-parsed parameters; negligible relative to rendering.

# UI changes

## Screenshots or recordings

- Customizer with search field + `All / View / Dimensions / Features` chip row, matching the Option B mock.
- Search "depth" narrows to the single matching parameter; category chip "View" scopes to that section; gibberish search shows the "No parameters match your filters" empty state.

# Issue link

- Closes #149
